### PR TITLE
fix: default hourly cost quota should be unlimited (0.0), not $1.00

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -4656,8 +4656,8 @@ fn apply_budget_defaults(
     budget: &openfang_types::config::BudgetConfig,
     resources: &mut ResourceQuota,
 ) {
-    // Only override hourly if agent has the built-in default (1.0) and global is set
-    if budget.max_hourly_usd > 0.0 && resources.max_cost_per_hour_usd == 1.0 {
+    // Only override hourly if agent has unlimited default (0.0) and global is set
+    if budget.max_hourly_usd > 0.0 && resources.max_cost_per_hour_usd == 0.0 {
         resources.max_cost_per_hour_usd = budget.max_hourly_usd;
     }
     // Only override daily/monthly if agent has unlimited (0.0) and global is set

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -267,7 +267,7 @@ impl Default for ResourceQuota {
             max_tool_calls_per_minute: 60,
             max_llm_tokens_per_hour: 1_000_000,
             max_network_bytes_per_hour: 100 * 1024 * 1024, // 100 MB
-            max_cost_per_hour_usd: 1.0,
+            max_cost_per_hour_usd: 0.0,   // unlimited
             max_cost_per_day_usd: 0.0,   // unlimited
             max_cost_per_month_usd: 0.0, // unlimited
         }


### PR DESCRIPTION
## Summary

- Changed `ResourceQuota::default()` `max_cost_per_hour_usd` from `1.0` to `0.0` (unlimited), consistent with daily and monthly defaults
- Fixed `apply_budget_defaults()` in `kernel.rs` which compared against the old hardcoded `1.0` sentinel value

## Problem

When no quota is configured, `max_cost_per_hour_usd` defaults to `1.0` while `max_cost_per_day_usd` and `max_cost_per_month_usd` default to `0.0` (unlimited). This creates a hidden $1/hour cap that blocks agents unexpectedly.

## Test plan

- [x] Existing test `test_check_quota_zero_limit_skipped` validates that `0.0` means no enforcement
- [x] Tests `test_record_and_check_quota_under` and `test_check_quota_exceeded` set explicit values, unaffected

Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)