### PR TITLE
Fix clippy warnings and WhatsApp gateway Node 25 compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,6 +3852,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures",
  "hex",
+ "libc",
  "openfang-channels",
  "openfang-extensions",
  "openfang-hands",

--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -1813,18 +1813,14 @@ fn cmd_doctor(json: bool, repair: bool) {
                             ui::check_ok(".env file (permissions fixed to 0600)");
                         }
                         repaired = true;
-                    } else {
-                        if !json {
-                            ui::check_warn(&format!(
-                                ".env file has loose permissions ({:o}), should be 0600",
-                                mode
-                            ));
-                        }
+                    } else if !json {
+                        ui::check_warn(&format!(
+                            ".env file has loose permissions ({:o}), should be 0600",
+                            mode
+                        ));
                     }
-                } else {
-                    if !json {
-                        ui::check_ok(".env file");
-                    }
+                } else if !json {
+                    ui::check_ok(".env file");
                 }
             }
             #[cfg(not(unix))]

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -32,8 +32,7 @@ async function startConnection() {
   const pino = (await import('pino')).default || await import('pino');
 
   const logger = pino({ level: 'warn' });
-  const authDir = new URL('./auth_store/', import.meta.url || `file://${__dirname}/`).pathname
-    || require('node:path').join(__dirname, 'auth_store');
+  const authDir = require('node:path').join(__dirname, 'auth_store');
 
   const { state, saveCreds } = await useMultiFileAuthState(
     require('node:path').join(__dirname, 'auth_store')

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -5,6 +5,7 @@
   "bin": {
     "openfang-whatsapp-gateway": "./index.js"
   },
+  "type": "commonjs",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
## Summary
- Fix 2 collapsible else-if clippy warnings in CLI `doctor` command
- Add `"type": "commonjs"` to `packages/whatsapp-gateway/package.json` — Node.js 25 defaults to ESM and the gateway uses `require()`
- Replace `import.meta.url` with `__dirname` in `packages/whatsapp-gateway/index.js` — `import.meta` is invalid in CommonJS context

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test --workspace` — 1,769 tests pass
- [x] WhatsApp gateway starts successfully on Node.js 25 and returns QR code
- [x] Dashboard serves correctly at `http://127.0.0.1:50051/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)