### PR TITLE
fix: use char-safe string truncation to prevent UTF-8 panic

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -413,12 +413,9 @@ fn append_daily_memory_log(workspace: &Path, response: &str) {
             return;
         }
     }
-    // Truncate long responses for the log
-    let summary = if trimmed.len() > 500 {
-        &trimmed[..500]
-    } else {
-        trimmed
-    };
+    // Truncate long responses for the log (char-safe to avoid panic on multi-byte UTF-8)
+    let summary: String = trimmed.chars().take(500).collect();
+    let summary = summary.as_str();
     let timestamp = chrono::Utc::now().format("%H:%M:%S").to_string();
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
@@ -2196,7 +2193,7 @@ impl OpenFangKernel {
                 .take(5)
                 .enumerate()
                 .map(|(i, t)| {
-                    let truncated = if t.len() > 200 { &t[..200] } else { t };
+                    let truncated: String = t.chars().take(200).collect();
                     format!("{}. {}", i + 1, truncated)
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- `append_daily_memory_log` used `&trimmed[..500]` which panics when byte 500 falls inside a multi-byte UTF-8 character
- Session summary truncation used `&t[..200]` with the same issue
- Replaced both with `chars().take(N).collect()` for safe character-boundary truncation

## Root cause
Vietnamese/CJK text contains multi-byte UTF-8 characters (e.g. `ặ` = 3 bytes). Rust panics on byte-level string slicing at non-char boundaries:
```
thread 'tokio-runtime-worker' panicked at crates/openfang-kernel/src/kernel.rs:418:17:
byte index 500 is not a char boundary; it is inside 'ặ' (bytes 498..501)
```

## Impact
The panic kills a tokio worker thread. If the Telegram polling task was running on that thread, the polling loop dies silently — the bot stops responding to messages while the container remains healthy.

## Test plan
- [x] `cargo build --workspace --lib` compiles
- [x] Send a >500 char Vietnamese/CJK message through Telegram and verify daily memory log is written without panic

From [https://openfang.vn](https://openfang.vn) team with love!

🤖 Generated with [Claude Code](https://claude.com/claude-code)