### PR TITLE
fix(runtime): normalize openrouter model ids before API request

### DIFF
--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -57,9 +57,19 @@ const MAX_HISTORY_MESSAGES: usize = 20;
 /// but the upstream API expects just `org/model`. This also handles special routers
 /// like `openrouter/auto` → `auto`.
 pub fn strip_provider_prefix(model: &str, provider: &str) -> String {
-    let prefix = format!("{}/", provider);
-    if model.starts_with(&prefix) {
-        model[prefix.len()..].to_string()
+    let model = model.trim();
+    let provider = provider.trim();
+
+    if provider.is_empty() {
+        return model.to_string();
+    }
+
+    let prefix_len = provider.len();
+    if model.len() > prefix_len
+        && model.as_bytes().get(prefix_len) == Some(&b'/')
+        && model[..prefix_len].eq_ignore_ascii_case(provider)
+    {
+        model[prefix_len + 1..].to_string()
     } else {
         model.to_string()
     }
@@ -679,10 +689,13 @@ pub async fn run_agent_loop(
                 }
 
                 // Detect approval denials and inject guidance to prevent infinite retry loops
-                let denial_count = tool_result_blocks.iter().filter(|b| {
-                    matches!(b, ContentBlock::ToolResult { content, is_error: true, .. }
+                let denial_count = tool_result_blocks
+                    .iter()
+                    .filter(|b| {
+                        matches!(b, ContentBlock::ToolResult { content, is_error: true, .. }
                         if content.contains("requires human approval and was denied"))
-                }).count();
+                    })
+                    .count();
                 if denial_count > 0 {
                     tool_result_blocks.push(ContentBlock::Text {
                         text: format!(
@@ -1599,10 +1612,13 @@ pub async fn run_agent_loop_streaming(
                 }
 
                 // Detect approval denials and inject guidance to prevent infinite retry loops
-                let denial_count = tool_result_blocks.iter().filter(|b| {
-                    matches!(b, ContentBlock::ToolResult { content, is_error: true, .. }
+                let denial_count = tool_result_blocks
+                    .iter()
+                    .filter(|b| {
+                        matches!(b, ContentBlock::ToolResult { content, is_error: true, .. }
                         if content.contains("requires human approval and was denied"))
-                }).count();
+                    })
+                    .count();
                 if denial_count > 0 {
                     tool_result_blocks.push(ContentBlock::Text {
                         text: format!(
@@ -1889,6 +1905,18 @@ mod tests {
     #[test]
     fn test_max_history_messages() {
         assert_eq!(MAX_HISTORY_MESSAGES, 20);
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_openrouter() {
+        let got = strip_provider_prefix("openrouter/google/gemini-2.5-flash", "openrouter");
+        assert_eq!(got, "google/gemini-2.5-flash");
+    }
+
+    #[test]
+    fn test_strip_provider_prefix_case_insensitive_and_trimmed() {
+        let got = strip_provider_prefix(" openrouter/deepseek/deepseek-chat ", " OpenRouter ");
+        assert_eq!(got, "deepseek/deepseek-chat");
     }
 
     // --- Integration tests for empty response guards ---

--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -27,6 +27,13 @@ impl OpenAIDriver {
             client: reqwest::Client::new(),
         }
     }
+
+    fn normalized_model(&self, model: &str) -> String {
+        if self.base_url.contains("openrouter.ai") {
+            return crate::agent_loop::strip_provider_prefix(model, "openrouter");
+        }
+        model.trim().to_string()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -277,7 +284,7 @@ impl LlmDriver for OpenAIDriver {
         };
 
         let mut oai_request = OaiRequest {
-            model: request.model.clone(),
+            model: self.normalized_model(&request.model),
             messages: oai_messages,
             max_tokens: request.max_tokens,
             temperature: request.temperature,
@@ -556,7 +563,7 @@ impl LlmDriver for OpenAIDriver {
         };
 
         let mut oai_request = OaiRequest {
-            model: request.model.clone(),
+            model: self.normalized_model(&request.model),
             messages: oai_messages,
             max_tokens: request.max_tokens,
             temperature: request.temperature,
@@ -949,5 +956,29 @@ mod tests {
         assert!(result.is_some());
         let resp = result.unwrap();
         assert_eq!(resp.tool_calls[0].name, "shell_exec");
+    }
+
+    #[test]
+    fn test_normalized_model_for_openrouter_strips_prefix() {
+        let driver = OpenAIDriver::new(
+            "test-key".to_string(),
+            "https://openrouter.ai/api/v1".to_string(),
+        );
+        assert_eq!(
+            driver.normalized_model("openrouter/google/gemini-2.5-flash"),
+            "google/gemini-2.5-flash"
+        );
+    }
+
+    #[test]
+    fn test_normalized_model_for_non_openrouter_keeps_model() {
+        let driver = OpenAIDriver::new(
+            "test-key".to_string(),
+            "https://api.openai.com/v1".to_string(),
+        );
+        assert_eq!(
+            driver.normalized_model("openrouter/google/gemini-2.5-flash"),
+            "openrouter/google/gemini-2.5-flash"
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes model ID normalization for OpenRouter to ensure `openrouter/org/model` is correctly transformed to `org/model` before sending requests, preventing 400 errors from upstream APIs.

### Changes

1. **`strip_provider_prefix` robustness** (`crates/openfang-runtime/src/drivers/openai.rs`)
   - Added `trim()` for both model and provider inputs
   - Implemented case-insensitive prefix matching using `eq_ignore_ascii_case`
   - Handles empty provider gracefully to avoid slice out-of-bounds issues
   - Ensures `openrouter/google/gemini-2.5-flash` → `google/gemini-2.5-flash`

2. **Driver-level fallback normalization** (`OpenAIDriver`)
   - Added `normalized_model()` helper that detects OpenRouter base URLs
   - Forces `openrouter/...` → `org/model` normalization as a safety net
   - Applied to both standard (`run_agent_loop`) and streaming (`run_agent_loop_streaming`) request paths

3. **Test coverage**
   - `test_strip_provider_prefix_openrouter` – verifies nested model ID handling
   - `test_strip_provider_prefix_case_insensitive_and_trimmed` – verifies case-insensitivity and whitespace handling  
   - `test_normalized_model_for_openrouter_strips_prefix` – verifies driver-level fallback for OpenRouter URLs
   - `test_normalized_model_for_non_openrouter_keeps_model` – verifies no-op for non-OpenRouter providers

## Testing

```bash
# Build check
cargo test -p openfang-runtime --no-run

# Unit tests
cargo test -p openfang-runtime test_strip_provider_prefix_openrouter -- --nocapture
cargo test -p openfang-runtime test_strip_provider_prefix_case_insensitive_and_trimmed -- --nocapture
cargo test -p openfang-runtime test_normalized_model_for_openrouter_strips_prefix -- --nocapture
cargo test -p openfang-runtime test_normalized_model_for_non_openrouter_keeps_model -- --nocapture