### PR TITLE
 Bundle required runtimes in Docker image (Rust + Python + Node)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,16 @@ COPY agents ./agents
 COPY packages ./packages
 RUN cargo build --release --bin openfang
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM rust:1-slim-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    python3 \
+    python3-pip \
+    python3-venv \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /build/target/release/openfang /usr/local/bin/
 COPY --from=builder /build/agents /opt/openfang/agents
 EXPOSE 4200


### PR DESCRIPTION
## Summary
`openfang doctor` reports missing Rust/Python/Node in the current runtime image, which prevents Python/Node skill execution out of the box. This PR updates the Dockerfile so the final container includes the runtimes/toolchain OpenFang expects at runtime, while keeping the build stage unchanged.

## Changes
- Switch final stage base image from `debian:bookworm-slim` to `rust:1-slim-bookworm` to include the Rust toolchain in the runtime image.
- Install Python runtime dependencies: `python3`, `python3-pip`, `python3-venv`.
- Install Node runtime dependencies: `nodejs`, `npm`.
- Keep existing behavior: copy `openfang` binary + `agents`, expose `4200`, mount `/data`, and run `openfang start`.

## Rationale
- Ensures the container is self-contained for common OpenFang workflows (running skills that require Python/Node).
- Avoids relying on `doctor --repair` or manual provisioning in derived images.
- Keeps runtime and builder on the same Debian base family for compatibility.