### PR TITLE
Fix default hourly cost quota to unlimited instead of $1.00

### DIFF
--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -267,9 +267,9 @@ impl Default for ResourceQuota {
             max_tool_calls_per_minute: 60,
             max_llm_tokens_per_hour: 1_000_000,
             max_network_bytes_per_hour: 100 * 1024 * 1024, // 100 MB
-            max_cost_per_hour_usd: 1.0,
-            max_cost_per_day_usd: 0.0,   // unlimited
-            max_cost_per_month_usd: 0.0, // unlimited
+            max_cost_per_hour_usd: 0.0,                    // unlimited by default
+            max_cost_per_day_usd: 0.0,                     // unlimited
+            max_cost_per_month_usd: 0.0,                   // unlimited
         }
     }
 }


### PR DESCRIPTION
## Summary

- `ResourceQuota::default()` had `max_cost_per_hour_usd` hardcoded to `1.0`, causing agents to hit an unexpected \$1/hour hard stop even when no budget was explicitly configured by the user
- `max_cost_per_day_usd` and `max_cost_per_month_usd` already defaulted to `0.0` (unlimited) — this PR makes `max_cost_per_hour_usd` consistent with them
- Changed default from `1.0` to `0.0` (unlimited)

## Reproduction

1. Install OpenFang via the install script on a fresh server
2. Create any agent (or use the default `dona` template)  
3. Have an active conversation that exceeds \$1.00 in LLM costs within an hour
4. Agent stops with: `Agent error: Resource quota exceeded: ... exceeded hourly cost quota: $1.XXXX / $1.0000`
5. The Budget settings page shows all agents capped at `$1.0000` hourly even with global limits set to unlimited

## Fix

```rust
// Before
max_cost_per_hour_usd: 1.0,

// After  
max_cost_per_hour_usd: 0.0, // unlimited by default
```

## Test plan

- [x] `cargo test -p openfang-types` — 287 tests pass
- [x] `cargo clippy -p openfang-types -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — no diff on changed file