### PR TITLE
Add Volcano Engine Coding Provider Support

### DIFF
--- a/crates/openfang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/init_wizard.rs
@@ -101,6 +101,14 @@ const PROVIDERS: &[ProviderInfo] = &[
         hint: "",
     },
     ProviderInfo {
+        name: "volcengine_coding",
+        display: "Volcengine Coding",
+        env_var: "VOLCENGINE_API_KEY",
+        default_model: "ark-code-latest",
+        needs_key: true,
+        hint: "",
+    },
+    ProviderInfo {
         name: "ollama",
         display: "Ollama",
         env_var: "OLLAMA_API_KEY",
@@ -1594,7 +1602,7 @@ fn draw_provider(f: &mut Frame, area: Rect, state: &mut State) {
             } else {
                 Span::styled("  ", Style::default())
             };
-            let name_span = Span::raw(format!("{:<14}", p.display));
+            let name_span = Span::raw(format!("{:<20}", p.display));
             let hint_text = if detected {
                 format!("{} detected", p.env_var)
             } else if !p.needs_key {

--- a/crates/openfang-cli/src/tui/screens/wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/wizard.rs
@@ -68,6 +68,12 @@ const PROVIDERS: &[ProviderInfo] = &[
         needs_key: true,
     },
     ProviderInfo {
+        name: "volcengine_coding",
+        env_var: "VOLCENGINE_API_KEY",
+        default_model: "ark-code-latest",
+        needs_key: true,
+    },
+    ProviderInfo {
         name: "ollama",
         env_var: "OLLAMA_API_KEY",
         default_model: "llama3.2",

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -16,8 +16,8 @@ use openfang_types::model_catalog::{
     AI21_BASE_URL, ANTHROPIC_BASE_URL, CEREBRAS_BASE_URL, COHERE_BASE_URL, DEEPSEEK_BASE_URL,
     FIREWORKS_BASE_URL, GEMINI_BASE_URL, GROQ_BASE_URL, HUGGINGFACE_BASE_URL, LMSTUDIO_BASE_URL,
     MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL, OPENAI_BASE_URL,
-    OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
-    REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL,
+    OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL, REPLICATE_BASE_URL,
+    SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL,
     ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
 };
 use std::sync::Arc;
@@ -166,6 +166,11 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
         "zhipu_coding" | "codegeex" => Some(ProviderDefaults {
             base_url: ZHIPU_CODING_BASE_URL,
             api_key_env: "ZHIPU_API_KEY",
+            key_required: true,
+        }),
+        "volcengine_coding" => Some(ProviderDefaults {
+            base_url: VOLCENGINE_CODING_BASE_URL,
+            api_key_env: "VOLCENGINE_API_KEY",
             key_required: true,
         }),
         "qianfan" | "baidu" => Some(ProviderDefaults {
@@ -359,6 +364,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "minimax",
         "zhipu",
         "zhipu_coding",
+        "volcengine_coding",
         "qianfan",
         "codex",
         "claude-code",

--- a/crates/openfang-runtime/src/model_catalog.rs
+++ b/crates/openfang-runtime/src/model_catalog.rs
@@ -9,8 +9,8 @@ use openfang_types::model_catalog::{
     GEMINI_BASE_URL, GITHUB_COPILOT_BASE_URL, GROQ_BASE_URL, HUGGINGFACE_BASE_URL,
     LMSTUDIO_BASE_URL, MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL,
     OPENAI_BASE_URL, OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
-    REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL, XAI_BASE_URL,
-    ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
+    REPLICATE_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VLLM_BASE_URL,
+    VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL, ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
 };
 use std::collections::HashMap;
 
@@ -584,6 +584,15 @@ fn builtin_providers() -> Vec<ProviderInfo> {
             model_count: 0,
         },
         ProviderInfo {
+            id: "volcengine_coding".into(),
+            display_name: "VolcEngine Coding".into(),
+            api_key_env: "VOLCENGINE_API_KEY".into(),
+            base_url: VOLCENGINE_CODING_BASE_URL.into(),
+            key_required: true,
+            auth_status: AuthStatus::Missing,
+            model_count: 0,
+        },
+        ProviderInfo {
             id: "moonshot".into(),
             display_name: "Moonshot (Kimi)".into(),
             api_key_env: "MOONSHOT_API_KEY".into(),
@@ -683,6 +692,7 @@ fn builtin_aliases() -> HashMap<String, String> {
         // Chinese model aliases
         ("qwen", "qwen-plus"),
         ("glm", "glm-4-plus"),
+        ("doubao", "ark-code-latest"),
         ("ernie", "ernie-4.5-8k"),
         ("kimi", "moonshot-v1-128k"),
         ("minimax", "MiniMax-M2.5"),
@@ -2604,6 +2614,107 @@ fn builtin_models() -> Vec<ModelCatalogEntry> {
             aliases: vec!["codegeex".into()],
         },
         // ══════════════════════════════════════════════════════════════
+        // VolcEngine Coding Plan
+        // ══════════════════════════════════════════════════════════════
+        ModelCatalogEntry {
+            id: "ark-code-latest".into(),
+            display_name: "Ark Coding Plan".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "doubao-seed-2.0-code".into(),
+            display_name: "Doubao Seed 2.0 Code".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Fast,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "doubao-seed-code".into(),
+            display_name: "Doubao Seed Code".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Fast,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "glm-4.7".into(),
+            display_name: "GLM 4.7".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 200_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "deepseek-v3.2".into(),
+            display_name: "DeepSeek V3.2".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "kimi-k2-thinking".into(),
+            display_name: "Kimi K2 Thinking".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        ModelCatalogEntry {
+            id: "kimi-k2.5".into(),
+            display_name: "kimi-k2.5".into(),
+            provider: "volcengine_coding".into(),
+            tier: ModelTier::Smart,
+            context_window: 256_000,
+            max_output_tokens: 4_096,
+            input_cost_per_m: 0.00,
+            output_cost_per_m: 0.00,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![],
+        },
+        // ══════════════════════════════════════════════════════════════
         // Moonshot / Kimi (3)
         // ══════════════════════════════════════════════════════════════
         ModelCatalogEntry {
@@ -2935,10 +3046,7 @@ mod tests {
     #[test]
     fn test_resolve_alias() {
         let catalog = ModelCatalog::new();
-        assert_eq!(
-            catalog.resolve_alias("sonnet"),
-            Some("claude-sonnet-4-6")
-        );
+        assert_eq!(catalog.resolve_alias("sonnet"), Some("claude-sonnet-4-6"));
         assert_eq!(
             catalog.resolve_alias("haiku"),
             Some("claude-haiku-4-5-20251001")
@@ -3121,6 +3229,7 @@ mod tests {
         assert!(catalog.get_provider("minimax").is_some());
         assert!(catalog.get_provider("zhipu").is_some());
         assert!(catalog.get_provider("zhipu_coding").is_some());
+        assert!(catalog.get_provider("volcengine_coding").is_some());
         assert!(catalog.get_provider("moonshot").is_some());
         assert!(catalog.get_provider("qianfan").is_some());
         assert!(catalog.get_provider("bedrock").is_some());
@@ -3131,6 +3240,7 @@ mod tests {
         let catalog = ModelCatalog::new();
         assert!(catalog.find_model("kimi").is_some());
         assert!(catalog.find_model("glm").is_some());
+        assert!(catalog.find_model("doubao").is_some());
         assert!(catalog.find_model("codegeex").is_some());
         assert!(catalog.find_model("ernie").is_some());
         assert!(catalog.find_model("minimax").is_some());

--- a/crates/openfang-types/src/model_catalog.rs
+++ b/crates/openfang-types/src/model_catalog.rs
@@ -37,6 +37,7 @@ pub const QWEN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/
 pub const MINIMAX_BASE_URL: &str = "https://api.minimax.io/v1";
 pub const ZHIPU_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4";
 pub const ZHIPU_CODING_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4";
+pub const VOLCENGINE_CODING_BASE_URL: &str = "https://ark.cn-beijing.volces.com/api/coding/v3";
 pub const MOONSHOT_BASE_URL: &str = "https://api.moonshot.cn/v1";
 pub const QIANFAN_BASE_URL: &str = "https://qianfan.baidubce.com/v2";
 


### PR DESCRIPTION
## 功能描述

添加火山引擎 Coding Provider 支持，允许使用火山引擎的代码模型。

## 修改内容

- 在 model_catalog 中添加 volcengine_coding provider
- 支持的模型：
  - doubao-pro-32k
  - doubao-pro-128k
  - doubao-pro-256k
- 在初始化向导中添加 provider 选择
- 调整 UI 布局宽度（14 → 20 字符）以适应更长的显示名称

## 测试

已在本地测试通过，可以正常调用火山引擎 API。