### PR TITLE
fix(claude-code): add --verbose flag for stream-json output format

### DIFF
--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -194,6 +194,7 @@ impl LlmDriver for ClaudeCodeDriver {
         let mut cmd = tokio::process::Command::new(&self.cli_path);
         cmd.arg("-p")
             .arg(&prompt)
+            .arg("--verbose")
             .arg("--output-format")
             .arg("stream-json");
 


### PR DESCRIPTION
## Summary

- Claude CLI requires `--verbose` when using `--output-format=stream-json` with `-p` (print mode)
- Without it, the CLI exits with code 1 and all streaming requests fail silently
- Added the missing `--verbose` flag in the `stream()` method of `ClaudeCodeDriver`

## Reproduction

```
$ claude -p "hello" --output-format stream-json
Error: When using --print, --output-format=stream-json requires --verbose
```

## Test plan

- [x] Verified `claude -p "hello" --output-format stream-json` fails without `--verbose`
- [x] Verified `claude -p "hello" --verbose --output-format stream-json` works correctly
- [x] Tested full agent loop with streaming — messages are now processed successfully

Fixes #304