### PR TITLE
feat(providers): add kimi-for-coding provider (Moonshot AI Kimi K2)

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -5940,6 +5940,9 @@ pub async fn set_provider_url(
         );
     }
 
+    // Strip trailing slash to prevent double-slash in concatenated paths
+    let base_url = base_url.trim_end_matches('/').to_string();
+
     // Update catalog in memory
     {
         let mut catalog = state
@@ -6012,7 +6015,9 @@ fn upsert_provider_url(
         std::fs::create_dir_all(parent)?;
     }
 
-    std::fs::write(config_path, toml::to_string_pretty(&doc)?)?;
+    let tmp_path = config_path.with_extension("toml.tmp");
+    std::fs::write(&tmp_path, toml::to_string_pretty(&doc)?)?;
+    std::fs::rename(&tmp_path, config_path)?;
     Ok(())
 }
 

--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -1212,6 +1212,12 @@ fn provider_list() -> Vec<(&'static str, &'static str, &'static str, &'static st
         ("gemini", "GEMINI_API_KEY", "gemini-2.5-flash", "Gemini"),
         ("deepseek", "DEEPSEEK_API_KEY", "deepseek-chat", "DeepSeek"),
         (
+            "kimi-for-coding",
+            "MOONSHOT_API_KEY",
+            "kimi-k2",
+            "Kimi (Coding)",
+        ),
+        (
             "anthropic",
             "ANTHROPIC_API_KEY",
             "claude-sonnet-4-20250514",

--- a/crates/openfang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/init_wizard.rs
@@ -53,6 +53,14 @@ const PROVIDERS: &[ProviderInfo] = &[
         hint: "cheap",
     },
     ProviderInfo {
+        name: "kimi-for-coding",
+        display: "Kimi (Coding)",
+        env_var: "MOONSHOT_API_KEY",
+        default_model: "kimi-k2",
+        needs_key: true,
+        hint: "code-optimized",
+    },
+    ProviderInfo {
         name: "anthropic",
         display: "Anthropic",
         env_var: "ANTHROPIC_API_KEY",

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -525,7 +525,9 @@ impl OpenFangKernel {
         let driver_config = DriverConfig {
             provider: config.default_model.provider.clone(),
             api_key: std::env::var(&config.default_model.api_key_env).ok(),
-            base_url: config.default_model.base_url.clone(),
+            base_url: config.default_model.base_url.as_deref()
+                .or_else(|| config.provider_urls.get(&config.default_model.provider).map(|s| s.as_str()))
+                .map(|s| s.to_string()),
         };
         let primary_driver = drivers::create_driver(&driver_config)
             .map_err(|e| KernelError::BootFailed(format!("LLM driver init failed: {e}")))?;
@@ -541,7 +543,9 @@ impl OpenFangKernel {
                     } else {
                         std::env::var(&fb.api_key_env).ok()
                     },
-                    base_url: fb.base_url.clone(),
+                    base_url: fb.base_url.as_deref()
+                        .or_else(|| config.provider_urls.get(&fb.provider).map(|s| s.as_str()))
+                        .map(|s| s.to_string()),
                 };
                 match drivers::create_driver(&fb_config) {
                     Ok(d) => {
@@ -599,6 +603,15 @@ impl OpenFangKernel {
                 "applied {} provider URL override(s)",
                 config.provider_urls.len()
             );
+        }
+        // Sync default_model.base_url into catalog for health probe accuracy.
+        // provider_urls takes precedence if it already has an entry for this provider.
+        if let Some(ref url) = config.default_model.base_url {
+            let provider = &config.default_model.provider;
+            if !config.provider_urls.contains_key(provider.as_str()) {
+                model_catalog.set_provider_url(provider, url);
+                info!("applied default_model.base_url to catalog provider={}", provider);
+            }
         }
         let available_count = model_catalog.available_models().len();
         let total_count = model_catalog.list_models().len();
@@ -3451,6 +3464,16 @@ impl OpenFangKernel {
         );
     }
 
+    /// Resolve the effective base URL for a provider, following the precedence chain:
+    ///   1. `explicit_url` — per-agent manifest or default_model override (highest priority)
+    ///   2. `config.provider_urls[provider]` — provider-level override from config
+    ///   3. `None` — delegates to `create_driver` which uses hardcoded default
+    fn resolve_base_url(&self, explicit_url: Option<&str>, provider: &str) -> Option<String> {
+        explicit_url
+            .map(|u| u.to_string())
+            .or_else(|| self.config.provider_urls.get(provider).cloned())
+    }
+
     /// Resolve the LLM driver for an agent.
     ///
     /// If the agent's manifest specifies a different provider than the kernel default,
@@ -3499,7 +3522,10 @@ impl OpenFangKernel {
             let driver_config = DriverConfig {
                 provider: agent_provider.clone(),
                 api_key: std::env::var(&api_key_env).ok(),
-                base_url: manifest.model.base_url.clone(),
+                base_url: self.resolve_base_url(
+                    manifest.model.base_url.as_deref(),
+                    agent_provider,
+                ),
             };
 
             drivers::create_driver(&driver_config).map_err(|e| {
@@ -3517,7 +3543,7 @@ impl OpenFangKernel {
                         .api_key_env
                         .as_ref()
                         .and_then(|env| std::env::var(env).ok()),
-                    base_url: fb.base_url.clone(),
+                    base_url: self.resolve_base_url(fb.base_url.as_deref(), &fb.provider),
                 };
                 match drivers::create_driver(&config) {
                     Ok(d) => chain.push(d),

--- a/crates/openfang-kernel/src/metering.rs
+++ b/crates/openfang-kernel/src/metering.rs
@@ -384,6 +384,9 @@ fn estimate_cost_rates(model: &str) -> (f64, f64) {
     }
 
     // ── Moonshot / Kimi ─────────────────────────────────────────
+    if model.contains("kimi-k2") {
+        return (0.60, 2.50);
+    }
     if model.contains("moonshot") || model.contains("kimi") {
         return (0.80, 0.80);
     }

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -13,11 +13,11 @@ pub mod openai;
 use crate::llm_driver::{DriverConfig, LlmDriver, LlmError};
 use openfang_types::model_catalog::{
     AI21_BASE_URL, ANTHROPIC_BASE_URL, CEREBRAS_BASE_URL, COHERE_BASE_URL, DEEPSEEK_BASE_URL,
-    FIREWORKS_BASE_URL, GEMINI_BASE_URL, GROQ_BASE_URL, HUGGINGFACE_BASE_URL, LMSTUDIO_BASE_URL,
-    MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL, OPENAI_BASE_URL,
-    OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
-    REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL,
-    ZHIPU_BASE_URL,
+    FIREWORKS_BASE_URL, GEMINI_BASE_URL, GROQ_BASE_URL, HUGGINGFACE_BASE_URL,
+    KIMI_FOR_CODING_BASE_URL, LMSTUDIO_BASE_URL, MINIMAX_BASE_URL, MISTRAL_BASE_URL,
+    MOONSHOT_BASE_URL, OLLAMA_BASE_URL, OPENAI_BASE_URL, OPENROUTER_BASE_URL,
+    PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL, REPLICATE_BASE_URL,
+    SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL, ZHIPU_BASE_URL,
 };
 use std::sync::Arc;
 
@@ -134,6 +134,11 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
         }),
         "moonshot" | "kimi" => Some(ProviderDefaults {
             base_url: MOONSHOT_BASE_URL,
+            api_key_env: "MOONSHOT_API_KEY",
+            key_required: true,
+        }),
+        "kimi-for-coding" => Some(ProviderDefaults {
+            base_url: KIMI_FOR_CODING_BASE_URL,
             api_key_env: "MOONSHOT_API_KEY",
             key_required: true,
         }),
@@ -313,6 +318,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "xai",
         "replicate",
         "github-copilot",
+        "kimi-for-coding",
         "moonshot",
         "qwen",
         "minimax",
@@ -410,7 +416,7 @@ mod tests {
         assert!(providers.contains(&"minimax"));
         assert!(providers.contains(&"zhipu"));
         assert!(providers.contains(&"qianfan"));
-        assert_eq!(providers.len(), 26);
+        assert_eq!(providers.len(), 27);
     }
 
     #[test]

--- a/crates/openfang-runtime/src/model_catalog.rs
+++ b/crates/openfang-runtime/src/model_catalog.rs
@@ -7,7 +7,8 @@ use openfang_types::model_catalog::{
     AuthStatus, ModelCatalogEntry, ModelTier, ProviderInfo, AI21_BASE_URL, ANTHROPIC_BASE_URL,
     BEDROCK_BASE_URL, CEREBRAS_BASE_URL, COHERE_BASE_URL, DEEPSEEK_BASE_URL, FIREWORKS_BASE_URL,
     GEMINI_BASE_URL, GITHUB_COPILOT_BASE_URL, GROQ_BASE_URL, HUGGINGFACE_BASE_URL,
-    LMSTUDIO_BASE_URL, MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL,
+    KIMI_FOR_CODING_BASE_URL, LMSTUDIO_BASE_URL, MINIMAX_BASE_URL, MISTRAL_BASE_URL,
+    MOONSHOT_BASE_URL, OLLAMA_BASE_URL,
     OPENAI_BASE_URL, OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
     REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL,
     ZHIPU_BASE_URL,
@@ -445,6 +446,15 @@ fn builtin_providers() -> Vec<ProviderInfo> {
             model_count: 0,
         },
         ProviderInfo {
+            id: "kimi-for-coding".into(),
+            display_name: "Kimi (Coding)".into(),
+            api_key_env: "MOONSHOT_API_KEY".into(),
+            base_url: KIMI_FOR_CODING_BASE_URL.into(),
+            key_required: true,
+            auth_status: AuthStatus::Missing,
+            model_count: 0,
+        },
+        ProviderInfo {
             id: "qianfan".into(),
             display_name: "Baidu Qianfan".into(),
             api_key_env: "QIANFAN_API_KEY".into(),
@@ -518,6 +528,9 @@ fn builtin_aliases() -> HashMap<String, String> {
         ("ernie", "ernie-4.5-8k"),
         ("kimi", "moonshot-v1-128k"),
         ("minimax", "minimax-text-01"),
+        // Kimi K2 aliases
+        ("kimi-k2", "kimi-k2"),
+        ("kimi-coding", "kimi-k2"),
     ];
     pairs
         .into_iter()
@@ -2395,6 +2408,65 @@ fn builtin_models() -> Vec<ModelCatalogEntry> {
             aliases: vec![],
         },
         // ══════════════════════════════════════════════════════════════
+        // Kimi for Coding / Kimi K2 (4)
+        // ══════════════════════════════════════════════════════════════
+        ModelCatalogEntry {
+            id: "kimi-k2".into(),
+            display_name: "Kimi K2".into(),
+            provider: "kimi-for-coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 131_072,
+            max_output_tokens: 16_384,
+            input_cost_per_m: 0.60,
+            output_cost_per_m: 2.50,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec!["kimi-k2".into(), "kimi-coding".into()],
+        },
+        ModelCatalogEntry {
+            id: "kimi-k2-0905".into(),
+            display_name: "Kimi K2 (256K)".into(),
+            provider: "kimi-for-coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 262_144,
+            max_output_tokens: 32_768,
+            input_cost_per_m: 0.60,
+            output_cost_per_m: 2.50,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "kimi-k2-thinking".into(),
+            display_name: "Kimi K2 Thinking".into(),
+            provider: "kimi-for-coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 262_144,
+            max_output_tokens: 32_768,
+            input_cost_per_m: 0.60,
+            output_cost_per_m: 2.50,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "kimi-k2.5".into(),
+            display_name: "Kimi K2.5".into(),
+            provider: "kimi-for-coding".into(),
+            tier: ModelTier::Frontier,
+            context_window: 262_144,
+            max_output_tokens: 32_768,
+            input_cost_per_m: 0.60,
+            output_cost_per_m: 2.50,
+            supports_tools: true,
+            supports_vision: true,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        // ══════════════════════════════════════════════════════════════
         // Baidu Qianfan / ERNIE (3)
         // ══════════════════════════════════════════════════════════════
         ModelCatalogEntry {
@@ -2570,7 +2642,7 @@ mod tests {
     #[test]
     fn test_catalog_has_providers() {
         let catalog = ModelCatalog::new();
-        assert_eq!(catalog.list_providers().len(), 27);
+        assert_eq!(catalog.list_providers().len(), 28);
     }
 
     #[test]
@@ -2855,5 +2927,23 @@ mod tests {
             catalog.get_provider("lmstudio").unwrap().base_url,
             LMSTUDIO_BASE_URL
         );
+    }
+
+    #[test]
+    fn test_no_duplicate_provider_ids() {
+        let catalog = ModelCatalog::new();
+        let mut seen = std::collections::HashSet::new();
+        for p in catalog.list_providers() {
+            assert!(seen.insert(p.id.clone()), "Duplicate provider ID: {}", p.id);
+        }
+    }
+
+    #[test]
+    fn test_no_duplicate_model_ids() {
+        let catalog = ModelCatalog::new();
+        let mut seen = std::collections::HashSet::new();
+        for m in catalog.list_models() {
+            assert!(seen.insert(m.id.clone()), "Duplicate model ID: {}", m.id);
+        }
     }
 }

--- a/crates/openfang-types/src/model_catalog.rs
+++ b/crates/openfang-types/src/model_catalog.rs
@@ -37,6 +37,7 @@ pub const QWEN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/
 pub const MINIMAX_BASE_URL: &str = "https://api.minimax.chat/v1";
 pub const ZHIPU_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4";
 pub const MOONSHOT_BASE_URL: &str = "https://api.moonshot.cn/v1";
+pub const KIMI_FOR_CODING_BASE_URL: &str = "https://api.moonshot.ai/v1";
 pub const QIANFAN_BASE_URL: &str = "https://qianfan.baidubce.com/v2";
 
 // ── AWS Bedrock ───────────────────────────────────────────────────

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ Complete reference for `config.toml`, covering every configurable field in the O
   - [Channel Overrides](#channel-overrides)
 - [Environment Variables](#environment-variables)
 - [Validation](#validation)
+- [Remote Ollama Setup](#remote-ollama-setup)
 
 ---
 
@@ -96,6 +97,13 @@ provider = "anthropic"
 model = "claude-sonnet-4-20250514"
 api_key_env = "ANTHROPIC_API_KEY"
 # base_url = "https://api.anthropic.com"  # Optional override
+
+# --- Provider URL Overrides (optional) ---
+# Override base URLs for any provider — useful for remote/self-hosted inference.
+# The URL must include the /v1 suffix for OpenAI-compatible endpoints.
+# [provider_urls]
+# ollama = "http://192.168.1.100:11434/v1"   # Remote Ollama on LAN
+# vllm = "http://gpu-server.local:8000/v1"   # vLLM on a GPU server
 
 # --- Fallback Providers ---
 [[fallback_providers]]
@@ -271,6 +279,50 @@ api_key_env = "ANTHROPIC_API_KEY"
 | `model` | string | `"claude-sonnet-4-20250514"` | Model identifier. Aliases like `sonnet`, `haiku`, `gpt-4o`, `gemini-flash` are resolved by the model catalog. |
 | `api_key_env` | string | `"ANTHROPIC_API_KEY"` | Name of the environment variable holding the API key. The actual key is read from this env var at runtime, never stored in config. |
 | `base_url` | string or null | `null` | Override the API base URL. Useful for proxies or self-hosted endpoints. When `null`, the provider's default URL from the model catalog is used. |
+
+#### Remote Ollama Setup
+
+Ollama can run on a separate machine (e.g., a dedicated GPU box on your LAN) and OpenFang can connect to it over the network. There are two equivalent ways to configure this.
+
+**Option 1 — `[provider_urls]` (recommended)**
+
+The `[provider_urls]` table maps provider names to base URL overrides and applies globally to all agents:
+
+```toml
+# Remote Ollama on another machine (e.g., 192.168.1.100)
+[provider_urls]
+ollama = "http://192.168.1.100:11434/v1"
+```
+
+**Option 2 — `[default_model] base_url`**
+
+Set `base_url` directly on the model config for the same effect:
+
+```toml
+[default_model]
+provider = "ollama"
+model = "llama3.2:latest"
+api_key_env = ""
+base_url = "http://192.168.1.100:11434/v1"
+```
+
+> **Important:** The URL must end with `/v1`. Ollama's OpenAI-compatible endpoint is at `/v1/chat/completions`. The URL `http://host:11434` (without `/v1`) will result in 404 errors.
+
+The same `/v1` suffix requirement applies to other self-hosted OpenAI-compatible servers (vLLM, LM Studio, etc.).
+
+#### `[provider_urls]`
+
+An optional table that overrides the default base URL for any provider. Keys are provider names (matching the `provider` field in `[default_model]` and `[[fallback_providers]]`). Values are the full base URL including the `/v1` path segment for OpenAI-compatible servers.
+
+```toml
+[provider_urls]
+ollama = "http://192.168.1.100:11434/v1"
+vllm = "http://gpu-server.local:8000/v1"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `<provider_name>` | string | (catalog default) | Base URL override for the named provider. Must include the `/v1` path suffix for OpenAI-compatible endpoints. |
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # LLM Providers Guide
 
-OpenFang ships with a comprehensive model catalog covering **3 native LLM drivers**, **20 providers**, **51 builtin models**, and **23 aliases**. Every provider uses one of three battle-tested drivers: the native **Anthropic** driver, the native **Gemini** driver, or the universal **OpenAI-compatible** driver. This guide is the single source of truth for configuring, selecting, and managing LLM providers in OpenFang.
+OpenFang ships with a comprehensive model catalog covering **3 native LLM drivers**, **21 providers**, **55 builtin models**, and **23 aliases**. Every provider uses one of three battle-tested drivers: the native **Anthropic** driver, the native **Gemini** driver, or the universal **OpenAI-compatible** driver. This guide is the single source of truth for configuring, selecting, and managing LLM providers in OpenFang.
 
 ---
 
@@ -540,6 +540,32 @@ For Gemini specifically, either `GEMINI_API_KEY` or `GOOGLE_API_KEY` will work.
 2. Go to Account > API Tokens
 3. `export REPLICATE_API_TOKEN="r8_..."`
 
+### 21. Kimi (Coding) — K2 Series
+
+| | |
+|---|---|
+| **Display Name** | Kimi (Coding) |
+| **Driver** | OpenAI-compatible |
+| **Env Var** | `MOONSHOT_API_KEY` |
+| **Base URL** | `https://api.moonshot.ai/v1` |
+| **Key Required** | Yes |
+| **Free Tier** | No |
+| **Auth** | `Authorization: Bearer` header |
+| **Models** | 4 |
+
+**Available Models:**
+- `kimi-k2` (Smart) — 128K context, 1T MoE, optimized for coding/agents
+- `kimi-k2-0905` (Smart) — 256K context snapshot
+- `kimi-k2-thinking` (Smart) — 256K with extended reasoning/CoT
+- `kimi-k2.5` (Frontier) — 256K, multimodal vision (MoonViT3d), Jan 2026
+
+**Setup:**
+1. Sign up at [platform.moonshot.ai](https://platform.moonshot.ai)
+2. Create an API key
+3. `export MOONSHOT_API_KEY="sk-..."`
+
+**Notes:** The `MOONSHOT_API_KEY` is shared with the `moonshot` provider (V1 series). Both providers activate with the same key. China-region users can override the base URL by adding `kimi-for-coding = "https://api.moonshot.cn/v1"` under `[provider_urls]` in `config.toml` (supports hot-reload, no daemon restart needed).
+
 ---
 
 ## Model Catalog
@@ -594,6 +620,10 @@ The complete catalog of all 51 builtin models, sorted by provider. Pricing is pe
 | 44 | `grok-2-mini` | Grok 2 Mini | xai | Fast | 131,072 | 32,768 | $0.30 | $0.50 | Yes | No |
 | 45 | `hf/meta-llama/Llama-3.3-70B-Instruct` | Llama 3.3 70B (HF) | huggingface | Balanced | 128,000 | 4,096 | $0.30 | $0.30 | No | No |
 | 46 | `replicate/meta-llama-3.3-70b-instruct` | Llama 3.3 70B (Replicate) | replicate | Balanced | 128,000 | 4,096 | $0.40 | $0.40 | No | No |
+| 47 | `kimi-k2` | Kimi K2 | kimi-for-coding | Smart | 131,072 | 16,384 | $0.60 | $2.50 | Yes | No |
+| 48 | `kimi-k2-0905` | Kimi K2 (256K) | kimi-for-coding | Smart | 262,144 | 32,768 | $0.60 | $2.50 | Yes | No |
+| 49 | `kimi-k2-thinking` | Kimi K2 Thinking | kimi-for-coding | Smart | 262,144 | 32,768 | $0.60 | $2.50 | Yes | No |
+| 50 | `kimi-k2.5` | Kimi K2.5 | kimi-for-coding | Frontier | 262,144 | 32,768 | $0.60 | $2.50 | Yes | Yes |
 
 **Model Tiers:**
 
@@ -1033,6 +1063,7 @@ Quick reference for all provider environment variables:
 | Hugging Face | `HF_API_KEY` | Yes |
 | xAI | `XAI_API_KEY` | Yes |
 | Replicate | `REPLICATE_API_TOKEN` | Yes |
+| Kimi (Coding) | `MOONSHOT_API_KEY` | Yes |
 
 ---
 

--- a/openfang.toml.example
+++ b/openfang.toml.example
@@ -11,6 +11,17 @@ model = "claude-sonnet-4-20250514"        # Model identifier
 api_key_env = "ANTHROPIC_API_KEY"         # Environment variable holding API key
 # base_url = "https://api.anthropic.com"  # Optional: override API endpoint
 
+# Provider base URL overrides — use to point providers at remote or custom endpoints.
+# The URL must include the /v1 path for OpenAI-compatible providers.
+#
+# Example: Ollama running on a remote machine at 192.168.1.100
+# [provider_urls]
+# ollama = "http://192.168.1.100:11434/v1"
+#
+# Example: vLLM on a GPU server
+# [provider_urls]
+# vllm = "http://gpu-server.local:8000/v1"
+
 [memory]
 decay_rate = 0.05                         # Memory confidence decay rate
 # sqlite_path = "~/.openfang/data/openfang.db"   # Optional: custom DB path


### PR DESCRIPTION
Adds kimi-for-coding as a new provider with 4 models: kimi-k2 (128K), kimi-k2-0905 (256K), kimi-k2-thinking (256K), and kimi-k2.5 (256K + vision). Includes init wizard support, metering rates, and model catalog entries with aliases (kimi-k2, kimi-coding).

Also fixes base_url resolution so provider_urls config is applied to actual LLM calls (not just health probes), and uses atomic file writes for config updates