### PR TITLE
Enrich Ollama model discovery with real metadata

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -4864,7 +4864,9 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             entry["reachable"] = serde_json::json!(probe.reachable);
             entry["latency_ms"] = serde_json::json!(probe.latency_ms);
             if !probe.discovered_models.is_empty() {
-                entry["discovered_models"] = serde_json::json!(probe.discovered_models);
+                let names: Vec<&str> =
+                    probe.discovered_models.iter().map(|m| m.name.as_str()).collect();
+                entry["discovered_models"] = serde_json::json!(names);
             }
             if let Some(err) = &probe.error {
                 entry["error"] = serde_json::json!(err);

--- a/crates/openfang-runtime/src/model_catalog.rs
+++ b/crates/openfang-runtime/src/model_catalog.rs
@@ -170,8 +170,14 @@ impl ModelCatalog {
     /// Merge dynamically discovered models from a local provider.
     ///
     /// Adds models not already in the catalog with `Local` tier and zero cost.
-    /// Also updates the provider's `model_count`.
-    pub fn merge_discovered_models(&mut self, provider: &str, model_ids: &[String]) {
+    /// For Ollama models with enriched metadata (from `/api/show`), uses real
+    /// context_window, vision/tool support, etc. For unenriched models, falls
+    /// back to sensible defaults. Also updates the provider's `model_count`.
+    pub fn merge_discovered_models(
+        &mut self,
+        provider: &str,
+        models: &[crate::provider_health::DiscoveredModel],
+    ) {
         let existing_ids: std::collections::HashSet<String> = self
             .models
             .iter()
@@ -180,23 +186,23 @@ impl ModelCatalog {
             .collect();
 
         let mut added = 0usize;
-        for id in model_ids {
-            if existing_ids.contains(&id.to_lowercase()) {
+        for model in models {
+            if existing_ids.contains(&model.name.to_lowercase()) {
                 continue;
             }
-            // Generate a human-friendly display name
-            let display = format!("{} ({})", id, provider);
+
+            let display = build_discovered_display_name(&model.name, provider, model);
             self.models.push(ModelCatalogEntry {
-                id: id.clone(),
+                id: model.name.clone(),
                 display_name: display,
                 provider: provider.to_string(),
                 tier: ModelTier::Local,
-                context_window: 32_768,
-                max_output_tokens: 4_096,
+                context_window: model.context_window.unwrap_or(32_768),
+                max_output_tokens: model.max_output_tokens.unwrap_or(4_096),
                 input_cost_per_m: 0.0,
                 output_cost_per_m: 0.0,
-                supports_tools: true,
-                supports_vision: false,
+                supports_tools: model.supports_tools.unwrap_or(true),
+                supports_vision: model.supports_vision.unwrap_or(false),
                 supports_streaming: true,
                 aliases: Vec::new(),
             });
@@ -287,6 +293,25 @@ impl Default for ModelCatalog {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Build an enriched display name for a discovered local model.
+///
+/// Includes parameter size and quantization when available from enrichment.
+/// Examples: `"llama3.2:latest 3B Q4_K_M (ollama)"`, `"qwen2:7b (vllm)"`.
+fn build_discovered_display_name(
+    name: &str,
+    provider: &str,
+    model: &crate::provider_health::DiscoveredModel,
+) -> String {
+    let mut parts = vec![name.to_string()];
+    if let Some(ref size) = model.parameter_size {
+        parts.push(size.clone());
+    }
+    if let Some(ref quant) = model.quantization_level {
+        parts.push(quant.clone());
+    }
+    format!("{} ({})", parts.join(" "), provider)
 }
 
 /// Read an OpenAI API key from the Codex CLI credential file.
@@ -3081,11 +3106,15 @@ mod tests {
 
     #[test]
     fn test_merge_adds_new_models() {
+        use crate::provider_health::DiscoveredModel;
         let mut catalog = ModelCatalog::new();
         let before = catalog.models_by_provider("ollama").len();
         catalog.merge_discovered_models(
             "ollama",
-            &["codestral:latest".to_string(), "qwen2:7b".to_string()],
+            &[
+                DiscoveredModel { name: "codestral:latest".into(), ..Default::default() },
+                DiscoveredModel { name: "qwen2:7b".into(), ..Default::default() },
+            ],
         );
         let after = catalog.models_by_provider("ollama").len();
         assert_eq!(after, before + 2);
@@ -3097,21 +3126,70 @@ mod tests {
 
     #[test]
     fn test_merge_skips_existing() {
+        use crate::provider_health::DiscoveredModel;
         let mut catalog = ModelCatalog::new();
         // "llama3.2" is already a builtin Ollama model
         let before = catalog.list_models().len();
-        catalog.merge_discovered_models("ollama", &["llama3.2".to_string()]);
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModel { name: "llama3.2".into(), ..Default::default() }],
+        );
         let after = catalog.list_models().len();
         assert_eq!(after, before); // no new model added
     }
 
     #[test]
     fn test_merge_updates_model_count() {
+        use crate::provider_health::DiscoveredModel;
         let mut catalog = ModelCatalog::new();
         let before_count = catalog.get_provider("ollama").unwrap().model_count;
-        catalog.merge_discovered_models("ollama", &["new-model:latest".to_string()]);
+        catalog.merge_discovered_models(
+            "ollama",
+            &[DiscoveredModel { name: "new-model:latest".into(), ..Default::default() }],
+        );
         let after_count = catalog.get_provider("ollama").unwrap().model_count;
         assert_eq!(after_count, before_count + 1);
+    }
+
+    #[test]
+    fn test_merge_enriched_ollama_model() {
+        use crate::provider_health::DiscoveredModel;
+        let mut catalog = ModelCatalog::new();
+        let enriched = DiscoveredModel {
+            name: "llava:13b".into(),
+            context_window: Some(131_072),
+            max_output_tokens: None,
+            supports_vision: Some(true),
+            supports_tools: Some(false),
+            family: Some("llava".into()),
+            families: Some(vec!["llava".into(), "clip".into()]),
+            parameter_size: Some("13B".into()),
+            quantization_level: Some("Q4_K_M".into()),
+        };
+        catalog.merge_discovered_models("ollama", &[enriched]);
+        let model = catalog.find_model("llava:13b").unwrap();
+        assert_eq!(model.context_window, 131_072);
+        assert!(model.supports_vision);
+        assert!(!model.supports_tools);
+        assert_eq!(model.tier, ModelTier::Local);
+        assert!(model.display_name.contains("13B"));
+        assert!(model.display_name.contains("Q4_K_M"));
+    }
+
+    #[test]
+    fn test_merge_unenriched_uses_defaults() {
+        use crate::provider_health::DiscoveredModel;
+        let mut catalog = ModelCatalog::new();
+        let unenriched = DiscoveredModel {
+            name: "some-vllm-model".into(),
+            ..Default::default()
+        };
+        catalog.merge_discovered_models("vllm", &[unenriched]);
+        let model = catalog.find_model("some-vllm-model").unwrap();
+        assert_eq!(model.context_window, 32_768);
+        assert_eq!(model.max_output_tokens, 4_096);
+        assert!(model.supports_tools);
+        assert!(!model.supports_vision);
     }
 
     #[test]

--- a/crates/openfang-runtime/src/provider_health.rs
+++ b/crates/openfang-runtime/src/provider_health.rs
@@ -1,9 +1,36 @@
 //! Provider health probing — lightweight HTTP checks for local LLM providers.
 //!
 //! Probes local providers (Ollama, vLLM, LM Studio) for reachability and
-//! dynamically discovers which models they currently serve.
+//! dynamically discovers which models they currently serve. For Ollama,
+//! enriches discovered models with real metadata from `/api/show`.
 
 use std::time::Instant;
+
+/// Metadata for a model discovered from a local provider's listing endpoint.
+///
+/// For Ollama, enriched with data from `POST /api/show`. For other providers
+/// (vLLM, LM Studio), only `name` is populated and all other fields are `None`.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DiscoveredModel {
+    /// Model name/ID as returned by the listing endpoint.
+    pub name: String,
+    /// Context window size in tokens.
+    pub context_window: Option<u64>,
+    /// Maximum output tokens.
+    pub max_output_tokens: Option<u64>,
+    /// Whether the model supports vision/image inputs.
+    pub supports_vision: Option<bool>,
+    /// Whether the model supports tool/function calling.
+    pub supports_tools: Option<bool>,
+    /// Model family (e.g., "llama", "gemma", "qwen2").
+    pub family: Option<String>,
+    /// Model families list (e.g., \["llama", "clip"\] for multimodal).
+    pub families: Option<Vec<String>>,
+    /// Parameter size string (e.g., "8B", "70B").
+    pub parameter_size: Option<String>,
+    /// Quantization level (e.g., "Q4_K_M", "Q8_0").
+    pub quantization_level: Option<String>,
+}
 
 /// Result of probing a provider endpoint.
 #[derive(Debug, Clone, Default)]
@@ -12,8 +39,8 @@ pub struct ProbeResult {
     pub reachable: bool,
     /// Round-trip latency in milliseconds.
     pub latency_ms: u64,
-    /// Model IDs discovered from the provider's listing endpoint.
-    pub discovered_models: Vec<String>,
+    /// Models discovered from the provider's listing endpoint.
+    pub discovered_models: Vec<DiscoveredModel>,
     /// Error message if the probe failed.
     pub error: Option<String>,
 }
@@ -31,9 +58,16 @@ pub fn is_local_provider(provider: &str) -> bool {
 /// Probe timeout for local provider health checks.
 const PROBE_TIMEOUT_SECS: u64 = 5;
 
+/// Timeout for individual `/api/show` calls (per model).
+const SHOW_TIMEOUT_SECS: u64 = 10;
+
+/// Maximum concurrent `/api/show` requests to avoid overwhelming Ollama.
+const OLLAMA_SHOW_CONCURRENCY: usize = 4;
+
 /// Probe a provider's health by hitting its model listing endpoint.
 ///
-/// - **Ollama**: `GET {base_url_root}/api/tags` → parses `.models[].name`
+/// - **Ollama**: `GET {base_url_root}/api/tags` → parses `.models[].name`,
+///   then enriches each model via `POST /api/show` for real metadata.
 /// - **OpenAI-compat** (vLLM, LM Studio): `GET {base_url}/models` → parses `.data[].id`
 ///
 /// `base_url` should be the provider's base URL from the catalog (e.g.,
@@ -57,17 +91,24 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
     let lower = provider.to_lowercase();
 
     // Ollama uses a non-OpenAI endpoint for model listing
-    let (url, is_ollama) = if lower == "ollama" {
-        // base_url is typically "http://localhost:11434/v1" — strip /v1 for the tags endpoint
-        let root = base_url
-            .trim_end_matches('/')
-            .trim_end_matches("/v1")
-            .trim_end_matches("/v1/");
-        (format!("{root}/api/tags"), true)
+    let ollama_root = if lower == "ollama" {
+        Some(
+            base_url
+                .trim_end_matches('/')
+                .trim_end_matches("/v1")
+                .trim_end_matches("/v1/")
+                .to_string(),
+        )
     } else {
-        // OpenAI-compatible: GET {base_url}/models
+        None
+    };
+    let is_ollama = ollama_root.is_some();
+
+    let url = if let Some(ref root) = ollama_root {
+        format!("{root}/api/tags")
+    } else {
         let trimmed = base_url.trim_end_matches('/');
-        (format!("{trimmed}/models"), false)
+        format!("{trimmed}/models")
     };
 
     let resp = match client.get(&url).send().await {
@@ -104,7 +145,7 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
     let latency_ms = start.elapsed().as_millis() as u64;
 
     // Parse model names
-    let models = if is_ollama {
+    let model_names: Vec<String> = if is_ollama {
         // Ollama: { "models": [ { "name": "llama3.2:latest", ... }, ... ] }
         body.get("models")
             .and_then(|v| v.as_array())
@@ -130,12 +171,193 @@ pub async fn probe_provider(provider: &str, base_url: &str) -> ProbeResult {
             .unwrap_or_default()
     };
 
+    // For Ollama, enrich models with /api/show metadata
+    let discovered_models = if is_ollama && !model_names.is_empty() {
+        enrich_ollama_models(ollama_root.as_deref().unwrap(), model_names).await
+    } else {
+        model_names
+            .into_iter()
+            .map(|name| DiscoveredModel {
+                name,
+                ..Default::default()
+            })
+            .collect()
+    };
+
     ProbeResult {
         reachable: true,
         latency_ms,
-        discovered_models: models,
+        discovered_models,
         error: None,
     }
+}
+
+/// Enrich a list of model names with metadata from Ollama's `/api/show` endpoint.
+///
+/// Calls `/api/show` for each model in parallel (up to [`OLLAMA_SHOW_CONCURRENCY`]
+/// concurrent requests). Models that fail enrichment retain only their name.
+async fn enrich_ollama_models(root_url: &str, model_names: Vec<String>) -> Vec<DiscoveredModel> {
+    use futures::stream::StreamExt;
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(SHOW_TIMEOUT_SECS))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => {
+            return model_names
+                .into_iter()
+                .map(|name| DiscoveredModel {
+                    name,
+                    ..Default::default()
+                })
+                .collect();
+        }
+    };
+
+    let root = root_url.to_string();
+    futures::stream::iter(model_names)
+        .map(|name| {
+            let client = client.clone();
+            let root = root.clone();
+            async move { fetch_ollama_model_info(&client, &root, &name).await }
+        })
+        .buffer_unordered(OLLAMA_SHOW_CONCURRENCY)
+        .collect()
+        .await
+}
+
+/// Fetch detailed model info from Ollama's `POST /api/show` endpoint.
+///
+/// Extracts context_window, vision/tool support, model family, parameter size,
+/// and quantization level. On failure, returns a `DiscoveredModel` with only
+/// the `name` set (all metadata fields `None`).
+async fn fetch_ollama_model_info(
+    client: &reqwest::Client,
+    root_url: &str,
+    model_name: &str,
+) -> DiscoveredModel {
+    let url = format!("{}/api/show", root_url.trim_end_matches('/'));
+    let body = serde_json::json!({ "name": model_name });
+
+    let resp = match client.post(&url).json(&body).send().await {
+        Ok(r) if r.status().is_success() => r,
+        _ => {
+            return DiscoveredModel {
+                name: model_name.to_string(),
+                ..Default::default()
+            };
+        }
+    };
+
+    let json: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => {
+            return DiscoveredModel {
+                name: model_name.to_string(),
+                ..Default::default()
+            };
+        }
+    };
+
+    // Extract context_window from model_info — keys are "{arch}.context_length"
+    let context_window = json
+        .get("model_info")
+        .and_then(|info| {
+            info.as_object().and_then(|map| {
+                map.iter()
+                    .find(|(k, _)| k.ends_with(".context_length"))
+                    .and_then(|(_, v)| v.as_u64())
+            })
+        })
+        .or_else(|| parse_num_ctx_from_parameters(json.get("parameters")));
+
+    // Extract vision support — primary: capabilities array
+    let supports_vision_from_caps = json
+        .get("capabilities")
+        .and_then(|c| c.as_array())
+        .map(|arr| arr.iter().any(|v| v.as_str() == Some("vision")));
+
+    // Extract families list from details
+    let families = json
+        .get("details")
+        .and_then(|d| d.get("families"))
+        .and_then(|f| f.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Vec<String>>()
+        });
+
+    // Vision: capabilities > family heuristic > model name heuristic
+    let supports_vision = supports_vision_from_caps.or_else(|| {
+        families
+            .as_ref()
+            .map(|fams| fams.iter().any(|f| is_vision_family(f)))
+    });
+
+    // Extract tool support from capabilities
+    let supports_tools = json
+        .get("capabilities")
+        .and_then(|c| c.as_array())
+        .map(|arr| arr.iter().any(|v| v.as_str() == Some("tools")));
+
+    // Extract details
+    let family = json
+        .get("details")
+        .and_then(|d| d.get("family"))
+        .and_then(|f| f.as_str())
+        .map(|s| s.to_string());
+
+    let parameter_size = json
+        .get("details")
+        .and_then(|d| d.get("parameter_size"))
+        .and_then(|p| p.as_str())
+        .map(|s| s.to_string());
+
+    let quantization_level = json
+        .get("details")
+        .and_then(|d| d.get("quantization_level"))
+        .and_then(|q| q.as_str())
+        .map(|s| s.to_string());
+
+    DiscoveredModel {
+        name: model_name.to_string(),
+        context_window,
+        max_output_tokens: None, // Ollama doesn't expose this separately
+        supports_vision,
+        supports_tools,
+        family,
+        families,
+        parameter_size,
+        quantization_level,
+    }
+}
+
+/// Parse `num_ctx` from Ollama's parameters text field.
+///
+/// The parameters field is a newline-separated key-value text like:
+/// ```text
+/// temperature 0.7
+/// num_ctx 2048
+/// ```
+fn parse_num_ctx_from_parameters(params: Option<&serde_json::Value>) -> Option<u64> {
+    let text = params?.as_str()?;
+    for line in text.lines() {
+        let mut parts = line.split_whitespace();
+        if parts.next() == Some("num_ctx") {
+            return parts.next().and_then(|v| v.parse().ok());
+        }
+    }
+    None
+}
+
+/// Known vision model families from Ollama.
+fn is_vision_family(family: &str) -> bool {
+    matches!(
+        family.to_lowercase().as_str(),
+        "llava" | "bakllava" | "moondream" | "clip" | "mllama"
+    )
 }
 
 /// Lightweight model probe -- sends a minimal completion request to verify a model is responsive.
@@ -253,5 +475,36 @@ mod tests {
     async fn test_probe_model_unreachable() {
         let result = probe_model("test", "http://127.0.0.1:19998/v1", "test-model", None).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_num_ctx_from_parameters() {
+        let params = serde_json::json!("temperature 0.7\nnum_ctx 4096\ntop_p 0.9");
+        assert_eq!(parse_num_ctx_from_parameters(Some(&params)), Some(4096));
+
+        let no_ctx = serde_json::json!("temperature 0.7\ntop_p 0.9");
+        assert_eq!(parse_num_ctx_from_parameters(Some(&no_ctx)), None);
+
+        assert_eq!(parse_num_ctx_from_parameters(None), None);
+    }
+
+    #[test]
+    fn test_is_vision_family() {
+        assert!(is_vision_family("llava"));
+        assert!(is_vision_family("clip"));
+        assert!(is_vision_family("mllama"));
+        assert!(is_vision_family("LLAVA"));
+        assert!(!is_vision_family("llama"));
+        assert!(!is_vision_family("qwen2"));
+    }
+
+    #[test]
+    fn test_discovered_model_default() {
+        let model = DiscoveredModel::default();
+        assert!(model.name.is_empty());
+        assert!(model.context_window.is_none());
+        assert!(model.supports_vision.is_none());
+        assert!(model.supports_tools.is_none());
+        assert!(model.family.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Enhance Ollama auto-discovery to query `/api/show` for each model, extracting real context window, vision/tool capabilities, model family, parameter size, and quantization level
- Previously all discovered Ollama models received hardcoded defaults (32K context, no vision, tools=true)

## What's New
- `DiscoveredModel` struct with optional metadata fields for enriched model info
- `fetch_ollama_model_info()` calls Ollama's `POST /api/show` per model
- `enrich_ollama_models()` runs enrichment in parallel (max 4 concurrent)
- Enriched display names include parameter size and quantization (e.g., "llama3.2:latest 3B Q4_K_M (ollama)")

## Core Features
- **Context window**: extracted from `model_info[*.context_length]` with `num_ctx` parameter fallback
- **Vision support**: detected from `capabilities` array or family-based heuristic (llava, clip, mllama)
- **Tool support**: detected from `capabilities` array
- **Graceful degradation**: if `/api/show` fails for a model, falls back to previous defaults

## Technical Details
- `ProbeResult.discovered_models` changed from `Vec<String>` to `Vec<DiscoveredModel>`
- `merge_discovered_models()` uses `.unwrap_or()` for backward-compatible defaults
- vLLM/LM Studio discovery unchanged (no enrichment, same defaults)
- API response remains backward-compatible (emits model name strings)

## Testing
- All existing tests updated for new signature
- New tests: enriched model merge, unenriched defaults, `num_ctx` parsing, vision family detection
- `cargo build --workspace --lib` passes
- `cargo test --workspace` passes (1826 tests, 0 failures)
- `cargo clippy -p openfang-runtime -p openfang-api --lib -- -D warnings` clean