### PR TITLE
fix(installer): improve shell detection and fix Fish shell PATH injection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,18 +111,68 @@ install() {
     chmod +x "$INSTALL_DIR/openfang"
 
     # Add to PATH
+    # Detect current shell with fallback to $SHELL, parent process, and defaults
+    detect_shell() {
+        # Check if we're running under fish directly
+        if [ -n "${FISH_VERSION:-}" ]; then
+            echo "fish"
+            return
+        fi
+
+        # Check if we're running under zsh
+        if [ -n "${ZSH_VERSION:-}" ]; then
+            echo "zsh"
+            return
+        fi
+
+        # Check if we're running under bash
+        if [ -n "${BASH:-}" ]; then
+            echo "bash"
+            return
+        fi
+
+        # Fallback to $SHELL environment variable
+        if [ -n "${SHELL:-}" ]; then
+            case "$SHELL" in
+                */fish) echo "fish"; return ;;
+                */zsh) echo "zsh"; return ;;
+                */bash) echo "bash"; return ;;
+            esac
+        fi
+
+        # Try to detect from parent process
+        if command -v ps &>/dev/null; then
+            local parent_shell=$(ps -p $PPID -o comm= 2>/dev/null || echo "")
+            case "$parent_shell" in
+                *fish) echo "fish"; return ;;
+                *zsh) echo "zsh"; return ;;
+                *bash) echo "bash"; return ;;
+            esac
+        fi
+
+        # Last resort: default to bash for compatibility
+        echo "bash"
+    }
+
+    CURRENT_SHELL=$(detect_shell)
     SHELL_RC=""
-    case "${SHELL:-}" in
-        */zsh) SHELL_RC="$HOME/.zshrc" ;;
-        */bash) SHELL_RC="$HOME/.bashrc" ;;
-        */fish) SHELL_RC="$HOME/.config/fish/config.fish" ;;
+    case "$CURRENT_SHELL" in
+        zsh) SHELL_RC="$HOME/.zshrc" ;;
+        bash) SHELL_RC="$HOME/.bashrc" ;;
+        fish) SHELL_RC="$HOME/.config/fish/config.fish" ;;
     esac
 
     if [ -n "$SHELL_RC" ] && ! grep -q "openfang" "$SHELL_RC" 2>/dev/null; then
-        case "${SHELL:-}" in
-            */fish)
+        case "$CURRENT_SHELL" in
+            fish)
                 mkdir -p "$(dirname "$SHELL_RC")"
-                echo "set -gx PATH \"$INSTALL_DIR\" \$PATH" >> "$SHELL_RC"
+                # Use fish_add_path for cleaner PATH management (Fish 3.3+)
+                # Fallback to set -gx for older Fish versions
+                echo 'if command -q fish_add_path' >> "$SHELL_RC"
+                echo "    fish_add_path \"$INSTALL_DIR\"" >> "$SHELL_RC"
+                echo 'else' >> "$SHELL_RC"
+                echo "    set -gx PATH \"$INSTALL_DIR\" \$PATH" >> "$SHELL_RC"
+                echo 'end' >> "$SHELL_RC"
                 ;;
             *)
                 echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$SHELL_RC"


### PR DESCRIPTION
Fixes #372

## Problem
The installer script only used the `/bin/zsh` environment variable to detect the user's shell. However, `/bin/zsh` reflects the login shell (e.g., /bin/bash or /bin/zsh), not the shell actually being used. When users ran the installer script from Fish shell, it would incorrectly inject Bash export syntax into their `config.fish`, breaking the shell.

## Solution
- Added `detect_shell()` function with multi-layer detection:
  1. Check shell-specific environment variables (`FISH_VERSION`, `ZSH_VERSION`, `BASH`)
  2. Fallback to `/bin/zsh` environment variable
  3. Detect from parent process name via `ps` command
  4. Default to bash for compatibility

- Improved Fish shell handling:
  - Use `fish_add_path` command (recommended for Fish 3.3+)
  - Provide fallback `set -gx PATH` for older Fish versions
  - Avoid injecting Bash syntax into Fish config files