### PR TITLE
fix(api): add cache and rate limiting for ClawHub API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-api"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-channels"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-desktop"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "axum",
  "open",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-extensions"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-hands"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-kernel"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-memory"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-migrate"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-runtime"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4137,9 +4137,10 @@ dependencies = [
 
 [[package]]
 name = "openfang-skills"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
+ "dashmap",
  "hex",
  "openfang-types",
  "reqwest 0.12.28",
@@ -4159,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-types"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4178,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-wire"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8790,7 +8791,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.2.6"
+version = "0.2.7"
 
 [[package]]
 name = "yoke"

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -13,8 +13,12 @@ use openfang_kernel::workflow::{
 use openfang_kernel::OpenFangKernel;
 use openfang_runtime::kernel_handle::KernelHandle;
 use openfang_runtime::tool_runner::builtin_tool_definitions;
+use openfang_skills::clawhub::{
+    ClawHubBrowseResponse, ClawHubCache, ClawHubSearchResponse, ClawHubSkillDetail,
+};
 use openfang_types::agent::{AgentId, AgentIdentity, AgentManifest};
 use std::collections::HashMap;
+
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -33,6 +37,12 @@ pub struct AppState {
     pub channels_config: tokio::sync::RwLock<openfang_types::config::ChannelsConfig>,
     /// Notify handle to trigger graceful HTTP server shutdown from the API.
     pub shutdown_notify: Arc<tokio::sync::Notify>,
+    /// In-memory cache for ClawHub search responses (TTL: 60 seconds).
+    pub clawhub_search_cache: Arc<ClawHubCache<ClawHubSearchResponse>>,
+    /// In-memory cache for ClawHub browse responses (TTL: 60 seconds).
+    pub clawhub_browse_cache: Arc<ClawHubCache<ClawHubBrowseResponse>>,
+    /// In-memory cache for ClawHub skill details (TTL: 60 seconds).
+    pub clawhub_detail_cache: Arc<ClawHubCache<ClawHubSkillDetail>>,
 }
 
 /// POST /api/agents — Spawn a new agent.
@@ -2765,6 +2775,8 @@ pub async fn marketplace_search(
 /// Query parameters:
 /// - `q` — search query (required)
 /// - `limit` — max results (default: 20, max: 50)
+///
+/// Uses in-memory caching with 60s TTL to reduce API calls.
 pub async fn clawhub_search(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
@@ -2782,12 +2794,44 @@ pub async fn clawhub_search(
         .and_then(|v| v.parse().ok())
         .unwrap_or(20);
 
+    // Check cache first
+    let cache_key = format!("search:{}:{}", query, limit);
+    if let Some(cached) = state.clawhub_search_cache.get(&cache_key) {
+        tracing::debug!("ClawHub search cache hit for query: {}", query);
+        let items: Vec<serde_json::Value> = cached
+            .results
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "slug": e.slug,
+                    "name": e.display_name,
+                    "description": e.summary,
+                    "version": e.version,
+                    "score": e.score,
+                    "updated_at": e.updated_at,
+                })
+            })
+            .collect();
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "items": items,
+                "next_cursor": null,
+                "cached": true,
+            })),
+        );
+    }
+
     let cache_dir = state.kernel.config.home_dir.join(".cache").join("clawhub");
     let client = openfang_skills::clawhub::ClawHubClient::new(cache_dir);
 
     match client.search(&query, limit).await {
-        Ok(results) => {
-            let items: Vec<serde_json::Value> = results
+        Ok(response) => {
+            // Cache the response
+            state.clawhub_search_cache.insert(cache_key, response.data.clone());
+
+            let items: Vec<serde_json::Value> = response
+                .data
                 .results
                 .iter()
                 .map(|e| {
@@ -2810,11 +2854,24 @@ pub async fn clawhub_search(
             )
         }
         Err(e) => {
-            tracing::warn!("ClawHub search failed: {e}");
+            let error_msg = format!("{e}");
+            tracing::warn!("ClawHub search failed: {error_msg}");
+
+            // Check if it's a rate limit error (429)
+            if error_msg.contains("429") || error_msg.contains("rate limit") {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({
+                        "error": error_msg,
+                        "retry_after": 60,
+                    })),
+                );
+            }
+
             (
-                StatusCode::OK,
+                StatusCode::BAD_GATEWAY,
                 Json(
-                    serde_json::json!({"items": [], "next_cursor": null, "error": format!("{e}")}),
+                    serde_json::json!({"items": [], "next_cursor": null, "error": error_msg}),
                 ),
             )
         }
@@ -2827,6 +2884,8 @@ pub async fn clawhub_search(
 /// - `sort` — sort order: "trending", "downloads", "stars", "updated", "rating" (default: "trending")
 /// - `limit` — max results (default: 20, max: 50)
 /// - `cursor` — pagination cursor from previous response
+///
+/// Uses in-memory caching with 60s TTL to reduce API calls.
 pub async fn clawhub_browse(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
@@ -2846,12 +2905,40 @@ pub async fn clawhub_browse(
 
     let cursor = params.get("cursor").map(|s| s.as_str());
 
+    // Check cache first
+    let cache_key = format!(
+        "browse:{}:{}:{}",
+        sort.as_str(),
+        limit,
+        cursor.unwrap_or("")
+    );
+    if let Some(cached) = state.clawhub_browse_cache.get(&cache_key) {
+        tracing::debug!("ClawHub browse cache hit");
+        let items: Vec<serde_json::Value> = cached
+            .items
+            .iter()
+            .map(clawhub_browse_entry_to_json)
+            .collect();
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "items": items,
+                "next_cursor": cached.next_cursor,
+                "cached": true,
+            })),
+        );
+    }
+
     let cache_dir = state.kernel.config.home_dir.join(".cache").join("clawhub");
     let client = openfang_skills::clawhub::ClawHubClient::new(cache_dir);
 
     match client.browse(sort, limit, cursor).await {
-        Ok(results) => {
-            let items: Vec<serde_json::Value> = results
+        Ok(response) => {
+            // Cache the response
+            state.clawhub_browse_cache.insert(cache_key, response.data.clone());
+
+            let items: Vec<serde_json::Value> = response
+                .data
                 .items
                 .iter()
                 .map(clawhub_browse_entry_to_json)
@@ -2860,16 +2947,29 @@ pub async fn clawhub_browse(
                 StatusCode::OK,
                 Json(serde_json::json!({
                     "items": items,
-                    "next_cursor": results.next_cursor,
+                    "next_cursor": response.data.next_cursor,
                 })),
             )
         }
         Err(e) => {
-            tracing::warn!("ClawHub browse failed: {e}");
+            let error_msg = format!("{e}");
+            tracing::warn!("ClawHub browse failed: {error_msg}");
+
+            // Check if it's a rate limit error (429)
+            if error_msg.contains("429") || error_msg.contains("rate limit") {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({
+                        "error": error_msg,
+                        "retry_after": 60,
+                    })),
+                );
+            }
+
             (
-                StatusCode::OK,
+                StatusCode::BAD_GATEWAY,
                 Json(
-                    serde_json::json!({"items": [], "next_cursor": null, "error": format!("{e}")}),
+                    serde_json::json!({"items": [], "next_cursor": null, "error": error_msg}),
                 ),
             )
         }
@@ -2877,10 +2977,63 @@ pub async fn clawhub_browse(
 }
 
 /// GET /api/clawhub/skill/{slug} — Get detailed info about a ClawHub skill.
+///
+/// Uses in-memory caching with 60s TTL to reduce API calls.
 pub async fn clawhub_skill_detail(
     State(state): State<Arc<AppState>>,
     Path(slug): Path<String>,
 ) -> impl IntoResponse {
+    // Check cache first
+    let cache_key = format!("skill:{}", slug);
+    if let Some(cached) = state.clawhub_detail_cache.get(&cache_key) {
+        tracing::debug!("ClawHub skill detail cache hit for: {}", slug);
+        let skills_dir = state.kernel.config.home_dir.join("skills");
+        let cache_dir = state.kernel.config.home_dir.join(".cache").join("clawhub");
+        let client = openfang_skills::clawhub::ClawHubClient::new(cache_dir);
+        let is_installed = client.is_installed(&slug, &skills_dir);
+
+        let version = cached
+            .latest_version
+            .as_ref()
+            .map(|v| v.version.as_str())
+            .unwrap_or("");
+        let author = cached
+            .owner
+            .as_ref()
+            .map(|o| o.handle.as_str())
+            .unwrap_or("");
+        let author_name = cached
+            .owner
+            .as_ref()
+            .map(|o| o.display_name.as_str())
+            .unwrap_or("");
+        let author_image = cached
+            .owner
+            .as_ref()
+            .map(|o| o.image.as_str())
+            .unwrap_or("");
+
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "slug": cached.skill.slug,
+                "name": cached.skill.display_name,
+                "description": cached.skill.summary,
+                "version": version,
+                "downloads": cached.skill.stats.downloads,
+                "stars": cached.skill.stats.stars,
+                "author": author,
+                "author_name": author_name,
+                "author_image": author_image,
+                "tags": cached.skill.tags,
+                "updated_at": cached.skill.updated_at,
+                "created_at": cached.skill.created_at,
+                "installed": is_installed,
+                "cached": true,
+            })),
+        );
+    }
+
     let cache_dir = state.kernel.config.home_dir.join(".cache").join("clawhub");
     let client = openfang_skills::clawhub::ClawHubClient::new(cache_dir);
 
@@ -2888,7 +3041,11 @@ pub async fn clawhub_skill_detail(
     let is_installed = client.is_installed(&slug, &skills_dir);
 
     match client.get_skill(&slug).await {
-        Ok(detail) => {
+        Ok(response) => {
+            // Cache the response
+            state.clawhub_detail_cache.insert(cache_key, response.data.clone());
+
+            let detail = response.data;
             let version = detail
                 .latest_version
                 .as_ref()
@@ -2929,10 +3086,26 @@ pub async fn clawhub_skill_detail(
                 })),
             )
         }
-        Err(e) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": format!("{e}")})),
-        ),
+        Err(e) => {
+            let error_msg = format!("{e}");
+            tracing::warn!("ClawHub skill detail failed for {}: {}", slug, error_msg);
+
+            // Check if it's a rate limit error (429)
+            if error_msg.contains("429") || error_msg.contains("rate limit") {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({
+                        "error": error_msg,
+                        "retry_after": 60,
+                    })),
+                );
+            }
+
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": error_msg})),
+            )
+        }
     }
 }
 

--- a/crates/openfang-api/src/server.rs
+++ b/crates/openfang-api/src/server.rs
@@ -8,10 +8,11 @@ use crate::webchat;
 use crate::ws;
 use axum::Router;
 use openfang_kernel::OpenFangKernel;
+use openfang_skills::clawhub::ClawHubCache;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -49,6 +50,9 @@ pub async fn build_router(
         bridge_manager: tokio::sync::Mutex::new(bridge),
         channels_config: tokio::sync::RwLock::new(channels_config),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::new(Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::new(Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::new(Duration::from_secs(60))),
     });
 
     // CORS: allow localhost origins by default. If API key is set, the API

--- a/crates/openfang-api/tests/api_integration_test.rs
+++ b/crates/openfang-api/tests/api_integration_test.rs
@@ -12,6 +12,7 @@ use openfang_api::middleware;
 use openfang_api::routes::{self, AppState};
 use openfang_api::ws;
 use openfang_kernel::OpenFangKernel;
+use openfang_skills::clawhub::{ClawHubBrowseResponse, ClawHubCache, ClawHubSearchResponse, ClawHubSkillDetail};
 use openfang_types::config::{DefaultModelConfig, KernelConfig};
 use std::sync::Arc;
 use std::time::Instant;
@@ -76,6 +77,9 @@ async fn start_test_server_with_provider(
         bridge_manager: tokio::sync::Mutex::new(None),
         channels_config: tokio::sync::RwLock::new(Default::default()),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::<ClawHubSearchResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::<ClawHubBrowseResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::<ClawHubSkillDetail>::new(std::time::Duration::from_secs(60))),
     });
 
     let app = Router::new()
@@ -702,6 +706,9 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         bridge_manager: tokio::sync::Mutex::new(None),
         channels_config: tokio::sync::RwLock::new(Default::default()),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::<ClawHubSearchResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::<ClawHubBrowseResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::<ClawHubSkillDetail>::new(std::time::Duration::from_secs(60))),
     });
 
     let api_key_state = state.kernel.config.api_key.clone();

--- a/crates/openfang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/openfang-api/tests/daemon_lifecycle_test.rs
@@ -7,6 +7,7 @@ use axum::Router;
 use openfang_api::middleware;
 use openfang_api::routes::{self, AppState};
 use openfang_api::server::{read_daemon_info, DaemonInfo};
+use openfang_skills::clawhub::{ClawHubBrowseResponse, ClawHubCache, ClawHubSearchResponse, ClawHubSkillDetail};
 use openfang_kernel::OpenFangKernel;
 use openfang_types::config::{DefaultModelConfig, KernelConfig};
 use std::sync::Arc;
@@ -113,6 +114,9 @@ async fn test_full_daemon_lifecycle() {
         bridge_manager: tokio::sync::Mutex::new(None),
         channels_config: tokio::sync::RwLock::new(Default::default()),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::<ClawHubSearchResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::<ClawHubBrowseResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::<ClawHubSkillDetail>::new(std::time::Duration::from_secs(60))),
     });
 
     let app = Router::new()
@@ -236,6 +240,9 @@ async fn test_server_immediate_responsiveness() {
         bridge_manager: tokio::sync::Mutex::new(None),
         channels_config: tokio::sync::RwLock::new(Default::default()),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::<ClawHubSearchResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::<ClawHubBrowseResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::<ClawHubSkillDetail>::new(std::time::Duration::from_secs(60))),
     });
 
     let app = Router::new()

--- a/crates/openfang-api/tests/load_test.rs
+++ b/crates/openfang-api/tests/load_test.rs
@@ -8,6 +8,7 @@
 use axum::Router;
 use openfang_api::middleware;
 use openfang_api::routes::{self, AppState};
+use openfang_skills::clawhub::{ClawHubBrowseResponse, ClawHubCache, ClawHubSearchResponse, ClawHubSkillDetail};
 use openfang_kernel::OpenFangKernel;
 use openfang_types::config::{DefaultModelConfig, KernelConfig};
 use std::sync::Arc;
@@ -57,6 +58,9 @@ async fn start_test_server() -> TestServer {
         bridge_manager: tokio::sync::Mutex::new(None),
         channels_config: tokio::sync::RwLock::new(Default::default()),
         shutdown_notify: Arc::new(tokio::sync::Notify::new()),
+        clawhub_search_cache: Arc::new(ClawHubCache::<ClawHubSearchResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_browse_cache: Arc::new(ClawHubCache::<ClawHubBrowseResponse>::new(std::time::Duration::from_secs(60))),
+        clawhub_detail_cache: Arc::new(ClawHubCache::<ClawHubSkillDetail>::new(std::time::Duration::from_secs(60))),
     });
 
     let app = Router::new()

--- a/crates/openfang-skills/Cargo.toml
+++ b/crates/openfang-skills/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 serde_yaml = { workspace = true }
+dashmap = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/openfang-skills/src/clawhub.rs
+++ b/crates/openfang-skills/src/clawhub.rs
@@ -14,9 +14,13 @@
 use crate::openclaw_compat;
 use crate::verify::{SkillVerifier, SkillWarning, WarningSeverity};
 use crate::SkillError;
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 // ---------------------------------------------------------------------------
@@ -184,7 +188,8 @@ pub enum ClawHubSort {
 }
 
 impl ClawHubSort {
-    fn as_str(self) -> &'static str {
+    /// Returns the string representation of the sort order.
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Trending => "trending",
             Self::Updated => "updated",
@@ -221,6 +226,72 @@ pub struct ClawHubInstallResult {
     pub is_prompt_only: bool,
 }
 
+/// Response from ClawHub API with status code information.
+#[derive(Debug, Clone)]
+pub struct ClawHubApiResponse<T> {
+    pub data: T,
+    pub status: u16,
+}
+
+/// In-memory cache entry for ClawHub API responses.
+#[derive(Debug, Clone)]
+struct CacheEntry<T> {
+    data: T,
+    cached_at: Instant,
+}
+
+/// Thread-safe in-memory cache with TTL.
+pub struct ClawHubCache<T: Clone + Send + Sync> {
+    entries: DashMap<String, CacheEntry<T>>,
+    ttl: Duration,
+}
+
+impl<T: Clone + Send + Sync> ClawHubCache<T> {
+    /// Create a new cache with the specified TTL.
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            entries: DashMap::new(),
+            ttl,
+        }
+    }
+
+    /// Get a value from the cache if it exists and hasn't expired.
+    pub fn get(&self, key: &str) -> Option<T> {
+        let entry = self.entries.get(key)?;
+        if entry.cached_at.elapsed() < self.ttl {
+            Some(entry.data.clone())
+        } else {
+            drop(entry);
+            self.entries.remove(key);
+            None
+        }
+    }
+
+    /// Insert a value into the cache.
+    pub fn insert(&self, key: String, data: T) {
+        self.entries.insert(
+            key,
+            CacheEntry {
+                data,
+                cached_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Clear all expired entries from the cache.
+    pub fn cleanup(&self) {
+        let keys_to_remove: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|entry| entry.value().cached_at.elapsed() >= self.ttl)
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in keys_to_remove {
+            self.entries.remove(&key);
+        }
+    }
+}
+
 /// Client for the ClawHub marketplace (clawhub.ai).
 pub struct ClawHubClient {
     /// Base URL for the ClawHub API.
@@ -229,9 +300,60 @@ pub struct ClawHubClient {
     client: reqwest::Client,
     /// Local cache directory for downloaded skills.
     _cache_dir: PathBuf,
+    /// Rate limiter for outgoing requests (10 req/min).
+    rate_limiter: Arc<tokio::sync::Mutex<ClawHubRateLimiter>>,
+}
+
+/// Simple rate limiter for ClawHub API calls.
+pub struct ClawHubRateLimiter {
+    /// Last request timestamps (circular buffer).
+    timestamps: Vec<Instant>,
+    /// Maximum requests per minute.
+    max_requests: usize,
+    /// Current index in circular buffer.
+    index: usize,
+}
+
+impl ClawHubRateLimiter {
+    /// Create a new rate limiter with the specified max requests per minute.
+    pub fn new(max_requests: usize) -> Self {
+        Self {
+            timestamps: Vec::with_capacity(max_requests),
+            max_requests,
+            index: 0,
+        }
+    }
+
+    /// Check if a request can be made, returning how long to wait if not.
+    pub fn check(&mut self) -> Result<(), Duration> {
+        let now = Instant::now();
+        let one_minute = Duration::from_secs(60);
+
+        // Remove timestamps older than 1 minute
+        self.timestamps.retain(|&t| now.duration_since(t) < one_minute);
+
+        if self.timestamps.len() < self.max_requests {
+            self.timestamps.push(now);
+            Ok(())
+        } else {
+            // Find the oldest timestamp to calculate wait time
+            let oldest = self.timestamps.iter().min().copied().unwrap_or(now);
+            let wait_time = one_minute.saturating_sub(now.duration_since(oldest));
+            Err(wait_time)
+        }
+    }
+
+    /// Reset the rate limiter.
+    pub fn reset(&mut self) {
+        self.timestamps.clear();
+        self.index = 0;
+    }
 }
 
 impl ClawHubClient {
+    /// Default rate limit: 10 requests per minute.
+    pub const DEFAULT_RATE_LIMIT: usize = 10;
+
     /// Create a new ClawHub client with default settings.
     ///
     /// Uses the official ClawHub API at `https://clawhub.ai/api/v1`.
@@ -248,18 +370,54 @@ impl ClawHubClient {
                 .build()
                 .unwrap_or_default(),
             _cache_dir: cache_dir,
+            rate_limiter: Arc::new(tokio::sync::Mutex::new(ClawHubRateLimiter::new(
+                Self::DEFAULT_RATE_LIMIT,
+            ))),
+        }
+    }
+
+    /// Create a ClawHub client with custom rate limit.
+    pub fn with_rate_limit(base_url: &str, cache_dir: PathBuf, max_requests: usize) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_default(),
+            _cache_dir: cache_dir,
+            rate_limiter: Arc::new(tokio::sync::Mutex::new(ClawHubRateLimiter::new(
+                max_requests,
+            ))),
+        }
+    }
+
+    /// Check rate limit and return error if exceeded.
+    async fn check_rate_limit(&self) -> Result<(), SkillError> {
+        let mut limiter = self.rate_limiter.lock().await;
+        match limiter.check() {
+            Ok(()) => Ok(()),
+            Err(wait_duration) => {
+                let wait_secs = wait_duration.as_secs().max(1);
+                Err(SkillError::Network(format!(
+                    "Rate limit exceeded. Retry after {} seconds",
+                    wait_secs
+                )))
+            }
         }
     }
 
     /// Search for skills on ClawHub using vector/semantic search.
     ///
     /// Uses `GET /api/v1/search?q=...&limit=...`.
-    /// Returns `ClawHubSearchResponse` whose root key is `results` (not `items`).
+    /// Returns `ClawHubApiResponse<ClawHubSearchResponse>` with status code.
     pub async fn search(
         &self,
         query: &str,
         limit: u32,
-    ) -> Result<ClawHubSearchResponse, SkillError> {
+    ) -> Result<ClawHubApiResponse<ClawHubSearchResponse>, SkillError> {
+        // Check client-side rate limit first
+        self.check_rate_limit().await?;
+
         let url = format!(
             "{}/search?q={}&limit={}",
             self.base_url,
@@ -275,6 +433,14 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("ClawHub search failed: {e}")))?;
 
+        let status = response.status().as_u16();
+
+        if response.status().as_u16() == 429 {
+            return Err(SkillError::Network(
+                "ClawHub API rate limit exceeded (429)".to_string(),
+            ));
+        }
+
         if !response.status().is_success() {
             return Err(SkillError::Network(format!(
                 "ClawHub API returned {}",
@@ -287,18 +453,22 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub response: {e}")))?;
 
-        Ok(results)
+        Ok(ClawHubApiResponse { data: results, status })
     }
 
     /// Browse skills by sort order (trending, downloads, stars, etc.).
     ///
     /// Uses `GET /api/v1/skills?limit=...&sort=...`.
+    /// Returns `ClawHubApiResponse<ClawHubBrowseResponse>` with status code.
     pub async fn browse(
         &self,
         sort: ClawHubSort,
         limit: u32,
         cursor: Option<&str>,
-    ) -> Result<ClawHubBrowseResponse, SkillError> {
+    ) -> Result<ClawHubApiResponse<ClawHubBrowseResponse>, SkillError> {
+        // Check client-side rate limit first
+        self.check_rate_limit().await?;
+
         let mut url = format!(
             "{}/skills?limit={}&sort={}",
             self.base_url,
@@ -318,6 +488,14 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("ClawHub browse failed: {e}")))?;
 
+        let status = response.status().as_u16();
+
+        if response.status().as_u16() == 429 {
+            return Err(SkillError::Network(
+                "ClawHub API rate limit exceeded (429)".to_string(),
+            ));
+        }
+
         if !response.status().is_success() {
             return Err(SkillError::Network(format!(
                 "ClawHub browse returned {}",
@@ -330,14 +508,21 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub browse: {e}")))?;
 
-        Ok(results)
+        Ok(ClawHubApiResponse { data: results, status })
     }
 
     /// Get detailed info about a specific skill.
     ///
     /// Uses `GET /api/v1/skills/{slug}`.
     /// Response is `{ skill: {...}, latestVersion: {...}, owner: {...}, moderation: null }`.
-    pub async fn get_skill(&self, slug: &str) -> Result<ClawHubSkillDetail, SkillError> {
+    /// Returns `ClawHubApiResponse<ClawHubSkillDetail>` with status code.
+    pub async fn get_skill(
+        &self,
+        slug: &str,
+    ) -> Result<ClawHubApiResponse<ClawHubSkillDetail>, SkillError> {
+        // Check client-side rate limit first
+        self.check_rate_limit().await?;
+
         let url = format!("{}/skills/{}", self.base_url, urlencoded(slug));
 
         let response = self
@@ -347,6 +532,14 @@ impl ClawHubClient {
             .send()
             .await
             .map_err(|e| SkillError::Network(format!("ClawHub detail failed: {e}")))?;
+
+        let status = response.status().as_u16();
+
+        if response.status().as_u16() == 429 {
+            return Err(SkillError::Network(
+                "ClawHub API rate limit exceeded (429)".to_string(),
+            ));
+        }
 
         if !response.status().is_success() {
             return Err(SkillError::Network(format!(
@@ -360,7 +553,7 @@ impl ClawHubClient {
             .await
             .map_err(|e| SkillError::Network(format!("Failed to parse ClawHub detail: {e}")))?;
 
-        Ok(detail)
+        Ok(ClawHubApiResponse { data: detail, status })
     }
 
     /// Helper: extract the version string from a browse entry.
@@ -798,5 +991,145 @@ mod tests {
             }),
         };
         assert_eq!(ClawHubClient::entry_version(&entry), "2.0.0");
+    }
+
+    // -------------------------------------------------------------------------
+    // Rate limiter tests (issue #191)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_clawhub_rate_limiter_allows_requests_up_to_limit() {
+        let mut limiter = ClawHubRateLimiter::new(10);
+
+        // First 10 requests should succeed
+        for i in 0..10 {
+            assert!(
+                limiter.check().is_ok(),
+                "Request {} should be allowed",
+                i + 1
+            );
+        }
+
+        // 11th request should be rate limited
+        assert!(limiter.check().is_err(), "11th request should be rate limited");
+    }
+
+    #[test]
+    fn test_clawhub_rate_limiter_reports_wait_time() {
+        let mut limiter = ClawHubRateLimiter::new(1);
+
+        // First request succeeds
+        assert!(limiter.check().is_ok());
+
+        // Second request should report wait time
+        let result = limiter.check();
+        assert!(result.is_err());
+        
+        // Wait time should be close to 60 seconds (but less since some time passed)
+        let wait_time = result.unwrap_err();
+        assert!(wait_time.as_secs() <= 60, "Wait time should be <= 60 seconds");
+    }
+
+    #[test]
+    fn test_clawhub_rate_limiter_reset() {
+        let mut limiter = ClawHubRateLimiter::new(2);
+
+        // Use up the rate limit
+        assert!(limiter.check().is_ok());
+        assert!(limiter.check().is_ok());
+        assert!(limiter.check().is_err());
+
+        // Reset and try again
+        limiter.reset();
+        assert!(limiter.check().is_ok(), "Request after reset should succeed");
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache tests (issue #191)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_clawhub_cache_stores_and_retrieves() {
+        let cache = ClawHubCache::<String>::new(Duration::from_secs(60));
+
+        // Insert a value
+        cache.insert("key1".to_string(), "value1".to_string());
+
+        // Should be retrievable immediately
+        let value = cache.get("key1");
+        assert_eq!(value, Some("value1".to_string()));
+    }
+
+    #[test]
+    fn test_clawhub_cache_returns_none_for_missing_key() {
+        let cache = ClawHubCache::<String>::new(Duration::from_secs(60));
+
+        // Key doesn't exist
+        let value = cache.get("nonexistent");
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn test_clawhub_cache_respects_ttl() {
+        // Create cache with very short TTL (10ms)
+        let cache = ClawHubCache::<String>::new(Duration::from_millis(10));
+
+        // Insert a value
+        cache.insert("key1".to_string(), "value1".to_string());
+
+        // Should be immediately available
+        assert_eq!(cache.get("key1"), Some("value1".to_string()));
+
+        // Wait for TTL to expire
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Should now return None (expired)
+        let value = cache.get("key1");
+        assert_eq!(value, None, "Value should expire after TTL");
+    }
+
+    #[test]
+    fn test_clawhub_cache_cleanup_removes_expired() {
+        let cache = ClawHubCache::<String>::new(Duration::from_millis(10));
+
+        // Insert a value
+        cache.insert("key1".to_string(), "value1".to_string());
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Cleanup should remove expired entries
+        cache.cleanup();
+
+        // Entry should be gone
+        assert_eq!(cache.get("key1"), None);
+    }
+
+    #[test]
+    fn test_clawhub_cache_handles_browse_response() {
+        let cache = ClawHubCache::<ClawHubBrowseResponse>::new(Duration::from_secs(60));
+
+        let response = ClawHubBrowseResponse {
+            items: vec![ClawHubBrowseEntry {
+                slug: "test-skill".to_string(),
+                display_name: "Test Skill".to_string(),
+                summary: "A test skill".to_string(),
+                tags: std::collections::HashMap::new(),
+                stats: ClawHubStats::default(),
+                created_at: 0,
+                updated_at: 0,
+                latest_version: None,
+            }],
+            next_cursor: Some("cursor123".to_string()),
+        };
+
+        cache.insert("browse:test".to_string(), response.clone());
+
+        let retrieved = cache.get("browse:test");
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.items.len(), 1);
+        assert_eq!(retrieved.items[0].slug, "test-skill");
+        assert_eq!(retrieved.next_cursor, Some("cursor123".to_string()));
     }
 }


### PR DESCRIPTION
Fixes #191

Adds client-side caching and rate limiting to prevent HTTP 429 errors when browsing ClawHub skills.

## Changes
- Add in-memory cache with 60s TTL for ClawHub responses
- Add rate limiting (10 req/min) for outgoing ClawHub requests
- Fix error handling to propagate HTTP 429 status
- Add comprehensive unit tests for cache and rate limiting behavior
- Fix unused import warnings

## Technical Details
- Cache key: request URL + params
- TTL: 60 seconds (configurable)
- Rate limit: 10 requests per minute per endpoint

## Testing
- Added 3 unit tests for rate limiting
- Added 5 unit tests for cache behavior
- All existing tests pass