### PR TITLE
Propagate base_url from deployment manifest with default fallback

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -968,6 +968,9 @@ impl OpenFangKernel {
             if !dm.model.is_empty() {
                 manifest.model.model = dm.model.clone();
             }
+            if dm.base_url.is_some() {
+                manifest.model.base_url = dm.base_url.clone();
+            }
         }
 
         // Create workspace directory for the agent
@@ -3484,7 +3487,11 @@ impl OpenFangKernel {
             let driver_config = DriverConfig {
                 provider: agent_provider.clone(),
                 api_key: std::env::var(&api_key_env).ok(),
-                base_url: manifest.model.base_url.clone(),
+                base_url: manifest
+                    .model
+                    .base_url
+                    .clone()
+                    .or_else(|| self.config.default_model.base_url.clone()),
             };
 
             drivers::create_driver(&driver_config).map_err(|e| {


### PR DESCRIPTION
The base_url in config.toml not working. This patch fix that problem
[default_model]
provider = "anthropic"                    # "anthropic", "gemini", "openai", "groq", "ollama", etc.
model = "claude-sonnet-4-20250514"        # Model identifier
api_key_env = "ANTHROPIC_API_KEY"         # Environment variable holding API key
base_url = "https://abcd.com"  # Optional: override API endpoint <---