### PR TITLE
fix: use truncate_str for UTF-8 safe string truncation

### DIFF
--- a/crates/openfang-kernel/src/triggers.rs
+++ b/crates/openfang-kernel/src/triggers.rs
@@ -278,7 +278,7 @@ fn describe_event(event: &Event) -> String {
                 tr.tool_id,
                 if tr.success { "succeeded" } else { "failed" },
                 tr.execution_time_ms,
-                &tr.content[..tr.content.len().min(200)]
+                openfang_types::truncate_str(&tr.content, 200)
             )
         }
         EventPayload::MemoryUpdate(delta) => {

--- a/crates/openfang-memory/src/session.rs
+++ b/crates/openfang-memory/src/session.rs
@@ -587,7 +587,7 @@ impl SessionStore {
                             ContentBlock::Thinking { thinking } => {
                                 text_parts.push(format!(
                                     "[thinking: {}]",
-                                    &thinking[..thinking.len().min(200)]
+                                    openfang_types::truncate_str(thinking, 200)
                                 ));
                             }
                             ContentBlock::Unknown => {}

--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -1227,7 +1227,7 @@ mod tests {
         assert!(
             text.contains("truncated from"),
             "Oversized message should be truncated, got: {}",
-            &text[..text.len().min(200)]
+            openfang_types::truncate_str(&text, 200)
         );
     }
 

--- a/crates/openfang-runtime/src/provider_health.rs
+++ b/crates/openfang-runtime/src/provider_health.rs
@@ -186,7 +186,7 @@ pub async fn probe_model(
     } else {
         let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
-        Err(format!("HTTP {status}: {}", &body[..body.len().min(200)]))
+        Err(format!("HTTP {status}: {}", openfang_types::truncate_str(&body, 200)))
     }
 }
 

--- a/crates/openfang-runtime/src/subprocess_sandbox.rs
+++ b/crates/openfang-runtime/src/subprocess_sandbox.rs
@@ -146,7 +146,7 @@ pub fn validate_command_allowlist(command: &str, policy: &ExecPolicy) -> Result<
         }
         ExecSecurityMode::Full => {
             tracing::warn!(
-                command = &command[..command.len().min(100)],
+                command = openfang_types::truncate_str(command, 100),
                 "Shell exec in full mode — no restrictions"
             );
             Ok(())

--- a/crates/openfang-runtime/src/tool_runner.rs
+++ b/crates/openfang-runtime/src/tool_runner.rs
@@ -41,7 +41,7 @@ fn check_taint_shell_exec(command: &str) -> Option<String> {
             labels.insert(TaintLabel::ExternalNetwork);
             let tainted = TaintedValue::new(command, labels, "llm_tool_call");
             if let Err(violation) = tainted.check_sink(&TaintSink::shell_exec()) {
-                warn!(command = &command[..command.len().min(80)], %violation, "Shell taint check failed");
+                warn!(command = openfang_types::truncate_str(command, 80), %violation, "Shell taint check failed");
                 return Some(violation.to_string());
             }
         }
@@ -68,7 +68,7 @@ fn check_taint_net_fetch(url: &str) -> Option<String> {
             labels.insert(TaintLabel::Secret);
             let tainted = TaintedValue::new(url, labels, "llm_tool_call");
             if let Err(violation) = tainted.check_sink(&TaintSink::net_fetch()) {
-                warn!(url = &url[..url.len().min(80)], %violation, "Net fetch taint check failed");
+                warn!(url = openfang_types::truncate_str(url, 80), %violation, "Net fetch taint check failed");
                 return Some(violation.to_string());
             }
         }


### PR DESCRIPTION
Replace all `&s[..s.len().min(N)]` patterns with
`openfang_types::truncate_str(s, N)` to prevent panics when the byte index falls inside a multi-byte character (e.g. CJK / emoji).

The bug manifests as a thread panic in session.rs when the thinking content contains non-ASCII text and the 200-byte boundary lands mid-character.

Affected crates: openfang-memory, openfang-kernel, openfang-runtime.