### PR TITLE
fix(exec_policy): resolve type mismatch and approval gate ordering for per-agent exec_policy override

### DIFF
--- a/crates/openfang-runtime/src/tool_runner.rs
+++ b/crates/openfang-runtime/src/tool_runner.rs
@@ -131,38 +131,45 @@ pub async fn execute_tool(
         }
     }
 
-    // Approval gate: check if this tool requires human approval before execution
-    if let Some(kh) = kernel {
-        if kh.requires_approval(tool_name) {
-            let agent_id_str = caller_agent_id.unwrap_or("unknown");
-            let input_str = input.to_string();
-            let summary = format!(
-                "{}: {}",
-                tool_name,
-                openfang_types::truncate_str(&input_str, 200)
-            );
-            match kh.request_approval(agent_id_str, tool_name, &summary).await {
-                Ok(true) => {
-                    debug!(tool_name, "Approval granted — proceeding with execution");
-                }
-                Ok(false) => {
-                    warn!(tool_name, "Approval denied — blocking tool execution");
-                    return ToolResult {
-                        tool_use_id: tool_use_id.to_string(),
-                        content: format!(
-                            "Execution denied: '{}' requires human approval and was denied or timed out. The operation was not performed.",
-                            tool_name
-                        ),
-                        is_error: true,
-                    };
-                }
-                Err(e) => {
-                    warn!(tool_name, error = %e, "Approval system error");
-                    return ToolResult {
-                        tool_use_id: tool_use_id.to_string(),
-                        content: format!("Approval system error: {e}"),
-                        is_error: true,
-                    };
+    // Approval gate: check if this tool requires human approval before execution.
+    // Agents with exec_policy mode = Full have pre-approved unrestricted execution;
+    // bypass the gate so that scheduled / headless runs are not blocked waiting for
+    // a human that will never respond.
+    let is_full_exec = exec_policy
+        .is_some_and(|p| p.mode == openfang_types::config::ExecSecurityMode::Full);
+    if !is_full_exec {
+        if let Some(kh) = kernel {
+            if kh.requires_approval(tool_name) {
+                let agent_id_str = caller_agent_id.unwrap_or("unknown");
+                let input_str = input.to_string();
+                let summary = format!(
+                    "{}: {}",
+                    tool_name,
+                    openfang_types::truncate_str(&input_str, 200)
+                );
+                match kh.request_approval(agent_id_str, tool_name, &summary).await {
+                    Ok(true) => {
+                        debug!(tool_name, "Approval granted — proceeding with execution");
+                    }
+                    Ok(false) => {
+                        warn!(tool_name, "Approval denied — blocking tool execution");
+                        return ToolResult {
+                            tool_use_id: tool_use_id.to_string(),
+                            content: format!(
+                                "Execution denied: '{}' requires human approval and was denied or timed out. The operation was not performed.",
+                                tool_name
+                            ),
+                            is_error: true,
+                        };
+                    }
+                    Err(e) => {
+                        warn!(tool_name, error = %e, "Approval system error");
+                        return ToolResult {
+                            tool_use_id: tool_use_id.to_string(),
+                            content: format!("Approval system error: {e}"),
+                            is_error: true,
+                        };
+                    }
                 }
             }
         }

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -474,7 +474,8 @@ pub struct AgentManifest {
     #[serde(default = "default_true")]
     pub generate_identity_files: bool,
     /// Per-agent exec policy override. If None, uses global exec_policy.
-    #[serde(default)]
+    /// Accepts a bare mode string ("allow", "deny", "restricted") or a full ExecPolicy struct.
+    #[serde(default, deserialize_with = "crate::serde_compat::exec_policy_override")]
     pub exec_policy: Option<crate::config::ExecPolicy>,
     /// Tool allowlist — only these tools are available (empty = all tools).
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]

--- a/crates/openfang-types/src/serde_compat.rs
+++ b/crates/openfang-types/src/serde_compat.rs
@@ -303,4 +303,121 @@ mod tests {
         assert!(new.fallback_models.is_empty());
         assert!(new.skills.is_empty());
     }
+
+    #[derive(Debug, Deserialize)]
+    struct TestExecPolicy {
+        #[serde(default, deserialize_with = "exec_policy_override")]
+        exec_policy: Option<crate::config::ExecPolicy>,
+    }
+
+    // Regression test for issue #182: `exec_policy = "allow"` in agent manifest was silently
+    // deserialized as None because the field type was `Option<ExecPolicy>` (a struct), not
+    // `Option<ExecSecurityMode>` (a string). The custom deserializer now accepts both forms.
+    #[test]
+    fn exec_policy_override_string_allow() {
+        let toml = r#"exec_policy = "allow""#;
+        let v: TestExecPolicy = toml::from_str(toml).unwrap();
+        assert_eq!(
+            v.exec_policy.unwrap().mode,
+            crate::config::ExecSecurityMode::Full
+        );
+    }
+
+    #[test]
+    fn exec_policy_override_string_deny() {
+        let toml = r#"exec_policy = "deny""#;
+        let v: TestExecPolicy = toml::from_str(toml).unwrap();
+        assert_eq!(
+            v.exec_policy.unwrap().mode,
+            crate::config::ExecSecurityMode::Deny
+        );
+    }
+
+    #[test]
+    fn exec_policy_override_string_restricted() {
+        let toml = r#"exec_policy = "restricted""#;
+        let v: TestExecPolicy = toml::from_str(toml).unwrap();
+        assert_eq!(
+            v.exec_policy.unwrap().mode,
+            crate::config::ExecSecurityMode::Allowlist
+        );
+    }
+
+    #[test]
+    fn exec_policy_override_absent_gives_none() {
+        let toml = r#""#;
+        let v: TestExecPolicy = toml::from_str(toml).unwrap();
+        assert!(v.exec_policy.is_none());
+    }
+
+    #[test]
+    fn exec_policy_override_full_struct_roundtrip() {
+        let toml = r#"
+[exec_policy]
+mode = "full"
+timeout_secs = 120
+"#;
+        let v: TestExecPolicy = toml::from_str(toml).unwrap();
+        let policy = v.exec_policy.unwrap();
+        assert_eq!(policy.mode, crate::config::ExecSecurityMode::Full);
+        assert_eq!(policy.timeout_secs, 120);
+    }
+
+    #[test]
+    fn exec_policy_override_msgpack_none_roundtrip() {
+        // When an old DB blob has exec_policy = None (the broken state from before the fix),
+        // restoring it must still yield None — no regression for existing agents.
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct OldRecord {
+            name: String,
+        }
+        let old = OldRecord {
+            name: "my-agent".to_string(),
+        };
+        let blob = rmp_serde::to_vec_named(&old).unwrap();
+
+        #[derive(Debug, Deserialize)]
+        struct NewRecord {
+            name: String,
+            #[serde(default, deserialize_with = "exec_policy_override")]
+            exec_policy: Option<crate::config::ExecPolicy>,
+        }
+        let new: NewRecord = rmp_serde::from_slice(&blob).unwrap();
+        assert_eq!(new.name, "my-agent");
+        assert!(new.exec_policy.is_none());
+    }
+}
+
+/// Deserialize `exec_policy` in an agent manifest.
+///
+/// Accepts either:
+/// - A bare `ExecSecurityMode` string: `"allow"`, `"deny"`, `"restricted"`, etc.
+/// - A full `ExecPolicy` struct: `{ mode = "allow", timeout_secs = 60, ... }`
+/// - Absent / null → `None` (fall through to the global exec_policy)
+///
+/// This resolves the type mismatch where manifest authors write `exec_policy = "allow"`
+/// (a string) but the field was typed as `Option<ExecPolicy>` (a struct), causing serde
+/// to silently fall back to `None` and ignore the author's intent.
+pub fn exec_policy_override<'de, D>(
+    deserializer: D,
+) -> Result<Option<crate::config::ExecPolicy>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum ExecPolicyInput {
+        Mode(crate::config::ExecSecurityMode),
+        Full(crate::config::ExecPolicy),
+    }
+
+    let opt = Option::<ExecPolicyInput>::deserialize(deserializer)?;
+    Ok(match opt {
+        None => None,
+        Some(ExecPolicyInput::Mode(mode)) => Some(crate::config::ExecPolicy {
+            mode,
+            ..Default::default()
+        }),
+        Some(ExecPolicyInput::Full(policy)) => Some(policy),
+    })
 }


### PR DESCRIPTION
Fixes #182.

## Root Cause

Two independent bugs caused `exec_policy = "allow"` in agent manifests to be silently ignored, leaving every `shell_exec` call blocked by the human approval gate even when an agent explicitly opts into full exec mode.

### Bug 1 — serde type mismatch (`agent.rs`)

`AgentManifest::exec_policy` was typed as `Option<ExecPolicy>` (a struct), but manifest authors write a bare string:

```toml
[capabilities]
exec_policy = "allow"
tools = ["shell_exec"]
```

Serde cannot deserialize a string into `ExecPolicy`, so `#[serde(default)]` silently returns `None`. The kernel then inherits the global `Allowlist` policy. This is confirmed in the kernel log from v0.3.0:

```
Agent exec_policy resolved agent=test-v30 exec_mode=Some(Allowlist)
```

`ExecSecurityMode` already has the correct aliases (`"allow"` → `Full`, `"restricted"` → `Allowlist`, `"deny"` → `Deny`), but the field type is wrong so they are never reached.

### Bug 2 — approval gate fires before exec_mode check (`tool_runner.rs`)

Even if the field parsed correctly, the approval gate in `execute_tool` fired unconditionally before any exec_policy inspection. For scheduled / headless agents there is no human in the loop, so the gate always times out and denies the tool call. The `is_full_exec` guard already existed further down in the function (for the taint check); it was just missing at the gate.

## Fix

**`crates/openfang-types/src/serde_compat.rs`** — adds `exec_policy_override` deserializer that accepts either a bare `ExecSecurityMode` string or a full `ExecPolicy` struct. A bare string is expanded into an `ExecPolicy` with that mode and all other fields at defaults. Absent / null fields return `None`, preserving backward compatibility with existing DB blobs.

**`crates/openfang-types/src/agent.rs`** — wires the new deserializer onto `AgentManifest::exec_policy` via `deserialize_with`.

**`crates/openfang-runtime/src/tool_runner.rs`** — computes `is_full_exec` before the approval gate and skips the gate when the agent is in Full exec mode.

## Tests

Six new tests in `serde_compat::tests`:

| Test | Asserts |
|------|---------|
| `exec_policy_override_string_allow` | `"allow"` → `ExecSecurityMode::Full` |
| `exec_policy_override_string_deny` | `"deny"` → `ExecSecurityMode::Deny` |
| `exec_policy_override_string_restricted` | `"restricted"` → `ExecSecurityMode::Allowlist` |
| `exec_policy_override_absent_gives_none` | absent field → `None` |
| `exec_policy_override_full_struct_roundtrip` | struct form still works |
| `exec_policy_override_msgpack_none_roundtrip` | old DB blob with no field → `None` (no regression) |

All 279 existing tests pass. Build is clean.

## Verification

Tested against a live v0.3.0 daemon before this PR. After applying the patch and spawning an agent with `exec_policy = "allow"` + `tools = ["shell_exec"]`, the kernel log shows:

```
Agent exec_policy resolved agent=test-v30 exec_mode=Some(Full)
```

And `shell_exec` runs without hitting the approval gate.