### PR TITLE
fix(api): implement Hand settings API endpoints (GET/PUT/PATCH)

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -6,6 +6,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use dashmap::DashMap;
+use serde::Deserialize;
 use openfang_kernel::triggers::{TriggerId, TriggerPattern};
 use openfang_kernel::workflow::{
     ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowStep,
@@ -3682,6 +3683,79 @@ pub async fn hand_instance_browser(
             "screenshot_base64": screenshot_base64,
         })),
     )
+}
+
+/// GET /api/hands/instances/{id}/settings — Get the current config of a hand instance.
+pub async fn get_hand_settings(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<uuid::Uuid>,
+) -> impl IntoResponse {
+    match state.kernel.get_hand_instance(id) {
+        Ok(instance) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "instance_id": instance.instance_id,
+                "hand_id": instance.hand_id,
+                "config": instance.config,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": format!("{e}")})),
+        ),
+    }
+}
+
+/// PUT /api/hands/instances/{id}/settings — Update the config of a hand instance.
+#[derive(Debug, Deserialize)]
+pub struct UpdateHandSettingsRequest {
+    pub config: std::collections::HashMap<String, serde_json::Value>,
+}
+
+pub async fn update_hand_settings(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<uuid::Uuid>,
+    Json(body): Json<UpdateHandSettingsRequest>,
+) -> impl IntoResponse {
+    match state.kernel.update_hand_config(id, body.config) {
+        Ok(instance) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "instance_id": instance.instance_id,
+                "hand_id": instance.hand_id,
+                "config": instance.config,
+                "status": format!("{}", instance.status),
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("{e}")})),
+        ),
+    }
+}
+
+/// PATCH /api/hands/instances/{id}/settings — Partially update the config of a hand instance.
+pub async fn patch_hand_settings(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<uuid::Uuid>,
+    Json(body): Json<UpdateHandSettingsRequest>,
+) -> impl IntoResponse {
+    // PATCH merges config like PUT (for hand settings, behavior is the same)
+    match state.kernel.update_hand_config(id, body.config) {
+        Ok(instance) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "instance_id": instance.instance_id,
+                "hand_id": instance.hand_id,
+                "config": instance.config,
+                "status": format!("{}", instance.status),
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("{e}")})),
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/openfang-api/src/server.rs
+++ b/crates/openfang-api/src/server.rs
@@ -355,6 +355,12 @@ pub async fn build_router(
             "/api/hands/instances/{id}/browser",
             axum::routing::get(routes::hand_instance_browser),
         )
+        .route(
+            "/api/hands/instances/{id}/settings",
+            axum::routing::get(routes::get_hand_settings)
+                .put(routes::update_hand_settings)
+                .patch(routes::patch_hand_settings),
+        )
         // MCP server endpoints
         .route(
             "/api/mcp/servers",

--- a/crates/openfang-hands/src/registry.rs
+++ b/crates/openfang-hands/src/registry.rs
@@ -240,6 +240,27 @@ impl HandRegistry {
         entry.updated_at = chrono::Utc::now();
         Ok(())
     }
+
+    /// Update the config of an active hand instance.
+    /// Merges new config values with existing ones.
+    pub fn update_instance_config(
+        &self,
+        instance_id: Uuid,
+        new_config: HashMap<String, serde_json::Value>,
+    ) -> HandResult<HandInstance> {
+        let mut entry = self
+            .instances
+            .get_mut(&instance_id)
+            .ok_or(HandError::InstanceNotFound(instance_id))?;
+
+        // Merge new config into existing config
+        for (key, value) in new_config {
+            entry.config.insert(key, value);
+        }
+        entry.updated_at = chrono::Utc::now();
+
+        Ok(entry.clone())
+    }
 }
 
 impl Default for HandRegistry {
@@ -433,6 +454,49 @@ mod tests {
         assert!(reg.deactivate(Uuid::new_v4()).is_err());
         assert!(reg.pause(Uuid::new_v4()).is_err());
         assert!(reg.resume(Uuid::new_v4()).is_err());
+        // update_instance_config should also return error for non-existent instance
+        assert!(reg.update_instance_config(Uuid::new_v4(), HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn update_instance_config_merges_and_returns_updated() {
+        let mut reg = HandRegistry::new();
+        reg.load_bundled();
+
+        // Activate with initial config
+        let mut initial_config: HashMap<String, serde_json::Value> = HashMap::new();
+        initial_config.insert("key1".to_string(), serde_json::json!("value1"));
+        initial_config.insert("key2".to_string(), serde_json::json!("value2"));
+
+        let instance = reg.activate("clip", initial_config.clone()).unwrap();
+        let id = instance.instance_id;
+
+        // Verify initial config
+        assert_eq!(instance.config.get("key1").unwrap(), "value1");
+        assert_eq!(instance.config.get("key2").unwrap(), "value2");
+
+        // Update config: modify key1, add key3, leave key2 unchanged
+        let mut update: HashMap<String, serde_json::Value> = HashMap::new();
+        update.insert("key1".to_string(), serde_json::json!("updated_value1"));
+        update.insert("key3".to_string(), serde_json::json!("value3"));
+
+        let updated = reg.update_instance_config(id, update).unwrap();
+
+        // Verify merged config
+        assert_eq!(updated.config.get("key1").unwrap(), "updated_value1"); // Modified
+        assert_eq!(updated.config.get("key2").unwrap(), "value2"); // Unchanged
+        assert_eq!(updated.config.get("key3").unwrap(), "value3"); // Added
+
+        // Verify updated_at was changed (should be greater than activated_at)
+        assert!(updated.updated_at >= updated.activated_at);
+
+        // Verify persisted by reading back
+        let retrieved = reg.get_instance(id).unwrap();
+        assert_eq!(retrieved.config.get("key1").unwrap(), "updated_value1");
+        assert_eq!(retrieved.config.get("key2").unwrap(), "value2");
+        assert_eq!(retrieved.config.get("key3").unwrap(), "value3");
+
+        reg.deactivate(id).unwrap();
     }
 
     #[test]

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -2714,6 +2714,28 @@ impl OpenFangKernel {
             .map_err(|e| KernelError::OpenFang(OpenFangError::Internal(e.to_string())))
     }
 
+    /// Get a hand instance by ID.
+    pub fn get_hand_instance(&self, instance_id: uuid::Uuid) -> KernelResult<openfang_hands::HandInstance> {
+        self.hand_registry
+            .get_instance(instance_id)
+            .ok_or_else(|| {
+                KernelError::OpenFang(OpenFangError::AgentNotFound(format!(
+                    "Hand instance not found: {instance_id}"
+                )))
+            })
+    }
+
+    /// Update the config of an active hand instance.
+    pub fn update_hand_config(
+        &self,
+        instance_id: uuid::Uuid,
+        config: std::collections::HashMap<String, serde_json::Value>,
+    ) -> KernelResult<openfang_hands::HandInstance> {
+        self.hand_registry
+            .update_instance_config(instance_id, config)
+            .map_err(|e| KernelError::OpenFang(OpenFangError::Internal(e.to_string())))
+    }
+
     /// Set the weak self-reference for trigger dispatch.
     ///
     /// Must be called once after the kernel is wrapped in `Arc`.


### PR DESCRIPTION
## Summary
Fixes #113 - Hand settings API returns empty responses.

## Changes
- Add `update_instance_config()` to HandRegistry
- Add `get_hand_instance()` and `update_hand_config()` to kernel
- Implement GET/PUT/PATCH handlers for `/api/hands/{id}/settings`
- Add unit tests

## Test Plan
- [x] `cargo build --workspace --lib` compiles
- [x] `cargo test --workspace` passes (36 tests)
- [x] `cargo clippy` passes with 0 warnings

## API
- GET `/api/hands/instances/{id}/settings` -> returns config
- PUT `/api/hands/instances/{id}/settings` -> updates config
- PATCH `/api/hands/instances/{id}/settings` -> merges config