### PR TITLE
fix(chat-ui): prevent Enter send during IME composition

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -735,7 +735,7 @@
                   <span class="text-xs" style="color:var(--danger)" x-text="formatRecordingTime()"></span>
                 </div>
                 <textarea id="msg-input" rows="1" :placeholder="recording ? 'Recording... release to send' : 'Message OpenFang... (/ for commands)'"
-                          @keydown.enter.prevent="if(!$event.shiftKey){if(showModelPicker && filteredModelPicker.length){pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else{sendMessage()}}"
+                          @keydown.enter.prevent="if(!$event.shiftKey && !$event.isComposing){if(showModelPicker && filteredModelPicker.length){pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else{sendMessage()}}"
                           @keydown.escape="showSlashMenu = false; showModelPicker = false"
                           @keydown.arrow-up.prevent="if(showModelPicker){modelPickerIdx = Math.max(0, modelPickerIdx - 1)}else if(showSlashMenu){slashIdx = Math.max(0, slashIdx - 1)}"
                           @keydown.arrow-down.prevent="if(showModelPicker){modelPickerIdx = Math.min(filteredModelPicker.length - 1, modelPickerIdx + 1)}else if(showSlashMenu){slashIdx = Math.min(filteredSlashCommands.length - 1, slashIdx + 1)}"


### PR DESCRIPTION
## Summary
Fix chat input Enter handling for CJK IME composition in the dashboard UI.

When users are composing text with an IME, pressing Enter should confirm the current candidate, not send the message.

## What changed
- Updated the chat textarea Enter handler in `crates/openfang-api/static/index_body.html`
- Added `!$event.isComposing` guard before calling `sendMessage()`

## Issue
Closes #429

## Validation
- Manual logic validation against browser IME behavior:
  - Enter sends only when `isComposing` is false
  - Shift+Enter behavior remains unchanged
- Local Rust checks were not runnable in this environment because `cargo` is not installed.
