### PR TITLE
Fix potential panic bugs in string slicing and server shutdown

### DIFF
--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -56,6 +56,16 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
+/// Safely truncate a string to at most n characters.
+/// Returns the original string if it's shorter than n characters.
+fn truncate_str(s: &str, n: usize) -> &str {
+    if s.len() > n {
+        &s[..n]
+    } else {
+        s
+    }
+}
+
 /// Wraps `OpenFangKernel` to implement `ChannelBridgeHandle`.
 pub struct KernelBridgeAdapter {
     kernel: Arc<OpenFangKernel>,
@@ -351,7 +361,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                 .map(|e| e.name.clone())
                 .unwrap_or_else(|| t.agent_id.to_string());
             let status = if t.enabled { "on" } else { "off" };
-            let id_short = &t.id.0.to_string()[..8];
+            let id_str = t.id.0.to_string();
+            let id_short = truncate_str(&id_str, 8);
             msg.push_str(&format!(
                 "  [{}] {} -> {} ({:?}) fires:{} [{}]\n",
                 id_short,
@@ -390,7 +401,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .kernel
             .triggers
             .register(agent.id, pattern, prompt.to_string(), 0);
-        let id_short = &trigger_id.0.to_string()[..8];
+        let id_str = trigger_id.0.to_string();
+        let id_short = truncate_str(&id_str, 8);
         format!("Trigger created [{id_short}] for agent '{agent_name}'.")
     }
 
@@ -405,7 +417,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             1 => {
                 let t = matched[0];
                 if self.kernel.triggers.remove(t.id) {
-                    format!("Trigger [{}] removed.", &t.id.0.to_string()[..8])
+                    let id_str = t.id.0.to_string();
+                    format!("Trigger [{}] removed.", truncate_str(&id_str, 8))
                 } else {
                     "Failed to remove trigger.".to_string()
                 }
@@ -428,7 +441,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                 .map(|e| e.name.clone())
                 .unwrap_or_else(|| job.agent_id.to_string());
             let status = if job.enabled { "on" } else { "off" };
-            let id_short = &job.id.0.to_string()[..8];
+            let id_str = job.id.0.to_string();
+            let id_short = truncate_str(&id_str, 8);
             let sched = match &job.schedule {
                 openfang_types::scheduler::CronSchedule::Cron { expr, .. } => expr.clone(),
                 openfang_types::scheduler::CronSchedule::Every { every_secs } => {
@@ -488,7 +502,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
 
                 match self.kernel.cron_scheduler.add_job(job, false) {
                     Ok(id) => {
-                        let id_short = &id.0.to_string()[..8];
+                        let id_str = id.0.to_string();
+                        let id_short = truncate_str(&id_str, 8);
                         format!("Job [{id_short}] created: '{cron_expr}' -> {agent_name}: \"{message}\"")
                     }
                     Err(e) => format!("Failed to create job: {e}"),
@@ -510,7 +525,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         let j = matched[0];
                         match self.kernel.cron_scheduler.remove_job(j.id) {
                             Ok(_) => {
-                                format!("Job [{}] '{}' removed.", &j.id.0.to_string()[..8], j.name)
+                                let id_str = j.id.0.to_string();
+                                format!("Job [{}] '{}' removed.", truncate_str(&id_str, 8), j.name)
                             }
                             Err(e) => format!("Failed to remove job: {e}"),
                         }
@@ -542,7 +558,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         };
                         match self.kernel.send_message(j.agent_id, &message).await {
                             Ok(result) => {
-                                let id_short = &j.id.0.to_string()[..8];
+                                let id_str = j.id.0.to_string();
+                                let id_short = truncate_str(&id_str, 8);
                                 format!("Job [{id_short}] ran:\n{}", result.response)
                             }
                             Err(e) => format!("Failed to run job: {e}"),
@@ -562,7 +579,8 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         }
         let mut msg = format!("Pending approvals ({}):\n", pending.len());
         for req in &pending {
-            let id_short = &req.id.to_string()[..8];
+            let id_str = req.id.to_string();
+            let id_short = truncate_str(&id_str, 8);
             let age_secs = (chrono::Utc::now() - req.requested_at).num_seconds();
             let age = if age_secs >= 60 {
                 format!("{}m", age_secs / 60)
@@ -603,10 +621,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                 ) {
                     Ok(_) => {
                         let verb = if approve { "Approved" } else { "Rejected" };
+                        let id_str = req.id.to_string();
                         format!(
                             "{} [{}] {} — {}",
                             verb,
-                            &req.id.to_string()[..8],
+                            truncate_str(&id_str, 8),
                             req.tool_name,
                             req.agent_id
                         )

--- a/crates/openfang-desktop/src/server.rs
+++ b/crates/openfang-desktop/src/server.rs
@@ -6,6 +6,7 @@
 use openfang_api::server::build_router;
 use openfang_kernel::OpenFangKernel;
 use std::net::{SocketAddr, TcpListener};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{error, info};
@@ -20,24 +21,40 @@ pub struct ServerHandle {
     shutdown_tx: watch::Sender<bool>,
     /// Join handle for the background server thread.
     server_thread: Option<std::thread::JoinHandle<()>>,
+    /// Track whether shutdown has already been initiated to prevent race conditions.
+    shutdown_initiated: Arc<AtomicBool>,
 }
 
 impl ServerHandle {
     /// Signal the server to shut down and wait for the background thread.
     pub fn shutdown(mut self) {
-        let _ = self.shutdown_tx.send(true);
-        if let Some(handle) = self.server_thread.take() {
-            let _ = handle.join();
+        // Only proceed if shutdown hasn't been initiated yet
+        if self
+            .shutdown_initiated
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+            .is_ok()
+        {
+            let _ = self.shutdown_tx.send(true);
+            if let Some(handle) = self.server_thread.take() {
+                let _ = handle.join();
+            }
+            self.kernel.shutdown();
+            info!("OpenFang embedded server stopped");
         }
-        self.kernel.shutdown();
-        info!("OpenFang embedded server stopped");
     }
 }
 
 impl Drop for ServerHandle {
     fn drop(&mut self) {
-        let _ = self.shutdown_tx.send(true);
-        // Best-effort: don't block in drop, the thread will exit on its own.
+        // Only send shutdown signal if it hasn't been initiated yet
+        if self
+            .shutdown_initiated
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+            .is_ok()
+        {
+            let _ = self.shutdown_tx.send(true);
+            // Best-effort: don't block in drop, the thread will exit on its own.
+        }
     }
 }
 
@@ -61,6 +78,7 @@ pub fn start_server() -> Result<ServerHandle, Box<dyn std::error::Error>> {
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let kernel_clone = kernel.clone();
+    let shutdown_initiated = Arc::new(AtomicBool::new(false));
 
     let server_thread = std::thread::Builder::new()
         .name("openfang-server".into())
@@ -83,6 +101,7 @@ pub fn start_server() -> Result<ServerHandle, Box<dyn std::error::Error>> {
         kernel,
         shutdown_tx,
         server_thread: Some(server_thread),
+        shutdown_initiated,
     })
 }
 

--- a/crates/openfang-runtime/src/tool_runner.rs
+++ b/crates/openfang-runtime/src/tool_runner.rs
@@ -3092,7 +3092,8 @@ async fn tool_canvas_present(
     let _ = tokio::fs::create_dir_all(&output_dir).await;
 
     let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
-    let filename = format!("canvas_{timestamp}_{}.html", &canvas_id[..8]);
+    let id_short = if canvas_id.len() > 8 { &canvas_id[..8] } else { &canvas_id };
+    let filename = format!("canvas_{timestamp}_{}.html", id_short);
     let filepath = output_dir.join(&filename);
 
     // Write the full HTML document


### PR DESCRIPTION
## Summary

This PR fixes several potential panic bugs and race conditions found in the codebase:

### 1. Race Condition in Desktop Server Shutdown (`crates/openfang-desktop/src/server.rs`)

**Problem**: Both `shutdown()` and `Drop` implementation tried to send shutdown signals and join threads, which could lead to race conditions when both try to manipulate the same resources simultaneously.

**Fix**: 
- Added `AtomicBool` flag (`shutdown_initiated`) to track shutdown state
- Both `shutdown()` and `Drop` now use `compare_exchange` to ensure shutdown only happens once
- This prevents duplicate shutdown attempts and potential race conditions

### 2. String Slicing Panic (`crates/openfang-api/src/channel_bridge.rs`)

**Problem**: Multiple locations used `&str[..8]` to truncate UUID strings for display without checking if the string was at least 8 characters long. While UUIDs are always 36 characters, this pattern is unsafe and could cause panics if the data changes.

**Fix**:
- Added `truncate_str()` helper function that safely returns the full string if it's shorter than the requested length
- Fixed 9 occurrences at lines: 354, 393, 408, 431, 491, 513, 545, 565, 609

### 3. String Slicing Panic (`crates/openfang-runtime/src/tool_runner.rs`)

**Problem**: Canvas filename generation used `&canvas_id[..8]` without checking length.

**Fix**: 
- Added length check before slicing
- Falls back to full string if shorter than 8 characters

## Test Plan

- [x] Build passes: `cargo build --workspace`
- [x] Tests pass: `cargo test --workspace`
- [x] No new clippy warnings introduced
- [x] Manual code review of all changes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)