### PR TITLE
fix: add type field to kv_store value parameter for llama.cpp compatibility

### DIFF
--- a/crates/openfang-runtime/src/tool_runner.rs
+++ b/crates/openfang-runtime/src/tool_runner.rs
@@ -627,7 +627,7 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
                 "type": "object",
                 "properties": {
                     "key": { "type": "string", "description": "The storage key" },
-                    "value": { "description": "The JSON value to store (any type)" }
+                    "value": { "type": "object", "description": "The JSON value to store (any type)" }
                 },
                 "required": ["key", "value"]
             }),


### PR DESCRIPTION
## Summary
- Add `"type": "object"` to the `value` parameter in `kv_store` tool's JSON schema definition

Fixes #236

## Problem
llama.cpp's OpenAI-compatible backend fails when encountering tool parameters without an explicit `type` field. The error:
JSON schema conversion failed: Unrecognized schema: {"description":"The JSON value to store (any type)"}
## Solution
Add `"type": "object"` to the value parameter schema, making it compatible with llama.cpp and other backends that require explicit typing.