### PR TITLE
fix: store channel list config values as strings to prevent deseriali…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-api"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "axum",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-channels"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "axum",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-cli"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-desktop"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "axum",
  "open",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-extensions"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-hands"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-kernel"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-memory"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-migrate"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-runtime"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-skills"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "chrono",
  "hex",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-types"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-wire"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8802,7 +8802,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.3.23"
+version = "0.3.24"
 
 [[package]]
 name = "yoke"

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -6947,11 +6947,7 @@ fn upsert_channel_config(
                     .split(',')
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
-                    .map(|s| {
-                        s.parse::<i64>()
-                            .map(toml::Value::Integer)
-                            .unwrap_or_else(|_| toml::Value::String(s.to_string()))
-                    })
+                    .map(|s| toml::Value::String(s.to_string()))
                     .collect();
                 toml::Value::Array(items)
             }

--- a/crates/openfang-channels/src/telegram.rs
+++ b/crates/openfang-channels/src/telegram.rs
@@ -28,7 +28,7 @@ pub struct TelegramAdapter {
     /// SECURITY: Bot token is zeroized on drop to prevent memory disclosure.
     token: Zeroizing<String>,
     client: reqwest::Client,
-    allowed_users: Vec<i64>,
+    allowed_users: Vec<String>,
     poll_interval: Duration,
     shutdown_tx: Arc<watch::Sender<bool>>,
     shutdown_rx: watch::Receiver<bool>,
@@ -39,7 +39,7 @@ impl TelegramAdapter {
     ///
     /// `token` is the raw bot token (read from env by the caller).
     /// `allowed_users` is the list of Telegram user IDs allowed to interact (empty = allow all).
-    pub fn new(token: String, allowed_users: Vec<i64>, poll_interval: Duration) -> Self {
+    pub fn new(token: String, allowed_users: Vec<String>, poll_interval: Duration) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             token: Zeroizing::new(token),
@@ -451,7 +451,7 @@ impl ChannelAdapter for TelegramAdapter {
 /// Handles both `message` and `edited_message` update types.
 fn parse_telegram_update(
     update: &serde_json::Value,
-    allowed_users: &[i64],
+    allowed_users: &[String],
 ) -> Option<ChannelMessage> {
     let message = update
         .get("message")
@@ -460,7 +460,8 @@ fn parse_telegram_update(
     let user_id = from["id"].as_i64()?;
 
     // Security: check allowed_users
-    if !allowed_users.is_empty() && !allowed_users.contains(&user_id) {
+    let user_id_str = user_id.to_string();
+    if !allowed_users.is_empty() && !allowed_users.iter().any(|u| u == &user_id_str) {
         debug!("Telegram: ignoring message from unlisted user {user_id}");
         return None;
     }
@@ -679,11 +680,11 @@ mod tests {
         assert!(msg.is_some());
 
         // Non-matching allowed_users = filter out
-        let msg = parse_telegram_update(&update, &[111, 222]);
+        let msg = parse_telegram_update(&update, &["111".to_string(), "222".to_string()]);
         assert!(msg.is_none());
 
         // Matching allowed_users = allow
-        let msg = parse_telegram_update(&update, &[999]);
+        let msg = parse_telegram_update(&update, &["999".to_string()]);
         assert!(msg.is_some());
     }
 

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -1,8 +1,27 @@
 //! Configuration types for the OpenFang kernel.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+/// Deserialize a `Vec<String>` that also accepts integers in the array.
+/// This allows TOML like `allowed_guilds = [1171476861218459718]` to deserialize
+/// into `Vec<String>` for backwards compatibility with configs written before
+/// the fix that stores all list items as strings.
+fn deserialize_string_or_int_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values: Vec<serde_json::Value> = Deserialize::deserialize(deserializer)?;
+    Ok(values
+        .into_iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => s,
+            serde_json::Value::Number(n) => n.to_string(),
+            other => other.to_string(),
+        })
+        .collect())
+}
 
 /// DM (direct message) policy for a channel.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1530,7 +1549,8 @@ pub struct TelegramConfig {
     /// Env var name holding the bot token (NOT the token itself).
     pub bot_token_env: String,
     /// Telegram user IDs allowed to interact (empty = allow all).
-    pub allowed_users: Vec<i64>,
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
+    pub allowed_users: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
     /// Polling interval in seconds.
@@ -1560,9 +1580,10 @@ pub struct DiscordConfig {
     pub bot_token_env: String,
     /// Guild (server) IDs allowed to interact (empty = allow all).
     /// Accepts strings for consistency with other channel configs.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_guilds: Vec<String>,
     /// User IDs allowed to interact (empty = allow all).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_users: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1595,6 +1616,7 @@ pub struct SlackConfig {
     /// Env var name holding the bot token (xoxb-) for REST API.
     pub bot_token_env: String,
     /// Channel IDs allowed to interact (empty = allow all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_channels: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1631,6 +1653,7 @@ pub struct WhatsAppConfig {
     /// When set, outgoing messages are routed through the gateway instead of Cloud API.
     pub gateway_url_env: String,
     /// Allowed phone numbers (empty = allow all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_users: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1663,6 +1686,7 @@ pub struct SignalConfig {
     /// Registered phone number.
     pub phone_number: String,
     /// Allowed phone numbers (empty = allow all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_users: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1694,6 +1718,7 @@ pub struct MatrixConfig {
     /// Env var name holding the access token.
     pub access_token_env: String,
     /// Room IDs to listen in (empty = all joined rooms).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_rooms: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1803,6 +1828,7 @@ pub struct MattermostConfig {
     /// Env var name holding the bot token.
     pub token_env: String,
     /// Allowed channel IDs (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_channels: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1836,6 +1862,7 @@ pub struct IrcConfig {
     /// Env var name holding the server password (optional).
     pub password_env: Option<String>,
     /// Channels to join (e.g., `["#openfang", "#general"]`).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub channels: Vec<String>,
     /// Use TLS (requires tokio-native-tls).
     pub use_tls: bool,
@@ -1868,6 +1895,7 @@ pub struct GoogleChatConfig {
     /// Env var name holding the service account JSON key.
     pub service_account_env: String,
     /// Space IDs to listen in.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub space_ids: Vec<String>,
     /// Port for the incoming webhook.
     pub webhook_port: u16,
@@ -1897,6 +1925,7 @@ pub struct TwitchConfig {
     /// Env var name holding the OAuth token.
     pub oauth_token_env: String,
     /// Twitch channels to join (without #).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub channels: Vec<String>,
     /// Bot nickname.
     pub nick: String,
@@ -1930,6 +1959,7 @@ pub struct RocketChatConfig {
     /// User ID for the bot.
     pub user_id: String,
     /// Allowed channel IDs (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_channels: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1962,6 +1992,7 @@ pub struct ZulipConfig {
     /// Env var name holding the API key.
     pub api_key_env: String,
     /// Streams to listen in.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub streams: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -1996,6 +2027,7 @@ pub struct XmppConfig {
     /// XMPP server port.
     pub port: u16,
     /// MUC rooms to join.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub rooms: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2120,6 +2152,7 @@ pub struct RedditConfig {
     /// Env var name holding the bot password.
     pub password_env: String,
     /// Subreddits to monitor.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub subreddits: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2263,6 +2296,7 @@ pub struct NextcloudConfig {
     /// Env var name holding the auth token.
     pub token_env: String,
     /// Room tokens to listen in (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_rooms: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2290,6 +2324,7 @@ pub struct GuildedConfig {
     /// Env var name holding the bot token.
     pub bot_token_env: String,
     /// Server IDs to listen in (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub server_ids: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2318,6 +2353,7 @@ pub struct KeybaseConfig {
     /// Env var name holding the paper key.
     pub paperkey_env: String,
     /// Team names to listen in (empty = all DMs).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_teams: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2374,6 +2410,7 @@ pub struct NostrConfig {
     /// Env var name holding the private key (nsec or hex).
     pub private_key_env: String,
     /// Relay URLs to connect to.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub relays: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2400,6 +2437,7 @@ pub struct WebexConfig {
     /// Env var name holding the bot token.
     pub bot_token_env: String,
     /// Room IDs to listen in (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_rooms: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2480,6 +2518,7 @@ pub struct TwistConfig {
     /// Workspace ID.
     pub workspace_id: String,
     /// Channel IDs to listen in (empty = all).
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub allowed_channels: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
@@ -2577,6 +2616,7 @@ pub struct DiscourseConfig {
     /// API username.
     pub api_username: String,
     /// Category slugs to monitor.
+    #[serde(default, deserialize_with = "deserialize_string_or_int_vec")]
     pub categories: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,


### PR DESCRIPTION

Discord guild IDs (and other numeric IDs) were parsed as TOML integers by upsert_channel_config(), but the config structs expect Vec<String>. This caused "invalid type: integer, expected a string" errors when loading config.

- Always serialize FieldType::List items as TOML strings
- Align TelegramConfig::allowed_users from Vec<i64> to Vec<String> for consistency
- Add deserialize_string_or_int_vec helper on all 22 channel Vec<String> fields for backwards compatibility with existing config files containing integers

## Summary
When I configure Discord through the web interface, everything seems fine, but the backend reports an error.

`2026-03-06T09:49:01.868039Z WARN openfang_kernel::config: Failed to deserialize merged config, using defaults error=invalid type: integer 1171XXXXXXXXXXXXX718, expected a string in channels.discord.allowed_guilds path=/data/config.toml`

<!-- What does this PR do? Link related issues with "Fixes #123". -->

## Changes

<!-- Brief list of what changed. -->

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [ ] User input validated at boundaries
