### PR TITLE
feat: per-agent tool blocklist + fix approval config key

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -3942,12 +3942,23 @@ impl OpenFangKernel {
 
         let caps = self.capabilities.list(agent_id);
 
-        // If agent has ToolAll, return all tools
+        // Apply per-agent blocklist
+        let empty_blocked: Vec<String> = Vec::new();
+        let blocked = entry
+            .as_ref()
+            .map(|e| &e.manifest.capabilities.blocked_tools)
+            .unwrap_or(&empty_blocked);
+
+
+        // If agent has ToolAll, return all tools (minus blocked)
         if caps.iter().any(|c| matches!(c, Capability::ToolAll)) {
-            return all_tools;
+            return all_tools
+                .into_iter()
+                .filter(|tool| !blocked.iter().any(|b| b == &tool.name))
+                .collect();
         }
 
-        // Filter to tools the agent has capability for
+        // Filter to tools the agent has capability for, minus blocked
         all_tools
             .into_iter()
             .filter(|tool| {
@@ -3956,6 +3967,7 @@ impl OpenFangKernel {
                     _ => false,
                 })
             })
+            .filter(|tool| !blocked.iter().any(|b| b == &tool.name))
             .collect()
     }
 

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -356,6 +356,7 @@ impl ToolProfile {
             memory_write: vec!["self.*".into()],
             ofp_discover: false,
             ofp_connect: vec![],
+            blocked_tools: vec![],
         }
     }
 }
@@ -541,6 +542,9 @@ pub struct ManifestCapabilities {
     /// Allowed OFP peer patterns.
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub ofp_connect: Vec<String>,
+    /// Tools to exclude from this agent's available set (blocklist, overrides allowlist).
+    #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
+    pub blocked_tools: Vec<String>,
 }
 
 /// Human-readable session label (e.g., "support inbox", "research").


### PR DESCRIPTION
## Summary

- **Fix approval config**: The `[approval_policy]` TOML section was silently ignored by serde because the Rust struct field maps to `[approval]`. This caused `require_approval` to always fall back to the hardcoded default `["shell_exec"]`, meaning every shell_exec required approval regardless of config. Renaming the section to `[approval]` in config.toml fixes this (no code change needed, but documenting here for awareness).

- **Add tool blocklist**: Adds `blocked_tools: Vec<String>` to `ManifestCapabilities`. Tools listed in `blocked_tools` are filtered out of `available_tools()` for both the `ToolAll` and `ToolInvoke` capability paths. This gives operators a way to deny specific tools per-agent without rebuilding the entire allowlist.

## Changes

- `crates/openfang-types/src/agent.rs`: Add `blocked_tools` field to `ManifestCapabilities` struct and `implied_capabilities()` initializer
- `crates/openfang-kernel/src/kernel.rs`: Filter `blocked_tools` in `available_tools()` for both ToolAll and ToolInvoke paths

## Test plan

- [x] Rename `[approval_policy]` → `[approval]` in config.toml, restart daemon, send shell_exec — executes without approval gate
- [x] Set `blocked_tools: ["shell_exec"]` on agent manifest in SQLite, restart daemon — agent shows 11 tools (was 12), `shell_exec` absent from `Tools selected for LLM request` log
- [x] Verified on 4 agents (Rex, Sentinel, Accountant, Overwatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)