### PR TITLE
Fix macOS CLI binary SIGKILL (Code Signature Invalid)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,33 @@ jobs:
       - name: Build CLI
         if: matrix.target != 'aarch64-unknown-linux-gnu'
         run: cargo build --release --target ${{ matrix.target }} --bin openfang
-      - name: Ad-hoc codesign CLI binary (macOS)
+      - name: Import macOS signing certificate
         if: runner.os == 'macOS'
-        run: codesign --force --sign - target/${{ matrix.target }}/release/openfang
+        env:
+          MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          echo "$MAC_CERT_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import $RUNNER_TEMP/certificate.p12 -P "$MAC_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          echo "APPLE_SIGNING_IDENTITY=$IDENTITY" >> $GITHUB_ENV
+          rm -f $RUNNER_TEMP/certificate.p12
+      - name: Codesign CLI binary (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+            --timestamp --options runtime \
+            target/${{ matrix.target }}/release/openfang
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
         run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,9 +110,15 @@ install() {
     tar xzf "$ARCHIVE" -C "$INSTALL_DIR"
     chmod +x "$INSTALL_DIR/openfang"
 
-    # Ad-hoc codesign on macOS (prevents SIGKILL on Apple Silicon)
-    if [ "$OS" = "darwin" ] && command -v codesign &>/dev/null; then
-        codesign --force --sign - "$INSTALL_DIR/openfang" 2>/dev/null || true
+    # macOS: strip quarantine/provenance attrs and re-sign for Apple Silicon
+    if [ "$OS" = "darwin" ]; then
+        xattr -cr "$INSTALL_DIR/openfang" 2>/dev/null || true
+        if command -v codesign &>/dev/null; then
+            if ! codesign --force --sign - "$INSTALL_DIR/openfang" 2>&1; then
+                echo "  Warning: codesign failed. Run manually:"
+                echo "    codesign --force --sign - \"$INSTALL_DIR/openfang\""
+            fi
+        fi
     fi
 
     # Add to PATH — detect the user's login shell


### PR DESCRIPTION
Fixes #452

## Summary

The CLI binary (`openfang`) is immediately killed on macOS Apple Silicon with `SIGKILL (Code Signature Invalid)` / `Taskgated Invalid Signature`. Two compounding issues in the release pipeline:

1. **`release.yml`:** The CLI binary is signed with `codesign --force --sign -` (ad-hoc) in CI. Ad-hoc signatures are machine-specific and invalid when transferred to another Mac. Meanwhile, the Tauri desktop app is properly signed with a Developer ID certificate + notarized.

2. **`install.sh`:** The install script tries to re-sign locally but silences ALL errors (`2>/dev/null || true`). It also doesn't strip extended attributes first (`com.apple.provenance`), which causes codesign to produce an invalid result on newer macOS versions.

## Changes

### `scripts/install.sh`
- Strip quarantine/provenance extended attributes (`xattr -cr`) before codesigning
- Surface codesign errors instead of silencing them, with a manual fallback message

### `.github/workflows/release.yml`
- Replace ad-hoc signing with Developer ID certificate signing for the CLI binary
- Reuses the same `MAC_CERT_BASE64` / `MAC_CERT_PASSWORD` secrets already configured for the Tauri desktop build (lines 73-93)
- Adds `--timestamp` and `--options runtime` flags for proper signature

## Notes

- The `release.yml` change depends on the existing `MAC_CERT_BASE64` and `MAC_CERT_PASSWORD` CI secrets already configured for the desktop app build
- The `install.sh` fix works independently and will improve the experience even before the CI change takes effect

## Immediate workaround (for users hitting this now)

```bash
xattr -cr ~/.openfang/bin/openfang
codesign --force --sign - ~/.openfang/bin/openfang
openfang --version
```

## Test plan

- [x] Verify `install.sh` strips xattrs and re-signs successfully on macOS ARM64
- [x] Verify `install.sh` shows error message if codesign fails (instead of silent failure)
- [x] Verify `release.yml` CI signs CLI binary with Developer ID on macOS runners
- [x] Verify downloaded CLI binary runs without SIGKILL on a fresh macOS Apple Silicon machine