### PR TITLE
Fix UTF-8 panic in string truncation (kernel, CLI, channels)

### DIFF
--- a/crates/openfang-channels/src/nostr.rs
+++ b/crates/openfang-channels/src/nostr.rs
@@ -165,7 +165,7 @@ impl ChannelAdapter for NostrAdapter {
     ) -> Result<Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>, Box<dyn std::error::Error>>
     {
         let pubkey = self.derive_pubkey();
-        info!("Nostr adapter starting (pubkey: {}...)", &pubkey[..16]);
+        info!("Nostr adapter starting (pubkey: {}...)", openfang_types::truncate_str(&pubkey, 16));
 
         if self.relays.is_empty() {
             return Err("Nostr: no relay URLs configured".into());

--- a/crates/openfang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/init_wizard.rs
@@ -1912,11 +1912,7 @@ fn draw_routing_pick(f: &mut Frame, area: Rect, state: &mut State, tier: usize) 
                 .split('/')
                 .next_back()
                 .unwrap_or(&state.routing_models[t]);
-            let display = if short.len() > 14 {
-                &short[..14]
-            } else {
-                short
-            };
+            let display = openfang_types::truncate_str(short, 14);
             summary_spans.push(Span::styled(
                 format!("{name}:{display}"),
                 Style::default().fg(*c),

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -2212,7 +2212,7 @@ impl OpenFangKernel {
                 .take(5)
                 .enumerate()
                 .map(|(i, t)| {
-                    let truncated = if t.len() > 200 { &t[..200] } else { t };
+                    let truncated = openfang_types::truncate_str(t, 200);
                     format!("{}. {}", i + 1, truncated)
                 })
                 .collect::<Vec<_>>()

--- a/crates/openfang-types/src/lib.rs
+++ b/crates/openfang-types/src/lib.rs
@@ -59,6 +59,17 @@ mod tests {
     }
 
     #[test]
+    fn truncate_str_em_dash() {
+        // Em dash (—) is 3 bytes (0xE2 0x80 0x94) — the exact char that caused
+        // production panics in kernel.rs and session.rs (issue #104)
+        let s = "Here is a summary — with details";
+        // Byte 19 is inside the em dash (bytes 18..21)
+        assert_eq!(truncate_str(s, 19), "Here is a summary ");
+        assert_eq!(truncate_str(s, 20), "Here is a summary ");
+        assert_eq!(truncate_str(s, 21), "Here is a summary \u{2014}");
+    }
+
+    #[test]
     fn truncate_str_no_truncation() {
         assert_eq!(truncate_str("short", 100), "short");
     }


### PR DESCRIPTION
## Summary

- Replace 3 remaining raw byte-index string slices (`&s[..N]`) with the existing UTF-8-safe `openfang_types::truncate_str()` 
- Add regression test for em dash (`—`), the exact character that triggered production panics

## Problem

`&s[..200]` panics when byte 200 falls inside a multi-byte UTF-8 character. Agent responses frequently contain em dashes (3 bytes: `0xE2 0x80 0x94`), smart quotes, and emoji, making this a common crash in production.

**Panic sites fixed:**
| File | Line | Context |
|------|------|---------|
| `kernel.rs` | 2215 | Session summary truncation (`&t[..200]`) |
| `init_wizard.rs` | 1916 | Model name display (`&short[..14]`) |
| `nostr.rs` | 168 | Pubkey log message (`&pubkey[..16]`) |

## Production panic logs

```
thread 'tokio-runtime-worker' panicked at crates/openfang-kernel/src/kernel.rs:418:17:
byte index 500 is not a char boundary; it is inside '—' (bytes 499..502)
```

```
thread 'tokio-runtime-worker' panicked at crates/openfang-memory/src/session.rs:433:51:
byte index 200 is not a char boundary; it is inside '—' (bytes 199..202)
```

## Fix

All 3 sites now use `openfang_types::truncate_str(s, max_bytes)` which walks back to the nearest `is_char_boundary()`. This function already existed and was used in ~30 other call sites — these 3 were simply missed.

## Test plan

- [x] `cargo build --workspace --lib` — compiles clean
- [x] `cargo test --workspace` — 271 passed, 0 failed
- [x] `cargo clippy -p openfang-kernel -p openfang-types -p openfang-channels -p openfang-memory` — 0 warnings
- [x] New test `truncate_str_em_dash` covers the exact production failure case

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)