### PR TITLE
Fix browser hand Python detection on modern Linux (python3 vs python)

### DIFF
--- a/crates/openfang-hands/bundled/browser/HAND.toml
+++ b/crates/openfang-hands/bundled/browser/HAND.toml
@@ -17,7 +17,7 @@ tools = [
 key = "python3"
 label = "Python 3 must be installed"
 requirement_type = "binary"
-check_value = "python"
+check_value = "python3"
 description = "Python 3 is required to run Playwright, the browser automation library that powers this hand."
 
 [requires.install]


### PR DESCRIPTION
## Summary

- The browser hand installer checks for `python` binary to verify Python 3 is installed
- Modern Debian/Ubuntu (22.04+) only ships `python3` — `python` is not available by default
- This causes the dependency check to always fail even when Python 3 is properly installed, blocking the hand setup wizard

## Reproduction

1. Install OpenFang on Ubuntu 22.04+ or Debian 11+ (fresh install, no `python-is-python3` package)
2. Open the browser hand installer in the dashboard
3. Dependency check shows `✗ Python 3 must be installed` despite Python 3 being present at `/usr/bin/python3`

## Fix

Changed `check_value = "python"` to `check_value = "python3"` in `HAND.toml`. The install command (`sudo apt install python3`) was already correct.

```toml
# Before
check_value = "python"

# After
check_value = "python3"
```

## Test plan

- [x] `cargo test -p openfang-hands` — 35 tests pass
- [x] `cargo clippy -p openfang-hands -- -D warnings` — zero warnings