### PR TITLE
Fix CSP: add 'unsafe-eval' to script-src for dashboard

### DIFF
--- a/crates/openfang-api/src/middleware.rs
+++ b/crates/openfang-api/src/middleware.rs
@@ -202,7 +202,7 @@ pub async fn security_headers(request: Request<Body>, next: Next) -> Response<Bo
     // All JS/CSS is bundled inline — only external resource is Google Fonts.
     headers.insert(
         "content-security-policy",
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; font-src 'self' https://fonts.gstatic.com; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; font-src 'self' https://fonts.gstatic.com; media-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
             .parse()
             .unwrap(),
     );


### PR DESCRIPTION
## Summary

- Adds `'unsafe-eval'` to the `script-src` directive in the Content-Security-Policy header
- The dashboard's inline JS framework (Alpine.js/Petite-Vue) uses `new AsyncFunction()`, which requires `'unsafe-eval'` — without it the browser blocks execution and throws dozens of `EvalError` console errors

## Changed file

`crates/openfang-api/src/middleware.rs` — one-line change in `security_headers()` middleware

## Verification

```bash
curl -sI http://127.0.0.1:4200/ | grep -i content-security-policy
```

Should now include `script-src 'self' 'unsafe-inline' 'unsafe-eval'` and the dashboard should load without `EvalError` console errors.