### PR TITLE
Add Windows ARM64 release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
             args: "--target x86_64-pc-windows-msvc"
             rust_target: x86_64-pc-windows-msvc
 
+          - name: Windows ARM64
+            os: windows-latest
+            args: "--target aarch64-pc-windows-msvc"
+            rust_target: aarch64-pc-windows-msvc
+
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
@@ -150,6 +155,9 @@ jobs:
             os: macos-latest
             archive: tar.gz
           - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+          - target: aarch64-pc-windows-msvc
             os: windows-latest
             archive: zip
 


### PR DESCRIPTION
## Summary
- Add `aarch64-pc-windows-msvc` target to Desktop and CLI release matrices in CI
- Enables native Windows ARM64 builds (Snapdragon X Elite, etc.) in releases

## Test plan
- [x] Verified `cargo build --workspace --lib` passes on Snapdragon X Elite
- [x] Verified `cargo test --workspace` passes on Windows ARM64
- [x] Verified `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] Verified daemon starts and serves API + dashboard on ARM64
- [x] Verified LLM calls work via OpenRouter on ARM64

