### PR TITLE
feat(cli): add agent set command for live model switching

### DIFF
--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -475,14 +475,14 @@ enum AgentCommands {
         /// Agent ID (UUID).
         agent_id: String,
     },
-    /// Set an agent property (e.g., model).
+    /// Update a running agent's configuration (e.g., switch its model).
     Set {
-        /// Agent ID (UUID).
+        /// Agent ID (UUID or prefix).
         agent_id: String,
-        /// Field to set (model).
+        /// Field to update. Currently supported: model.
         field: String,
-        /// New value.
-        value: String,
+        /// New value for the field (interactive picker if omitted for model).
+        value: Option<String>,
     },
 }
 
@@ -852,7 +852,7 @@ fn main() {
                 agent_id,
                 field,
                 value,
-            } => cmd_agent_set(&agent_id, &field, &value),
+            } => cmd_agent_set(cli.config, &agent_id, &field, value),
         },
         Some(Commands::Workflow(sub)) => match sub {
             WorkflowCommands::List => cmd_workflow_list(),
@@ -1642,33 +1642,52 @@ fn cmd_agent_kill(config: Option<PathBuf>, agent_id_str: &str) {
     }
 }
 
-fn cmd_agent_set(agent_id_str: &str, field: &str, value: &str) {
+fn cmd_agent_set(config: Option<PathBuf>, agent_id_str: &str, field: &str, value: Option<String>) {
     match field {
         "model" => {
+            let model = value.unwrap_or_else(pick_model);
             if let Some(base) = find_daemon() {
                 let client = daemon_client();
                 let body = daemon_json(
                     client
                         .put(format!("{base}/api/agents/{agent_id_str}/model"))
-                        .json(&serde_json::json!({"model": value}))
+                        .json(&serde_json::json!({"model": model}))
                         .send(),
                 );
-                if body.get("status").is_some() {
-                    println!("Agent {agent_id_str} model set to {value}.");
-                } else {
-                    eprintln!(
+                if body.get("error").is_some() {
+                    ui::error(&format!(
                         "Failed to set model: {}",
                         body["error"].as_str().unwrap_or("Unknown error")
-                    );
+                    ));
                     std::process::exit(1);
                 }
+                ui::success(&format!(
+                    "Agent {agent_id_str} model set to: {model}"
+                ));
             } else {
-                eprintln!("No running daemon found. Start one with: openfang start");
-                std::process::exit(1);
+                let agent_id: AgentId = agent_id_str.parse().unwrap_or_else(|_| {
+                    ui::error(&format!("Invalid agent ID: {agent_id_str}"));
+                    ui::hint("Run `openfang agent list` to see agent IDs");
+                    std::process::exit(1);
+                });
+                let kernel = boot_kernel(config);
+                match kernel.set_agent_model(agent_id, &model) {
+                    Ok(()) => {
+                        ui::success(&format!(
+                            "Agent {agent_id} model set to: {model}"
+                        ));
+                    }
+                    Err(e) => {
+                        ui::error(&format!("Failed to set model: {e}"));
+                        std::process::exit(1);
+                    }
+                }
             }
         }
-        _ => {
-            eprintln!("Unknown field: {field}. Supported fields: model");
+        other => {
+            ui::error(&format!("Unknown field: '{other}'"));
+            ui::hint("Supported fields: model");
+            ui::hint("Usage: openfang agent set <AGENT_ID> model <MODEL>");
             std::process::exit(1);
         }
     }
@@ -1945,18 +1964,14 @@ fn cmd_doctor(json: bool, repair: bool) {
                             ui::check_ok(".env file (permissions fixed to 0600)");
                         }
                         repaired = true;
-                    } else {
-                        if !json {
-                            ui::check_warn(&format!(
-                                ".env file has loose permissions ({:o}), should be 0600",
-                                mode
-                            ));
-                        }
+                    } else if !json {
+                        ui::check_warn(&format!(
+                            ".env file has loose permissions ({:o}), should be 0600",
+                            mode
+                        ));
                     }
-                } else {
-                    if !json {
-                        ui::check_ok(".env file");
-                    }
+                } else if !json {
+                    ui::check_ok(".env file");
                 }
             }
             #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

Implements #86 — adds `openfang agent set <AGENT_ID> model <MODEL>` to switch a running agent's model from the CLI, closing the gap between API and CLI capabilities.

**What it does:**
- `openfang agent set <ID> model gpt-4o` — switches the agent's model via daemon API
- `openfang agent set <ID> model` (no model arg) — launches interactive model picker
- Non-daemon fallback: boots in-process kernel when no daemon is running
- Extensible `field` dispatch — only `model` is supported now, but adding `name`, `provider`, etc. later is trivial

**Acceptance criteria from #86:**
- [x] `openfang agent set AGENT_ID model MODEL` is available in `--help`
- [x] When daemon is running, CLI calls `PUT /api/agents/{id}/model` with JSON body `{ "model": "MODEL" }`
- [x] In non-daemon mode, CLI falls back to in-process `kernel.set_agent_model(...)`
- [x] Invalid field errors are explicit (currently only `model` is supported)
- [x] Success and failure messages are clear and actionable

**Bonus:** Fixed two pre-existing clippy warnings (collapsible else-if blocks in `cmd_doctor`).

## Test plan

- [x] `cargo build -p openfang-cli` — compiles clean
- [x] `cargo clippy -p openfang-cli -- -D warnings` — zero warnings
- [x] `openfang agent set --help` — shows correct usage
- [x] `openfang agent set <ID> badfield value` — prints clear error with supported fields hint
- [ ] With running daemon: `openfang agent set <ID> model gpt-4o` — switches model via API
- [ ] Without daemon: `openfang agent set <ID> model gpt-4o` — switches via kernel fallback

Closes #86