### PR TITLE
Add support for Zhipu Coding API endpoint (#41)

### DIFF
--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -17,7 +17,7 @@ use openfang_types::model_catalog::{
     MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL, OPENAI_BASE_URL,
     OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
     REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL,
-    ZHIPU_BASE_URL,
+    ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
 };
 use std::sync::Arc;
 
@@ -149,6 +149,11 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
         }),
         "zhipu" | "glm" => Some(ProviderDefaults {
             base_url: ZHIPU_BASE_URL,
+            api_key_env: "ZHIPU_API_KEY",
+            key_required: true,
+        }),
+        "zhipu_coding" => Some(ProviderDefaults {
+            base_url: ZHIPU_CODING_BASE_URL,
             api_key_env: "ZHIPU_API_KEY",
             key_required: true,
         }),
@@ -317,6 +322,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "qwen",
         "minimax",
         "zhipu",
+        "zhipu_coding",
         "qianfan",
     ]
 }
@@ -409,8 +415,9 @@ mod tests {
         assert!(providers.contains(&"qwen"));
         assert!(providers.contains(&"minimax"));
         assert!(providers.contains(&"zhipu"));
+        assert!(providers.contains(&"zhipu_coding"));
         assert!(providers.contains(&"qianfan"));
-        assert_eq!(providers.len(), 26);
+        assert_eq!(providers.len(), 27);
     }
 
     #[test]

--- a/crates/openfang-types/src/model_catalog.rs
+++ b/crates/openfang-types/src/model_catalog.rs
@@ -36,6 +36,7 @@ pub const GITHUB_COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
 pub const QWEN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 pub const MINIMAX_BASE_URL: &str = "https://api.minimax.chat/v1";
 pub const ZHIPU_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4";
+pub const ZHIPU_CODING_BASE_URL: &str = "https://open.bigmodel.cn/api/coding/paas/v4";
 pub const MOONSHOT_BASE_URL: &str = "https://api.moonshot.cn/v1";
 pub const QIANFAN_BASE_URL: &str = "https://qianfan.baidubce.com/v2";
 


### PR DESCRIPTION
## Summary

Add support for Zhipu AI's specialized Coding API endpoint, which provides models optimized for code-related tasks.

## Changes

- Add `ZHIPU_CODING_BASE_URL` constant (`https://open.bigmodel.cn/api/coding/paas/v4`) in `model_catalog.rs`
- Register `zhipu_coding` as a provider in the driver factory
- Update `known_providers()` list and corresponding tests

## Context

Resolves #41

The Zhipu Coding API uses a separate endpoint from the regular Zhipu API but shares the same `ZHIPU_API_KEY` authentication. This change enables users to configure agents with Zhipu's coding-specialized models.

## Test plan

- [x] Code compiles with `cargo build --workspace --lib`
- [x] Unit tests pass
- [x] Provider appears in `known_providers()` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)