### PR TITLE
feat: add theme switcher with system preference support

### DIFF
--- a/crates/openfang-api/src/webchat.rs
+++ b/crates/openfang-api/src/webchat.rs
@@ -92,6 +92,8 @@ const WEBCHAT_HTML: &str = concat!(
     "<script>\n",
     include_str!("../static/js/api.js"),
     "\n",
+    include_str!("../static/js/theme-manager.js"),
+    "\n",
     include_str!("../static/js/app.js"),
     "\n",
     include_str!("../static/js/pages/overview.js"),

--- a/crates/openfang-api/static/css/theme.css
+++ b/crates/openfang-api/static/css/theme.css
@@ -274,3 +274,36 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Theme Switcher — 3-option pill */
+.theme-switcher {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full, 999px);
+  padding: 2px;
+}
+
+.theme-opt {
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-full, 999px);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 3px 7px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.theme-opt:hover {
+  color: var(--text);
+}
+
+.theme-opt.active {
+  background: var(--surface);
+  color: var(--accent);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}

--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -13,7 +13,11 @@
           </div>
         </div>
       </div>
-      <button class="theme-toggle" @click="toggleTheme()" :title="theme === 'dark' ? 'Switch to light' : 'Switch to dark'" x-text="theme === 'dark' ? '\u2600' : '\u263E'"></button>
+      <div class="theme-switcher" role="group" aria-label="Theme">
+        <button class="theme-opt" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light">&#9728;</button>
+        <button class="theme-opt" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System">&#9711;</button>
+        <button class="theme-opt" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark">&#9790;</button>
+      </div>
     </div>
 
     <div class="sidebar-status" :class="{ offline: !connected && !$store.app.booting }">

--- a/crates/openfang-api/static/js/app.js
+++ b/crates/openfang-api/static/js/app.js
@@ -154,7 +154,7 @@ document.addEventListener('alpine:init', function() {
 function app() {
   return {
     page: 'agents',
-    theme: localStorage.getItem('openfang-theme') || 'light',
+    theme: ThemeManager.load(),
     sidebarCollapsed: localStorage.getItem('openfang-sidebar') === 'collapsed',
     mobileMenuOpen: false,
     connected: false,
@@ -166,6 +166,9 @@ function app() {
 
     init() {
       var self = this;
+
+      // Theme — init with system preference detection
+      this.theme = ThemeManager.init(this);
 
       // Hash routing
       var validPages = ['overview','agents','sessions','approvals','workflows','scheduler','channels','skills','hands','analytics','logs','settings','wizard'];
@@ -234,9 +237,13 @@ function app() {
       this.mobileMenuOpen = false;
     },
 
+    setTheme(t) {
+      ThemeManager.set(t, this);
+    },
+
     toggleTheme() {
-      this.theme = this.theme === 'dark' ? 'light' : 'dark';
-      localStorage.setItem('openfang-theme', this.theme);
+      // legacy 2-way toggle — kept for backward compat
+      this.setTheme(this.theme === 'dark' ? 'light' : 'dark');
     },
 
     toggleSidebar() {

--- a/crates/openfang-api/static/js/theme-manager.js
+++ b/crates/openfang-api/static/js/theme-manager.js
@@ -1,0 +1,62 @@
+/**
+ * ThemeManager — system preference detection + persistence for OpenFang
+ *
+ * Integrates with Alpine.js app store. Call ThemeManager.init(appComponent)
+ * from app() init() to wire system preference changes automatically.
+ */
+const ThemeManager = (() => {
+  const STORAGE_KEY = 'openfang-theme';
+  const VALID = ['light', 'dark', 'system'];
+  const QUERY = '(prefers-color-scheme: dark)';
+
+  function systemTheme() {
+    return window.matchMedia && window.matchMedia(QUERY).matches ? 'dark' : 'light';
+  }
+
+  function resolve(theme) {
+    return theme === 'system' ? systemTheme() : theme;
+  }
+
+  function applyToDOM(theme) {
+    const resolved = resolve(theme);
+    document.documentElement.setAttribute('data-theme', resolved);
+    document.documentElement.style.colorScheme = resolved;
+  }
+
+  function load() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return VALID.includes(stored) ? stored : 'system';
+  }
+
+  function save(theme) {
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+
+  /**
+   * Init — applies theme immediately and wires system preference listener.
+   * @param {object} alpineRef - Reference to Alpine component with { theme, setTheme }
+   */
+  function init(alpineRef) {
+    const theme = load();
+    applyToDOM(theme);
+
+    if (window.matchMedia) {
+      window.matchMedia(QUERY).addEventListener('change', () => {
+        if (alpineRef && alpineRef.theme === 'system') {
+          applyToDOM('system');
+        }
+      });
+    }
+
+    return theme;
+  }
+
+  function set(theme, alpineRef) {
+    if (!VALID.includes(theme)) return;
+    save(theme);
+    applyToDOM(theme);
+    if (alpineRef) alpineRef.theme = theme;
+  }
+
+  return { init, set, load, resolve, applyToDOM };
+})();


### PR DESCRIPTION
## What

Replaces the binary light/dark toggle with a 3-option theme switcher (Light / System / Dark) that respects OS-level preference and persists the user's choice across reloads.

## Changes

- **`theme-manager.js`** — new utility handling persistence, system preference detection via `prefers-color-scheme`, and DOM updates. Wires a `matchMedia` listener so the UI reacts automatically when the OS theme changes (only when set to System).
- **`app.js`** — integrated `ThemeManager`: init on load, new `setTheme(t)` method accepting `'light' | 'dark' | 'system'`, legacy `toggleTheme()` kept for backward compat.
- **`index_body.html`** — replaced single emoji button with a pill-style 3-button group (☀ / ○ / ☾), active state tracked via Alpine.js binding.
- **`theme.css`** — added `.theme-switcher` and `.theme-opt` styles (pill group, active highlight with accent color).
- **`webchat.rs`** — registered `theme-manager.js` in the `include_str!` bundle before `app.js`.

## Behavior

| Scenario | Result |
|---|---|
| First visit | Defaults to System (follows OS) |
| User picks Light/Dark | Persisted to `localStorage`, stays on reload |
| User picks System | Follows OS; updates live if OS theme changes |
| OS switches while on System | UI updates automatically, no reload needed |

## Zero dependencies

Pure vanilla JS + CSS. No new build steps, no external libs.