### PR TITLE
Add Config button to agent chips in Chat

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -786,6 +786,7 @@
                     <div class="font-bold" style="font-size:13px" x-text="agent.name"></div>
                     <div class="text-xs text-dim font-mono" style="font-size:11px" x-text="agent.model_name"></div>
                   </div>
+                  <button class="btn btn-ghost btn-sm" style="padding:4px 8px;font-size:11px" @click.stop="showDetail(agent)">Config</button>
                   <span class="badge" :class="'badge-' + agent.state.toLowerCase()" x-text="agent.state" style="font-size:10px"></span>
                 </div>
               </template>


### PR DESCRIPTION
## Summary
- add a Config button on each agent chip in Chat -> Your Agents
- wire the button to open the existing agent detail modal via showDetail(agent)
- keep current chip click behavior for chat via chatWithAgent(agent)

## Why
The detail modal tabs (Info / Files / Config) exist, but there is no obvious UI entry point from the Chat page. This adds a clear way to access agent configuration.

## Testing
- Open Chat page
- In Your Agents, click Config on an agent chip
- Confirm modal opens with tabs: Info, Files, Config
- Confirm clicking the chip body still opens chat
