### PR TITLE
feat(feishu): 添加WebSocket模式支持并重构适配器

### DIFF
--- a/crates/openfang-channels/src/feishu.rs
+++ b/crates/openfang-channels/src/feishu.rs
@@ -1,8 +1,11 @@
 //! Feishu/Lark Open Platform channel adapter.
 //!
-//! Uses the Feishu Open API for sending messages and a webhook HTTP server for
-//! receiving inbound events. Authentication is performed via a tenant access token
-//! obtained from `https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal`.
+//! Uses the Feishu Open API for sending messages. Supports two modes for receiving inbound events:
+//! 1. Webhook mode: HTTP server for receiving event callbacks
+//! 2. WebSocket mode: WebSocket long connection for receiving events (no public IP required)
+//!
+//! Authentication is performed via a tenant access token obtained from
+//! `https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal`.
 //! The token is cached and refreshed automatically (2-hour expiry).
 
 use crate::types::{
@@ -10,13 +13,14 @@ use crate::types::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use futures::Stream;
+use futures::{SinkExt, Stream, StreamExt};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, RwLock};
-use tracing::{info, warn};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tracing::{debug, error, info, warn};
 use zeroize::Zeroizing;
 
 /// Feishu tenant access token endpoint.
@@ -35,21 +39,31 @@ const MAX_MESSAGE_LEN: usize = 4096;
 /// Token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
 
+/// Feishu connection mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeishuConnectionMode {
+    /// Webhook mode: HTTP server receives event callbacks.
+    Webhook,
+    /// WebSocket mode: Long connection receives events (no public IP required).
+    WebSocket,
+}
+
 /// Feishu/Lark Open Platform adapter.
 ///
-/// Inbound messages arrive via a webhook HTTP server that receives event
-/// callbacks from the Feishu platform. Outbound messages are sent via the
-/// Feishu IM API with a tenant access token for authentication.
+/// Inbound messages arrive via either a webhook HTTP server or WebSocket long connection.
+/// Outbound messages are sent via the Feishu IM API with a tenant access token for authentication.
 pub struct FeishuAdapter {
     /// Feishu app ID.
     app_id: String,
     /// SECURITY: Feishu app secret, zeroized on drop.
     app_secret: Zeroizing<String>,
-    /// Port on which the inbound webhook HTTP server listens.
+    /// Connection mode (Webhook or WebSocket).
+    connection_mode: FeishuConnectionMode,
+    /// Port on which the inbound webhook HTTP server listens (Webhook mode only).
     webhook_port: u16,
-    /// Optional verification token for webhook event validation.
+    /// Optional verification token for webhook event validation (Webhook mode only).
     verification_token: Option<String>,
-    /// Optional encrypt key for webhook event decryption.
+    /// Optional encrypt key for webhook event decryption (Webhook mode only).
     encrypt_key: Option<String>,
     /// HTTP client for API calls.
     client: reqwest::Client,
@@ -61,7 +75,7 @@ pub struct FeishuAdapter {
 }
 
 impl FeishuAdapter {
-    /// Create a new Feishu adapter.
+    /// Create a new Feishu adapter in Webhook mode.
     ///
     /// # Arguments
     /// * `app_id` - Feishu application ID.
@@ -72,6 +86,7 @@ impl FeishuAdapter {
         Self {
             app_id,
             app_secret: Zeroizing::new(app_secret),
+            connection_mode: FeishuConnectionMode::Webhook,
             webhook_port,
             verification_token: None,
             encrypt_key: None,
@@ -82,7 +97,7 @@ impl FeishuAdapter {
         }
     }
 
-    /// Create a new Feishu adapter with webhook verification.
+    /// Create a new Feishu adapter in Webhook mode with verification.
     pub fn with_verification(
         app_id: String,
         app_secret: String,
@@ -96,9 +111,31 @@ impl FeishuAdapter {
         adapter
     }
 
+    /// Create a new Feishu adapter in WebSocket mode.
+    ///
+    /// WebSocket mode does not require a public IP or webhook configuration.
+    ///
+    /// # Arguments
+    /// * `app_id` - Feishu application ID.
+    /// * `app_secret` - Feishu application secret.
+    pub fn new_websocket(app_id: String, app_secret: String) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            app_id,
+            app_secret: Zeroizing::new(app_secret),
+            connection_mode: FeishuConnectionMode::WebSocket,
+            webhook_port: 0,
+            verification_token: None,
+            encrypt_key: None,
+            client: reqwest::Client::new(),
+            shutdown_tx: Arc::new(shutdown_tx),
+            shutdown_rx,
+            cached_token: Arc::new(RwLock::new(None)),
+        }
+    }
+
     /// Obtain a valid tenant access token, refreshing if expired or missing.
     async fn get_token(&self) -> Result<String, Box<dyn std::error::Error>> {
-        // Check cache first
         {
             let guard = self.cached_token.read().await;
             if let Some((ref token, expiry)) = *guard {
@@ -108,7 +145,6 @@ impl FeishuAdapter {
             }
         }
 
-        // Fetch a new tenant access token
         let body = serde_json::json!({
             "app_id": self.app_id,
             "app_secret": self.app_secret.as_str(),
@@ -140,7 +176,6 @@ impl FeishuAdapter {
             .to_string();
         let expire = resp_body["expire"].as_u64().unwrap_or(7200);
 
-        // Cache with safety buffer
         let expiry =
             Instant::now() + Duration::from_secs(expire.saturating_sub(TOKEN_REFRESH_BUFFER_SECS));
         *self.cached_token.write().await = Some((tenant_access_token.clone(), expiry));
@@ -227,167 +262,8 @@ impl FeishuAdapter {
         Ok(())
     }
 
-    /// Reply to a message in a thread.
-    #[allow(dead_code)]
-    async fn api_reply_message(
-        &self,
-        message_id: &str,
-        text: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let token = self.get_token().await?;
-        let url = format!(
-            "https://open.feishu.cn/open-apis/im/v1/messages/{}/reply",
-            message_id
-        );
-
-        let content = serde_json::json!({
-            "text": text,
-        });
-
-        let body = serde_json::json!({
-            "msg_type": "text",
-            "content": content.to_string(),
-        });
-
-        let resp = self
-            .client
-            .post(&url)
-            .bearer_auth(&token)
-            .json(&body)
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let resp_body = resp.text().await.unwrap_or_default();
-            return Err(format!("Feishu reply message error {status}: {resp_body}").into());
-        }
-
-        Ok(())
-    }
-}
-
-/// Parse a Feishu webhook event into a `ChannelMessage`.
-///
-/// Handles `im.message.receive_v1` events with text message type.
-fn parse_feishu_event(event: &serde_json::Value) -> Option<ChannelMessage> {
-    // Feishu v2 event schema
-    let header = event.get("header")?;
-    let event_type = header["event_type"].as_str().unwrap_or("");
-
-    if event_type != "im.message.receive_v1" {
-        return None;
-    }
-
-    let event_data = event.get("event")?;
-    let message = event_data.get("message")?;
-    let sender = event_data.get("sender")?;
-
-    let msg_type = message["message_type"].as_str().unwrap_or("");
-    if msg_type != "text" {
-        return None;
-    }
-
-    // Parse the content JSON string
-    let content_str = message["content"].as_str().unwrap_or("{}");
-    let content_json: serde_json::Value = serde_json::from_str(content_str).unwrap_or_default();
-    let text = content_json["text"].as_str().unwrap_or("");
-    if text.is_empty() {
-        return None;
-    }
-
-    let message_id = message["message_id"].as_str().unwrap_or("").to_string();
-    let chat_id = message["chat_id"].as_str().unwrap_or("").to_string();
-    let chat_type = message["chat_type"].as_str().unwrap_or("p2p");
-    let root_id = message["root_id"].as_str().map(|s| s.to_string());
-
-    let sender_id = sender
-        .get("sender_id")
-        .and_then(|s| s.get("open_id"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let sender_type = sender["sender_type"].as_str().unwrap_or("user");
-
-    // Skip bot messages
-    if sender_type == "bot" {
-        return None;
-    }
-
-    let is_group = chat_type == "group";
-
-    let msg_content = if text.starts_with('/') {
-        let parts: Vec<&str> = text.splitn(2, ' ').collect();
-        let cmd_name = parts[0].trim_start_matches('/');
-        let args: Vec<String> = parts
-            .get(1)
-            .map(|a| a.split_whitespace().map(String::from).collect())
-            .unwrap_or_default();
-        ChannelContent::Command {
-            name: cmd_name.to_string(),
-            args,
-        }
-    } else {
-        ChannelContent::Text(text.to_string())
-    };
-
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        "chat_id".to_string(),
-        serde_json::Value::String(chat_id.clone()),
-    );
-    metadata.insert(
-        "message_id".to_string(),
-        serde_json::Value::String(message_id.clone()),
-    );
-    metadata.insert(
-        "chat_type".to_string(),
-        serde_json::Value::String(chat_type.to_string()),
-    );
-    metadata.insert(
-        "sender_id".to_string(),
-        serde_json::Value::String(sender_id.clone()),
-    );
-    if let Some(mentions) = message.get("mentions") {
-        metadata.insert("mentions".to_string(), mentions.clone());
-    }
-
-    Some(ChannelMessage {
-        channel: ChannelType::Custom("feishu".to_string()),
-        platform_message_id: message_id,
-        sender: ChannelUser {
-            platform_id: chat_id,
-            display_name: sender_id,
-            openfang_user: None,
-        },
-        content: msg_content,
-        target_agent: None,
-        timestamp: Utc::now(),
-        is_group,
-        thread_id: root_id,
-        metadata,
-    })
-}
-
-#[async_trait]
-impl ChannelAdapter for FeishuAdapter {
-    fn name(&self) -> &str {
-        "feishu"
-    }
-
-    fn channel_type(&self) -> ChannelType {
-        ChannelType::Custom("feishu".to_string())
-    }
-
-    async fn start(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>, Box<dyn std::error::Error>>
-    {
-        // Validate credentials
-        let bot_name = self.validate().await?;
-        info!("Feishu adapter authenticated as {bot_name}");
-
-        let (tx, rx) = mpsc::channel::<ChannelMessage>(256);
+    /// Start webhook server (Webhook mode).
+    async fn start_webhook(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<(), Box<dyn std::error::Error>> {
         let port = self.webhook_port;
         let verification_token = self.verification_token.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
@@ -405,9 +281,7 @@ impl ChannelAdapter for FeishuAdapter {
                         let vt = Arc::clone(&vt);
                         let tx = Arc::clone(&tx);
                         async move {
-                            // Handle URL verification challenge
                             if let Some(challenge) = body.0.get("challenge") {
-                                // Verify token if configured
                                 if let Some(ref expected_token) = *vt {
                                     let token = body.0["token"].as_str().unwrap_or("");
                                     if token != expected_token {
@@ -426,19 +300,15 @@ impl ChannelAdapter for FeishuAdapter {
                                 );
                             }
 
-                            // Handle event callback
                             if let Some(schema) = body.0["schema"].as_str() {
                                 if schema == "2.0" {
-                                    // V2 event format
                                     if let Some(msg) = parse_feishu_event(&body.0) {
                                         let _ = tx.send(msg).await;
                                     }
                                 }
                             } else {
-                                // V1 event format (legacy)
                                 let event_type = body.0["event"]["type"].as_str().unwrap_or("");
                                 if event_type == "message" {
-                                    // Legacy format handling
                                     let event = &body.0["event"];
                                     let text = event["text"].as_str().unwrap_or("");
                                     if !text.is_empty() {
@@ -527,6 +397,339 @@ impl ChannelAdapter for FeishuAdapter {
             }
         });
 
+        Ok(())
+    }
+
+    /// Start WebSocket connection loop (WebSocket mode).
+    async fn start_websocket_loop(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<(), Box<dyn std::error::Error>> {
+        let self_arc = Arc::new(self.clone_adapter());
+        
+        tokio::spawn(async move {
+            info!("Starting Feishu WebSocket mode");
+            let mut backoff = Duration::from_secs(1);
+            let max_backoff = Duration::from_secs(60);
+            
+            loop {
+                match Self::run_websocket_inner(self_arc.clone(), tx.clone()).await {
+                    Ok(_) => {
+                        info!("Feishu WebSocket connection closed, reconnecting...");
+                    }
+                    Err(e) => {
+                        error!("Feishu WebSocket error: {e}, reconnecting in {backoff:?}");
+                    }
+                }
+                
+                tokio::time::sleep(backoff).await;
+                backoff = std::cmp::min(backoff * 2, max_backoff);
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Clone adapter for use in async tasks.
+    fn clone_adapter(&self) -> FeishuAdapterClone {
+        FeishuAdapterClone {
+            app_id: self.app_id.clone(),
+            app_secret: self.app_secret.clone(),
+            client: self.client.clone(),
+            cached_token: self.cached_token.clone(),
+            shutdown_rx: self.shutdown_rx.clone(),
+        }
+    }
+
+    /// Run WebSocket connection loop (inner implementation).
+    async fn run_websocket_inner(
+        adapter: Arc<FeishuAdapterClone>,
+        tx: mpsc::Sender<ChannelMessage>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let ws_url = adapter.get_websocket_endpoint().await?;
+        info!("Connecting to Feishu WebSocket endpoint: {ws_url}");
+
+        let (ws_stream, _) = connect_async(ws_url).await?;
+        info!("Feishu WebSocket connected successfully");
+
+        let (mut write, mut read) = ws_stream.split();
+        let mut shutdown_rx = adapter.shutdown_rx.clone();
+
+        loop {
+            tokio::select! {
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            debug!("Received Feishu WebSocket message: {text}");
+                            if let Ok(event) = serde_json::from_str::<serde_json::Value>(&text) {
+                                if let Some(msg) = parse_feishu_event(&event) {
+                                    let _ = tx.send(msg).await;
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Binary(data))) => {
+                            debug!("Received Feishu WebSocket binary message: {} bytes", data.len());
+                            if let Ok(text) = String::from_utf8(data) {
+                                if let Ok(event) = serde_json::from_str::<serde_json::Value>(&text) {
+                                    if let Some(msg) = parse_feishu_event(&event) {
+                                        let _ = tx.send(msg).await;
+                                    }
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            info!("Feishu WebSocket connection closed by server");
+                            break;
+                        }
+                        Some(Ok(Message::Ping(_))) => {
+                            debug!("Received Feishu WebSocket ping, sending pong");
+                            let _ = write.send(Message::Pong(Vec::new())).await;
+                        }
+                        Some(Ok(Message::Pong(_))) => {
+                            debug!("Received Feishu WebSocket pong");
+                        }
+                        Some(Ok(_)) => {
+                            debug!("Received unhandled Feishu WebSocket message type");
+                        }
+                        Some(Err(e)) => {
+                            error!("Feishu WebSocket error: {e}");
+                            break;
+                        }
+                        None => {
+                            info!("Feishu WebSocket stream ended");
+                            break;
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    info!("Feishu WebSocket shutting down");
+                    let _ = write.close().await;
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Cloneable Feishu adapter parts for use in async tasks.
+struct FeishuAdapterClone {
+    app_id: String,
+    app_secret: Zeroizing<String>,
+    client: reqwest::Client,
+    cached_token: Arc<RwLock<Option<(String, Instant)>>>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl FeishuAdapterClone {
+    /// Get a valid tenant access token, refreshing if expired or missing.
+    async fn get_token(&self) -> Result<String, Box<dyn std::error::Error>> {
+        {
+            let guard = self.cached_token.read().await;
+            if let Some((ref token, expiry)) = *guard {
+                if Instant::now() < expiry {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        let body = serde_json::json!({
+            "app_id": self.app_id,
+            "app_secret": self.app_secret.as_str(),
+        });
+
+        let resp = self
+            .client
+            .post(FEISHU_TOKEN_URL)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let resp_body = resp.text().await.unwrap_or_default();
+            return Err(format!("Feishu token request failed {status}: {resp_body}").into());
+        }
+
+        let resp_body: serde_json::Value = resp.json().await?;
+        let code = resp_body["code"].as_i64().unwrap_or(-1);
+        if code != 0 {
+            let msg = resp_body["msg"].as_str().unwrap_or("unknown error");
+            return Err(format!("Feishu token error: {msg}").into());
+        }
+
+        let tenant_access_token = resp_body["tenant_access_token"]
+            .as_str()
+            .ok_or("Missing tenant_access_token")?
+            .to_string();
+        let expire = resp_body["expire"].as_u64().unwrap_or(7200);
+
+        let expiry =
+            Instant::now() + Duration::from_secs(expire.saturating_sub(TOKEN_REFRESH_BUFFER_SECS));
+        *self.cached_token.write().await = Some((tenant_access_token.clone(), expiry));
+
+        Ok(tenant_access_token)
+    }
+
+    /// Get WebSocket endpoint from Feishu API.
+    async fn get_websocket_endpoint(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let token = self.get_token().await?;
+        let url = "https://open.feishu.cn/open-apis/ws/v1/endpoint";
+        
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(&token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let resp_body = resp.text().await.unwrap_or_default();
+            return Err(format!("Feishu WebSocket endpoint request failed {status}: {resp_body}").into());
+        }
+
+        let resp_body: serde_json::Value = resp.json().await?;
+        let code = resp_body["code"].as_i64().unwrap_or(-1);
+        if code != 0 {
+            let msg = resp_body["msg"].as_str().unwrap_or("unknown error");
+            return Err(format!("Feishu WebSocket endpoint error: {msg}").into());
+        }
+
+        let ws_url = resp_body["data"]["url"]
+            .as_str()
+            .ok_or("Missing WebSocket URL in response")?
+            .to_string();
+
+        Ok(ws_url)
+    }
+}
+
+/// Parse a Feishu webhook event into a `ChannelMessage`.
+///
+/// Handles `im.message.receive_v1` events with text message type.
+fn parse_feishu_event(event: &serde_json::Value) -> Option<ChannelMessage> {
+    let header = event.get("header")?;
+    let event_type = header["event_type"].as_str().unwrap_or("");
+
+    if event_type != "im.message.receive_v1" {
+        return None;
+    }
+
+    let event_data = event.get("event")?;
+    let message = event_data.get("message")?;
+    let sender = event_data.get("sender")?;
+
+    let msg_type = message["message_type"].as_str().unwrap_or("");
+    if msg_type != "text" {
+        return None;
+    }
+
+    let content_str = message["content"].as_str().unwrap_or("{}");
+    let content_json: serde_json::Value = serde_json::from_str(content_str).unwrap_or_default();
+    let text = content_json["text"].as_str().unwrap_or("");
+    if text.is_empty() {
+        return None;
+    }
+
+    let message_id = message["message_id"].as_str().unwrap_or("").to_string();
+    let chat_id = message["chat_id"].as_str().unwrap_or("").to_string();
+    let chat_type = message["chat_type"].as_str().unwrap_or("p2p");
+    let root_id = message["root_id"].as_str().map(|s| s.to_string());
+
+    let sender_id = sender
+        .get("sender_id")
+        .and_then(|s| s.get("open_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let sender_type = sender["sender_type"].as_str().unwrap_or("user");
+
+    if sender_type == "bot" {
+        return None;
+    }
+
+    let is_group = chat_type == "group";
+
+    let msg_content = if text.starts_with('/') {
+        let parts: Vec<&str> = text.splitn(2, ' ').collect();
+        let cmd_name = parts[0].trim_start_matches('/');
+        let args: Vec<String> = parts
+            .get(1)
+            .map(|a| a.split_whitespace().map(String::from).collect())
+            .unwrap_or_default();
+        ChannelContent::Command {
+            name: cmd_name.to_string(),
+            args,
+        }
+    } else {
+        ChannelContent::Text(text.to_string())
+    };
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "chat_id".to_string(),
+        serde_json::Value::String(chat_id.clone()),
+    );
+    metadata.insert(
+        "message_id".to_string(),
+        serde_json::Value::String(message_id.clone()),
+    );
+    metadata.insert(
+        "chat_type".to_string(),
+        serde_json::Value::String(chat_type.to_string()),
+    );
+    metadata.insert(
+        "sender_id".to_string(),
+        serde_json::Value::String(sender_id.clone()),
+    );
+    if let Some(mentions) = message.get("mentions") {
+        metadata.insert("mentions".to_string(), mentions.clone());
+    }
+
+    Some(ChannelMessage {
+        channel: ChannelType::Custom("feishu".to_string()),
+        platform_message_id: message_id,
+        sender: ChannelUser {
+            platform_id: chat_id,
+            display_name: sender_id,
+            openfang_user: None,
+        },
+        content: msg_content,
+        target_agent: None,
+        timestamp: Utc::now(),
+        is_group,
+        thread_id: root_id,
+        metadata,
+    })
+}
+
+#[async_trait]
+impl ChannelAdapter for FeishuAdapter {
+    fn name(&self) -> &str {
+        "feishu"
+    }
+
+    fn channel_type(&self) -> ChannelType {
+        ChannelType::Custom("feishu".to_string())
+    }
+
+    async fn start(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>, Box<dyn std::error::Error>>
+    {
+        let bot_name = self.validate().await?;
+        info!("Feishu adapter authenticated as {bot_name}");
+
+        let (tx, rx) = mpsc::channel::<ChannelMessage>(256);
+
+        match self.connection_mode {
+            FeishuConnectionMode::Webhook => {
+                self.start_webhook(tx).await?;
+            }
+            FeishuConnectionMode::WebSocket => {
+                self.start_websocket_loop(tx).await?;
+            }
+        }
+
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
 
@@ -537,7 +740,6 @@ impl ChannelAdapter for FeishuAdapter {
     ) -> Result<(), Box<dyn std::error::Error>> {
         match content {
             ChannelContent::Text(text) => {
-                // Use chat_id as receive_id with chat_id type
                 self.api_send_message(&user.platform_id, "chat_id", &text)
                     .await?;
             }
@@ -550,7 +752,6 @@ impl ChannelAdapter for FeishuAdapter {
     }
 
     async fn send_typing(&self, _user: &ChannelUser) -> Result<(), Box<dyn std::error::Error>> {
-        // Feishu does not support typing indicators via REST API
         Ok(())
     }
 
@@ -574,6 +775,21 @@ mod tests {
             ChannelType::Custom("feishu".to_string())
         );
         assert_eq!(adapter.webhook_port, 9000);
+        assert_eq!(adapter.connection_mode, FeishuConnectionMode::Webhook);
+    }
+
+    #[test]
+    fn test_feishu_websocket_adapter_creation() {
+        let adapter = FeishuAdapter::new_websocket(
+            "cli_abc123".to_string(),
+            "app-secret-456".to_string(),
+        );
+        assert_eq!(adapter.name(), "feishu");
+        assert_eq!(
+            adapter.channel_type(),
+            ChannelType::Custom("feishu".to_string())
+        );
+        assert_eq!(adapter.connection_mode, FeishuConnectionMode::WebSocket);
     }
 
     #[test]


### PR DESCRIPTION
添加Feishu通道的WebSocket模式支持，允许通过长连接接收事件而无需公网IP
重构适配器代码，分离Webhook和WebSocket实现，优化错误处理和日志记录