### PR TITLE
ci: add Linux aarch64 build and test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,39 @@ jobs:
       # Tests that need a display (Tauri) are skipped in headless CI via cfg
       - run: cargo test --workspace
 
+  # ── Linux aarch64 (cross-compiled + QEMU tests) ──────────────────────────
+  check-linux-aarch64:
+    name: Check / Linux aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: check-linux-aarch64
+      - name: Install cross
+        run: cargo install cross --locked
+      - name: Cross check
+        run: cross check --workspace --target aarch64-unknown-linux-gnu
+
+  test-linux-aarch64:
+    name: Test / Linux aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-linux-aarch64
+      - name: Install cross
+        run: cargo install cross --locked
+      - name: Cross test
+        run: cross test --workspace --target aarch64-unknown-linux-gnu
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
             args: "--target x86_64-unknown-linux-gnu"
             rust_target: x86_64-unknown-linux-gnu
 
+          - name: Linux aarch64
+            os: ubuntu-22.04
+            args: "--target aarch64-unknown-linux-gnu"
+            rust_target: aarch64-unknown-linux-gnu
+
           - name: macOS x86_64
             os: macos-latest
             args: "--target x86_64-apple-darwin"
@@ -51,8 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system deps (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system deps (Linux x86_64)
+        if: runner.os == 'Linux' && matrix.platform.rust_target != 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -61,6 +66,37 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
+
+      - name: Install system deps (Linux aarch64 cross)
+        if: matrix.platform.rust_target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo dpkg --add-architecture arm64
+          # Restrict existing repos to amd64, add arm64 from ports mirror
+          sudo sed -i 's/^deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+          cat <<'SOURCES' | sudo tee /etc/apt/sources.list.d/arm64-ports.list
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse
+          SOURCES
+          sudo sed -i 's/^[[:space:]]*//' /etc/apt/sources.list.d/arm64-ports.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            patchelf \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev:arm64 \
+            libgtk-3-dev:arm64 \
+            libayatana-appindicator3-dev:arm64 \
+            librsvg2-dev:arm64
+          # Configure cross-compilation env
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Add `check-linux-aarch64` and `test-linux-aarch64` jobs to CI pipeline using `cross` + QEMU emulation
- Add `Linux aarch64` desktop (Tauri) target to release pipeline with multiarch cross-compilation setup
- CLI and Docker already had aarch64 coverage; this closes the gap for CI checks and desktop builds

## Test plan
- [ ] Verify CI jobs `Check / Linux aarch64` and `Test / Linux aarch64` pass on this PR
- [ ] Verify existing CI jobs (x86_64 check/test/clippy/fmt) are unaffected
- [ ] On next tagged release, verify `Desktop / Linux aarch64` produces .AppImage/.deb artifacts