### PR TITLE
Fix CLI binary killed on macOS Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,9 @@ jobs:
       - name: Build CLI
         if: matrix.target != 'aarch64-unknown-linux-gnu'
         run: cargo build --release --target ${{ matrix.target }} --bin openfang
+      - name: Ad-hoc codesign CLI binary (macOS)
+        if: runner.os == 'macOS'
+        run: codesign --force --sign - target/${{ matrix.target }}/release/openfang
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
         run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,6 +110,11 @@ install() {
     tar xzf "$ARCHIVE" -C "$INSTALL_DIR"
     chmod +x "$INSTALL_DIR/openfang"
 
+    # macOS on Apple Silicon requires a valid code signature
+    if [ "$OS" = "darwin" ] && command -v codesign &>/dev/null; then
+        codesign --force --sign - "$INSTALL_DIR/openfang" 2>/dev/null || true
+    fi
+
     # Add to PATH
     SHELL_RC=""
     case "${SHELL:-}" in


### PR DESCRIPTION
## Summary

Fixes #109 -- CLI binary is immediately killed (SIGKILL / Killed: 9) on macOS Apple Silicon due to missing code signature.

- Add ad-hoc codesigning step to the CLI release job in release.yml, after build and before packaging
- Add ad-hoc codesigning to scripts/install.sh after extraction as a safety net

The desktop/Tauri builds are already properly Developer ID signed and notarized -- this only affects the CLI binary.

## Details

The CLI job produces binaries that are only **linker-signed** (the minimal signature Apple ld adds on arm64). Recent macOS versions reject these via Apple System Policy. Running codesign --force --sign - produces a proper ad-hoc signature that satisfies ASP without requiring a Developer ID certificate.

## Test plan

- [ ] Build a macOS arm64 CLI binary without this fix -- confirm it is linker-signed
- [ ] Build with this fix -- confirm codesign -d -vvvv shows adhoc without linker-signed
- [ ] Run the signed binary on macOS Apple Silicon -- confirm it launches without Killed: 9
- [ ] Run scripts/install.sh on macOS -- confirm codesign step runs after extraction