### PR TITLE
fix: support multi-word agent names in /agent command

### DIFF
--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -730,15 +730,15 @@ async fn handle_command(
             if args.is_empty() {
                 return "Usage: /agent <name>".to_string();
             }
-            let agent_name = &args[0];
-            match handle.find_agent_by_name(agent_name).await {
+            let agent_name = args.join(" ");
+            match handle.find_agent_by_name(&agent_name).await {
                 Ok(Some(agent_id)) => {
                     router.set_user_default(sender.platform_id.clone(), agent_id);
                     format!("Now talking to agent: {agent_name}")
                 }
                 Ok(None) => {
                     // Try to spawn it
-                    match handle.spawn_agent_by_name(agent_name).await {
+                    match handle.spawn_agent_by_name(&agent_name).await {
                         Ok(agent_id) => {
                             router.set_user_default(sender.platform_id.clone(), agent_id);
                             format!("Spawned and connected to agent: {agent_name}")


### PR DESCRIPTION
## Summary

- `/agent` command now joins all arguments with spaces instead of using only the first word
- Multi-word agent names like `Data Analyst` or `DevOps Engineer` now resolve correctly

## Problem

`/agent Data Analyst` only took `args[0]` which was `"Data"`, so the lookup failed with "agent not found". This affected all agents with spaces in their names.

## Changes

| File | Change |
|------|--------|
| `crates/openfang-channels/src/bridge.rs` | `args[0]` → `args.join(" ")` in the `/agent` command handler |

## Test plan

- [x] `/agent Data Analyst` correctly switches to the Data Analyst agent
- [x] `/agent assistant` (single word) still works as before
- [x] `cargo build --workspace --lib` compiles clean