### PR TITLE
Fix browser hand: add --no-sandbox when Chromium runs as root

### DIFF
--- a/crates/openfang-runtime/src/browser.rs
+++ b/crates/openfang-runtime/src/browser.rs
@@ -258,6 +258,12 @@ impl BrowserSession {
             args.insert(0, "--headless=new".to_string());
             args.push("--disable-gpu".to_string());
         }
+        // Chromium refuses to run as root without --no-sandbox. Detect this
+        // without adding a libc dependency by reading the effective UID from
+        // /proc/self/status (Linux) or falling back to the HOME env var.
+        if is_running_as_root() {
+            args.push("--no-sandbox".to_string());
+        }
 
         let mut cmd = tokio::process::Command::new(&chrome_path);
         cmd.args(&args);
@@ -1154,6 +1160,36 @@ const EXTRACT_CONTENT_JS: &str = r#"(() => {
     return JSON.stringify({title, url, content});
 })()"#;
 
+// ── Root detection ─────────────────────────────────────────────────────────
+
+/// Returns true if the current process is running as root (UID 0).
+///
+/// On Linux, reads `/proc/self/status` to get the effective UID without
+/// requiring a `libc` dependency. Falls back to checking the `HOME` env var
+/// on systems where `/proc` is not available.
+fn is_running_as_root() -> bool {
+    #[cfg(unix)]
+    {
+        // Primary: read effective UID from /proc/self/status (Linux)
+        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
+            for line in status.lines() {
+                if let Some(rest) = line.strip_prefix("Uid:") {
+                    // Format: "Uid:	<real> <effective> <saved> <fs>"
+                    if let Some(euid_str) = rest.split_whitespace().nth(1) {
+                        return euid_str == "0";
+                    }
+                }
+            }
+        }
+        // Fallback: HOME=/root is a reliable indicator on most Unix systems
+        std::env::var("HOME").map(|h| h == "/root").unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1288,6 +1324,12 @@ mod tests {
         let config = BrowserConfig::default();
         let mgr = BrowserManager::new(config);
         assert!(mgr.sessions.is_empty());
+    }
+
+    #[test]
+    fn test_is_running_as_root_returns_bool() {
+        // Just verify it doesn't panic and returns a bool.
+        let _ = is_running_as_root();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The browser hand fails immediately on any root-based OpenFang server install with: `Error: Chromium exited before printing DevTools URL`
- Chromium refuses to run as root without `--no-sandbox` — this is a known Chromium requirement
- The default OpenFang install script runs the daemon as root, making the browser hand broken out of the box on Linux servers

## Reproduction

1. Install OpenFang via the install script (runs as root)
2. Install and activate the browser hand
3. Ask any agent to navigate to a website
4. Error: `Chromium exited before printing DevTools URL. Is Chrome installed?`

## Fix

Added `is_running_as_root()` which detects UID 0 by reading `/proc/self/status` (no new dependencies needed). When running as root, `--no-sandbox` is automatically appended to Chromium's launch args.

```rust
if is_running_as_root() {
    args.push("--no-sandbox".to_string());
}
```

The root detection reads `/proc/self/status` on Linux (reliable, no deps) and falls back to checking `HOME=/root` on other Unix systems. On non-Unix platforms it always returns false.

## Test plan

- [x] `cargo build -p openfang-runtime` — compiles cleanly
- [x] `cargo clippy -p openfang-runtime -- -D warnings` — zero warnings
- [x] Verified manually on Ubuntu 24.04 running as root: browser hand navigates successfully after this fix