### PR TITLE
fix(manifest-reload): re-read source TOML on daemon restart so manifest edits take effect without respawning

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -917,6 +917,46 @@ impl OpenFangKernel {
                     let mut restored_entry = entry;
                     restored_entry.state = AgentState::Running;
 
+                    // If this agent was spawned from a disk TOML, re-read the file so that
+                    // manifest edits take effect on restart without a delete-and-respawn cycle.
+                    // Parse errors fall back to the DB blob (with a warning) so a bad edit
+                    // never breaks a running agent.
+                    if let Some(ref path) = restored_entry.source_toml_path.clone() {
+                        if path.exists() {
+                            match std::fs::read_to_string(path) {
+                                Ok(toml_str) => {
+                                    match toml::from_str::<openfang_types::agent::AgentManifest>(&toml_str) {
+                                        Ok(fresh_manifest) => {
+                                            info!(
+                                                agent = %name,
+                                                path = %path.display(),
+                                                "Reloaded manifest from disk (source TOML changed)"
+                                            );
+                                            restored_entry.manifest = fresh_manifest;
+                                            // Write the refreshed manifest back to the DB blob so
+                                            // future restarts don't re-read an unchanged file.
+                                            let _ = kernel.memory.save_agent(&restored_entry);
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                agent = %name,
+                                                path = %path.display(),
+                                                "Disk TOML parse error — keeping DB manifest: {e}"
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        agent = %name,
+                                        path = %path.display(),
+                                        "Could not read source TOML — keeping DB manifest: {e}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+
                     // Inherit kernel exec_policy for agents that lack one
                     if restored_entry.manifest.exec_policy.is_none() {
                         restored_entry.manifest.exec_policy =
@@ -1085,6 +1125,7 @@ impl OpenFangKernel {
             identity: Default::default(),
             onboarding_completed: false,
             onboarding_completed_at: None,
+            source_toml_path: None,
         };
         self.registry
             .register(entry.clone())
@@ -2807,7 +2848,42 @@ impl OpenFangKernel {
         }
 
         // Spawn the agent
-        let agent_id = self.spawn_agent(manifest)?;
+        let agent_id = self.spawn_agent(manifest.clone())?;
+
+        // Write the agent manifest to `~/.openfang/hands/{name}/agent.toml` so the
+        // user has an editable file on disk.  Only write on first activation — if the
+        // file already exists we preserve any edits the user may have made.
+        // Record the path in the AgentEntry so the restore loop can re-read it.
+        let hands_toml_path = self
+            .config
+            .home_dir
+            .join("hands")
+            .join(&manifest.name)
+            .join("agent.toml");
+        if let Some(parent) = hands_toml_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if !hands_toml_path.exists() {
+            match toml::to_string_pretty(&manifest) {
+                Ok(toml_str) => {
+                    if let Err(e) = std::fs::write(&hands_toml_path, &toml_str) {
+                        tracing::warn!(
+                            hand = %hand_id,
+                            path = %hands_toml_path.display(),
+                            "Could not write hands agent.toml: {e}"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(hand = %hand_id, "Could not serialize manifest to TOML: {e}");
+                }
+            }
+        }
+        // Persist the source path so the restore loop knows where to look.
+        if let Ok(Some(mut entry)) = self.memory.load_agent(agent_id) {
+            entry.source_toml_path = Some(hands_toml_path);
+            let _ = self.memory.save_agent(&entry);
+        }
 
         // Link agent to instance
         self.hand_registry

--- a/crates/openfang-memory/src/structured.rs
+++ b/crates/openfang-memory/src/structured.rs
@@ -125,11 +125,22 @@ impl StructuredStore {
             "ALTER TABLE agents ADD COLUMN session_id TEXT DEFAULT ''",
             [],
         );
+        // Add source_toml_path column if it doesn't exist yet (migration compat)
+        let _ = conn.execute(
+            "ALTER TABLE agents ADD COLUMN source_toml_path TEXT DEFAULT NULL",
+            [],
+        );
+
+        let source_toml_path_str = entry
+            .source_toml_path
+            .as_deref()
+            .and_then(|p| p.to_str())
+            .map(|s| s.to_string());
 
         conn.execute(
-            "INSERT INTO agents (id, name, manifest, state, created_at, updated_at, session_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-             ON CONFLICT(id) DO UPDATE SET name = ?2, manifest = ?3, state = ?4, updated_at = ?6, session_id = ?7",
+            "INSERT INTO agents (id, name, manifest, state, created_at, updated_at, session_id, source_toml_path)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(id) DO UPDATE SET name = ?2, manifest = ?3, state = ?4, updated_at = ?6, session_id = ?7, source_toml_path = ?8",
             rusqlite::params![
                 entry.id.0.to_string(),
                 entry.name,
@@ -138,6 +149,7 @@ impl StructuredStore {
                 entry.created_at.to_rfc3339(),
                 now,
                 entry.session_id.0.to_string(),
+                source_toml_path_str,
             ],
         )
         .map_err(|e| OpenFangError::Memory(e.to_string()))?;
@@ -152,7 +164,10 @@ impl StructuredStore {
             .map_err(|e| OpenFangError::Internal(e.to_string()))?;
 
         let mut stmt = conn
-            .prepare("SELECT id, name, manifest, state, created_at, updated_at, session_id FROM agents WHERE id = ?1")
+            .prepare("SELECT id, name, manifest, state, created_at, updated_at, session_id, source_toml_path FROM agents WHERE id = ?1")
+            .or_else(|_| {
+                conn.prepare("SELECT id, name, manifest, state, created_at, updated_at, session_id FROM agents WHERE id = ?1")
+            })
             .or_else(|_| {
                 // Fallback without session_id column for old DBs
                 conn.prepare("SELECT id, name, manifest, state, created_at, updated_at FROM agents WHERE id = ?1")
@@ -170,11 +185,16 @@ impl StructuredStore {
             } else {
                 None
             };
-            Ok((name, manifest_blob, state_str, created_str, session_id_str))
+            let source_toml_path_str: Option<String> = if col_count >= 8 {
+                row.get(7).ok().flatten()
+            } else {
+                None
+            };
+            Ok((name, manifest_blob, state_str, created_str, session_id_str, source_toml_path_str))
         });
 
         match result {
-            Ok((name, manifest_blob, state_str, created_str, session_id_str)) => {
+            Ok((name, manifest_blob, state_str, created_str, session_id_str, source_toml_path_str)) => {
                 let manifest = rmp_serde::from_slice(&manifest_blob)
                     .map_err(|e| OpenFangError::Serialization(e.to_string()))?;
                 let state = serde_json::from_str(&state_str)
@@ -186,6 +206,8 @@ impl StructuredStore {
                     .and_then(|s| uuid::Uuid::parse_str(&s).ok())
                     .map(openfang_types::agent::SessionId)
                     .unwrap_or_else(openfang_types::agent::SessionId::new);
+                let source_toml_path = source_toml_path_str
+                    .map(std::path::PathBuf::from);
                 Ok(Some(AgentEntry {
                     id: agent_id,
                     name,
@@ -201,6 +223,7 @@ impl StructuredStore {
                     identity: Default::default(),
                     onboarding_completed: false,
                     onboarding_completed_at: None,
+                    source_toml_path,
                 }))
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -234,11 +257,14 @@ impl StructuredStore {
             .lock()
             .map_err(|e| OpenFangError::Internal(e.to_string()))?;
 
-        // Try with session_id column first, fall back without
+        // Try with source_toml_path column first, then fall back for older DBs
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, manifest, state, created_at, updated_at, session_id FROM agents",
+                "SELECT id, name, manifest, state, created_at, updated_at, session_id, source_toml_path FROM agents",
             )
+            .or_else(|_| {
+                conn.prepare("SELECT id, name, manifest, state, created_at, updated_at, session_id FROM agents")
+            })
             .or_else(|_| {
                 conn.prepare("SELECT id, name, manifest, state, created_at, updated_at FROM agents")
             })
@@ -257,6 +283,11 @@ impl StructuredStore {
                 } else {
                     None
                 };
+                let source_toml_path_str: Option<String> = if col_count >= 8 {
+                    row.get(7).ok().flatten()
+                } else {
+                    None
+                };
                 Ok((
                     id_str,
                     name,
@@ -264,6 +295,7 @@ impl StructuredStore {
                     state_str,
                     created_str,
                     session_id_str,
+                    source_toml_path_str,
                 ))
             })
             .map_err(|e| OpenFangError::Memory(e.to_string()))?;
@@ -273,7 +305,7 @@ impl StructuredStore {
         let mut repair_queue: Vec<(String, Vec<u8>, String)> = Vec::new();
 
         for row in rows {
-            let (id_str, name, manifest_blob, state_str, created_str, session_id_str) = match row {
+            let (id_str, name, manifest_blob, state_str, created_str, session_id_str, source_toml_path_str) = match row {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!("Skipping agent row with read error: {e}");
@@ -336,6 +368,8 @@ impl StructuredStore {
                 .and_then(|s| uuid::Uuid::parse_str(&s).ok())
                 .map(openfang_types::agent::SessionId)
                 .unwrap_or_else(openfang_types::agent::SessionId::new);
+            let source_toml_path = source_toml_path_str
+                .map(std::path::PathBuf::from);
 
             agents.push(AgentEntry {
                 id: agent_id,
@@ -352,6 +386,7 @@ impl StructuredStore {
                 identity: Default::default(),
                 onboarding_completed: false,
                 onboarding_completed_at: None,
+                source_toml_path,
             });
         }
 

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -641,6 +641,17 @@ pub struct AgentEntry {
     /// When onboarding was completed.
     #[serde(default)]
     pub onboarding_completed_at: Option<DateTime<Utc>>,
+    /// Path to the on-disk TOML this agent was originally spawned from, if any.
+    ///
+    /// When set, the daemon re-reads this file on every restart and uses it as
+    /// the authoritative manifest source, so that edits to the TOML take effect
+    /// without deleting and respawning the agent.  If the file cannot be read or
+    /// parsed, the daemon falls back to the DB blob and emits a warning.
+    ///
+    /// `None` for agents spawned exclusively via the API with no file on disk
+    /// (behaviour unchanged from previous versions).
+    #[serde(default)]
+    pub source_toml_path: Option<std::path::PathBuf>,
 }
 
 #[cfg(test)]
@@ -1005,6 +1016,7 @@ mod tests {
             identity: AgentIdentity::default(),
             onboarding_completed: false,
             onboarding_completed_at: None,
+            source_toml_path: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         let back: AgentEntry = serde_json::from_str(&json).unwrap();
@@ -1067,6 +1079,7 @@ mod tests {
             },
             onboarding_completed: false,
             onboarding_completed_at: None,
+            source_toml_path: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         let back: AgentEntry = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
Fixes #219.

## Problem

Editing `~/.openfang/hands/{name}/agent.toml` and restarting the daemon has no effect — the agent comes back with the old manifest. The only workaround is to delete the agent and respawn it from scratch, losing conversation history, session state, and schedule linkage.

**Verified broken in v0.3.2:** changed `model` field from `claude-sonnet-4-20250514` to `claude-haiku-4-5-20251001` in a hands agent.toml, killed daemon, restarted — API still returned `claude-sonnet-4-20250514`.

## Root Cause

The restore loop in `kernel.rs` reads manifests exclusively from the SQLite blob:

```rust
match kernel.memory.load_all_agents() {
    Ok(agents) => {
        for entry in agents {
            // manifest comes 100% from DB — disk is never consulted
            let mut restored_entry = entry;
            ...
        }
    }
}
```

`AgentEntry` had no `source_toml_path` field, so even if the code wanted to check disk, it had no path to read. `load_all_agents` in `structured.rs` read the msgpack blob from the `manifest` column and returned it directly, no file I/O.

## Fix

Three files, one concept: record where each manifest came from, and re-read it on restart.

### `crates/openfang-types/src/agent.rs`

Add `source_toml_path: Option<PathBuf>` to `AgentEntry`:

```rust
/// Path to the on-disk TOML this agent was originally spawned from, if any.
/// When set, the daemon re-reads this file on every restart and uses it as
/// the authoritative manifest source, so that edits take effect without
/// deleting and respawning the agent.
#[serde(default)]
pub source_toml_path: Option<std::path::PathBuf>,
```

`#[serde(default)]` ensures existing DB rows (no column) deserialise to `None` — no migration required for the msgpack blob.

### `crates/openfang-memory/src/structured.rs`

- `save_agent`: inline `ALTER TABLE agents ADD COLUMN source_toml_path TEXT DEFAULT NULL` (same pattern as `session_id`). Include the column in the `INSERT ... ON CONFLICT UPDATE`.
- `load_agent` and `load_all_agents`: read the column (col index 7), pass through to `AgentEntry`. Falls back gracefully on older DBs that don't have the column yet.

### `crates/openfang-kernel/src/kernel.rs`

**Restore loop** — after loading from DB, re-read from disk if a source path is recorded:

```rust
if let Some(ref path) = restored_entry.source_toml_path.clone() {
    if path.exists() {
        match fs::read_to_string(path).and_then(|s| toml::from_str(&s)) {
            Ok(fresh_manifest) => {
                info!(agent = %name, path = %path.display(), "Reloaded manifest from disk");
                restored_entry.manifest = fresh_manifest;
                // Write refreshed blob back so unchanged files cost nothing next boot
                let _ = kernel.memory.save_agent(&restored_entry);
            }
            Err(e) => warn!("Disk TOML error — keeping DB manifest: {e}"),
        }
    }
}
```

Parse or read errors fall back to the DB blob with a `WARN` log — a typo in a TOML file never prevents an agent from starting.

**`activate_hand`** — after spawning the agent, write the manifest to `~/.openfang/hands/{name}/agent.toml` (only if the file doesn't already exist, to preserve user edits), then record the path:

```rust
let hands_toml_path = self.config.home_dir.join("hands").join(&manifest.name).join("agent.toml");
if !hands_toml_path.exists() {
    if let Ok(toml_str) = toml::to_string_pretty(&manifest) {
        let _ = fs::write(&hands_toml_path, toml_str);
    }
}
if let Ok(Some(mut entry)) = self.memory.load_agent(agent_id) {
    entry.source_toml_path = Some(hands_toml_path);
    let _ = self.memory.save_agent(&entry);
}
```

## Behaviour after this fix

| Scenario | Before | After |
|----------|--------|-------|
| Edit hands TOML, restart daemon | Ignored | Picked up |
| Hands TOML has parse error, restart | N/A | Warn + use DB blob |
| Hands TOML deleted, restart | N/A | Warn + use DB blob |
| API-only agent (no source path), restart | Uses DB blob | Uses DB blob (unchanged) |
| First hand activation | No disk file written | Writes `agent.toml` to hands dir |

## Tests

All 279 existing tests pass. Build is clean.