### PR TITLE
fix: set default User-Agent on OpenAI driver HTTP client

### DIFF
--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -25,7 +25,10 @@ impl OpenAIDriver {
         Self {
             api_key: Zeroizing::new(api_key),
             base_url,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .user_agent("OpenFang/1.0")
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             extra_headers: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

- `reqwest::Client::new()` does not set a `User-Agent` header by default
- Some OpenAI-compatible API providers and proxies reject requests without `User-Agent`, returning **405 errors**
- This sets `OpenFang/1.0` as a sensible default, with a graceful fallback to `reqwest::Client::new()` if the builder fails

## Changes

**File:** `crates/openfang-runtime/src/drivers/openai.rs` (1 file, +4 −1)

```rust
// Before
client: reqwest::Client::new(),

// After
client: reqwest::Client::builder()
    .user_agent("OpenFang/1.0")
    .build()
    .unwrap_or_else(|_| reqwest::Client::new()),
```

## Test plan

- [ ] Existing tests pass (no tests assert on User-Agent)
- [ ] Non-breaking, backward compatible — only adds a header that was previously absent
- [ ] Verified against providers that require User-Agent