### PR TITLE
feat(runtime): generic CLI exec driver for LLM providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-api"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "axum",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-channels"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "axum",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-cli"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-desktop"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "axum",
  "open",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-extensions"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-hands"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-kernel"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-memory"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-migrate"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-runtime"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-skills"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "chrono",
  "hex",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-types"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "openfang-wire"
-version = "0.3.30"
+version = "0.3.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8821,7 +8821,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "0.3.30"
+version = "0.3.32"
 
 [[package]]
 name = "yoke"

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -6817,6 +6817,7 @@ pub async fn test_provider(
         } else {
             Some(base_url)
         },
+        cli_backend_config: None,
     };
 
     match openfang_runtime::drivers::create_driver(&driver_config) {

--- a/crates/openfang-api/tests/api_integration_test.rs
+++ b/crates/openfang-api/tests/api_integration_test.rs
@@ -61,6 +61,7 @@ async fn start_test_server_with_provider(
             model: model.to_string(),
             api_key_env: api_key_env.to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     };
@@ -689,6 +690,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
             model: "test-model".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/openfang-api/tests/daemon_lifecycle_test.rs
@@ -98,6 +98,7 @@ async fn test_full_daemon_lifecycle() {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     };
@@ -223,6 +224,7 @@ async fn test_server_immediate_responsiveness() {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-api/tests/load_test.rs
+++ b/crates/openfang-api/tests/load_test.rs
@@ -42,6 +42,7 @@ async fn start_test_server() -> TestServer {
             model: "test-model".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -555,6 +555,19 @@ impl OpenFangKernel {
                 .base_url
                 .clone()
                 .or_else(|| config.provider_urls.get(&config.default_model.provider).cloned()),
+            cli_backend_config: if config.default_model.provider == "cli-exec" {
+                config.default_model.cli_backend.as_ref().and_then(|id| {
+                    config.cli_backends.iter().find(|b| b.id == *id).cloned()
+                }).or_else(|| {
+                    // Fall back to built-in presets
+                    config.default_model.cli_backend.as_ref().and_then(|id| {
+                        openfang_runtime::drivers::cli_exec::builtin_backends()
+                            .into_iter().find(|b| b.id == *id)
+                    })
+                })
+            } else {
+                None
+            },
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -575,6 +588,7 @@ impl OpenFangKernel {
                         provider: provider.to_string(),
                         api_key: std::env::var(env_var).ok(),
                         base_url: config.provider_urls.get(provider).cloned(),
+                        cli_backend_config: None,
                     };
                     match drivers::create_driver(&auto_config) {
                         Ok(d) => {
@@ -616,6 +630,7 @@ impl OpenFangKernel {
                     .base_url
                     .clone()
                     .or_else(|| config.provider_urls.get(&fb.provider).cloned()),
+                cli_backend_config: None,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -3972,6 +3987,7 @@ impl OpenFangKernel {
                 provider: agent_provider.clone(),
                 api_key,
                 base_url,
+                cli_backend_config: None,
             };
 
             drivers::create_driver(&driver_config).map_err(|e| {
@@ -3995,6 +4011,7 @@ impl OpenFangKernel {
                         .base_url
                         .clone()
                         .or_else(|| self.config.provider_urls.get(&fb.provider).cloned()),
+                    cli_backend_config: None,
                 };
                 match drivers::create_driver(&config) {
                     Ok(d) => chain.push((d, fb.model.clone())),

--- a/crates/openfang-kernel/tests/integration_test.rs
+++ b/crates/openfang-kernel/tests/integration_test.rs
@@ -19,6 +19,7 @@ fn test_config() -> KernelConfig {
             model: "llama-3.3-70b-versatile".to_string(),
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/multi_agent_test.rs
+++ b/crates/openfang-kernel/tests/multi_agent_test.rs
@@ -19,6 +19,7 @@ fn test_config() -> KernelConfig {
             model: "llama-3.3-70b-versatile".to_string(),
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/wasm_agent_integration_test.rs
+++ b/crates/openfang-kernel/tests/wasm_agent_integration_test.rs
@@ -115,6 +115,7 @@ fn test_config(tmp: &tempfile::TempDir) -> KernelConfig {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/workflow_integration_test.rs
+++ b/crates/openfang-kernel/tests/workflow_integration_test.rs
@@ -24,6 +24,7 @@ fn test_config(provider: &str, model: &str, api_key_env: &str) -> KernelConfig {
             model: model.to_string(),
             api_key_env: api_key_env.to_string(),
             base_url: None,
+            cli_backend: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-runtime/src/drivers/cli_exec.rs
+++ b/crates/openfang-runtime/src/drivers/cli_exec.rs
@@ -1,0 +1,462 @@
+//! Generic CLI exec driver.
+//!
+//! Spawns any CLI tool as a subprocess, supporting configurable command, args,
+//! input mode (stdin vs arg), and output parsing (text vs JSON).
+//! This allows using CLI tools like `claude`, `codex`, `gemini` as LLM providers
+//! without needing direct API keys — the CLI handles its own authentication.
+
+use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmDriver, LlmError, StreamEvent};
+use async_trait::async_trait;
+use openfang_types::config::{CliBackendConfig, CliInputMode, CliOutputFormat};
+use openfang_types::message::{ContentBlock, Role, StopReason, TokenUsage};
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, warn};
+
+/// LLM driver that delegates to an arbitrary CLI tool.
+pub struct CliExecDriver {
+    config: CliBackendConfig,
+}
+
+impl CliExecDriver {
+    /// Create a new CLI exec driver from a backend config.
+    pub fn new(config: CliBackendConfig) -> Self {
+        Self { config }
+    }
+
+    /// Check if the configured command is available on PATH.
+    pub fn detect(command: &str) -> bool {
+        std::process::Command::new(command)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Build a text prompt from the completion request messages.
+    fn build_prompt(request: &CompletionRequest) -> String {
+        let mut parts = Vec::new();
+
+        if let Some(ref sys) = request.system {
+            parts.push(format!("[System]\n{sys}"));
+        }
+
+        for msg in &request.messages {
+            let role_label = match msg.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+                Role::System => "System",
+            };
+            let text = msg.content.text_content();
+            if !text.is_empty() {
+                parts.push(format!("[{role_label}]\n{text}"));
+            }
+        }
+
+        parts.join("\n\n")
+    }
+
+    /// Extract the raw model name from a qualified model ID.
+    ///
+    /// Strips "cli-exec/{backend_id}/" prefix if present.
+    /// Examples:
+    ///   "cli-exec/codex/gpt-5.4" → "gpt-5.4"
+    ///   "codex/gpt-5.4"          → "gpt-5.4"
+    ///   "gpt-5.4"                → "gpt-5.4"
+    ///   "opus"                   → "opus"
+    fn extract_model<'a>(model: &'a str, backend_id: &str) -> &'a str {
+        let stripped = model.strip_prefix("cli-exec/").unwrap_or(model);
+        let stripped = stripped
+            .strip_prefix(backend_id)
+            .and_then(|s| s.strip_prefix('/'))
+            .unwrap_or(stripped);
+        stripped
+    }
+
+    /// Extract text from a JSON value using configured field names.
+    fn extract_json_text(&self, value: &serde_json::Value) -> Option<String> {
+        for field in &self.config.json_text_fields {
+            if let Some(serde_json::Value::String(s)) = value.get(field) {
+                if !s.is_empty() {
+                    return Some(s.clone());
+                }
+            }
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl LlmDriver for CliExecDriver {
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse, LlmError> {
+        let prompt = Self::build_prompt(&request);
+        let model = Self::extract_model(&request.model, &self.config.id);
+
+        let mut cmd = tokio::process::Command::new(&self.config.command);
+
+        // Add configured args
+        for arg in &self.config.args {
+            cmd.arg(arg);
+        }
+
+        // Add model flag if configured
+        if !self.config.model_arg.is_empty() && !model.is_empty() {
+            cmd.arg(&self.config.model_arg).arg(model);
+        }
+
+        // Handle input mode
+        match self.config.input {
+            CliInputMode::Arg => {
+                cmd.arg(&prompt);
+                cmd.stdin(std::process::Stdio::null());
+            }
+            CliInputMode::Stdin => {
+                cmd.stdin(std::process::Stdio::piped());
+            }
+        }
+
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        // Inherit safe env vars only — explicitly exclude CLAUDECODE so nested
+        // claude CLI invocations are not blocked by the parent process guard.
+        cmd.env_clear();
+        for var in &["PATH", "HOME", "USER", "LANG", "TERM", "SHELL", "TMPDIR",
+                     "XDG_CONFIG_HOME", "XDG_DATA_HOME"] {
+            if let Ok(val) = std::env::var(var) {
+                cmd.env(var, val);
+            }
+        }
+
+        debug!(
+            command = %self.config.command,
+            backend = %self.config.id,
+            model = %model,
+            "Spawning CLI exec"
+        );
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| LlmError::Http(format!(
+                "Failed to spawn '{}': {e}. Is it installed?",
+                self.config.command
+            )))?;
+
+        // Write prompt to stdin if needed
+        if matches!(self.config.input, CliInputMode::Stdin) {
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(prompt.as_bytes()).await.map_err(|e| {
+                    LlmError::Http(format!("Failed to write to stdin: {e}"))
+                })?;
+                drop(stdin);
+            }
+        }
+
+        // Apply timeout
+        let timeout_duration = if self.config.timeout_secs > 0 {
+            std::time::Duration::from_secs(self.config.timeout_secs)
+        } else {
+            std::time::Duration::from_secs(600)
+        };
+
+        let output = tokio::time::timeout(timeout_duration, child.wait_with_output())
+            .await
+            .map_err(|_| LlmError::Http(format!(
+                "CLI '{}' timed out after {}s",
+                self.config.command, self.config.timeout_secs
+            )))?
+            .map_err(|e| LlmError::Http(format!(
+                "CLI '{}' failed: {e}",
+                self.config.command
+            )))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            warn!(
+                command = %self.config.command,
+                code = ?output.status.code(),
+                stderr = %stderr,
+                "CLI exec failed"
+            );
+            // Some CLIs print the result to stdout even with non-zero exit
+            if !stdout.trim().is_empty() {
+                return Ok(CompletionResponse {
+                    content: vec![ContentBlock::Text {
+                        text: stdout.trim().to_string(),
+                    }],
+                    stop_reason: StopReason::EndTurn,
+                    tool_calls: Vec::new(),
+                    usage: TokenUsage::default(),
+                });
+            }
+            return Err(LlmError::Api {
+                status: output.status.code().unwrap_or(1) as u16,
+                message: format!("CLI '{}' failed: {stderr}", self.config.command),
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Parse output based on format
+        let text = match self.config.output {
+            CliOutputFormat::Json => {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout) {
+                    self.extract_json_text(&parsed)
+                        .unwrap_or_else(|| stdout.trim().to_string())
+                } else {
+                    stdout.trim().to_string()
+                }
+            }
+            CliOutputFormat::Text => stdout.trim().to_string(),
+        };
+
+        Ok(CompletionResponse {
+            content: vec![ContentBlock::Text { text }],
+            stop_reason: StopReason::EndTurn,
+            tool_calls: Vec::new(),
+            usage: TokenUsage::default(),
+        })
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+        tx: tokio::sync::mpsc::Sender<StreamEvent>,
+    ) -> Result<CompletionResponse, LlmError> {
+        // Generic CLIs don't support streaming — delegate to complete()
+        let response = self.complete(request).await?;
+        let text = response.text();
+        if !text.is_empty() {
+            let _ = tx.send(StreamEvent::TextDelta { text }).await;
+        }
+        let _ = tx
+            .send(StreamEvent::ContentComplete {
+                stop_reason: response.stop_reason,
+                usage: response.usage,
+            })
+            .await;
+        Ok(response)
+    }
+}
+
+/// Built-in CLI backend presets for common tools.
+pub fn builtin_backends() -> Vec<CliBackendConfig> {
+    vec![
+        CliBackendConfig {
+            id: "claude-code".into(),
+            command: "claude".into(),
+            args: vec!["--print".into()],
+            output: CliOutputFormat::Json,
+            input: CliInputMode::Stdin,
+            model_arg: "--model".into(),
+            json_text_fields: vec!["result".into(), "content".into(), "text".into()],
+            timeout_secs: 300,
+        },
+        CliBackendConfig {
+            id: "codex".into(),
+            command: "codex".into(),
+            args: vec!["exec".into()],
+            output: CliOutputFormat::Text,
+            input: CliInputMode::Arg,
+            model_arg: "--model".into(),
+            json_text_fields: vec![],
+            timeout_secs: 300,
+        },
+        CliBackendConfig {
+            id: "gemini".into(),
+            command: "gemini".into(),
+            args: vec!["-p".into()],
+            output: CliOutputFormat::Text,
+            input: CliInputMode::Arg,
+            model_arg: "--model".into(),
+            json_text_fields: vec![],
+            timeout_secs: 300,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openfang_types::message::{Message, MessageContent};
+
+    fn test_config() -> CliBackendConfig {
+        CliBackendConfig {
+            id: "test-cli".into(),
+            command: "echo".into(),
+            args: vec![],
+            output: CliOutputFormat::Text,
+            input: CliInputMode::Arg,
+            model_arg: "--model".into(),
+            json_text_fields: vec!["result".into(), "text".into()],
+            timeout_secs: 10,
+        }
+    }
+
+    #[test]
+    fn test_extract_model_full_prefix() {
+        assert_eq!(
+            CliExecDriver::extract_model("cli-exec/codex/gpt-5.4", "codex"),
+            "gpt-5.4"
+        );
+    }
+
+    #[test]
+    fn test_extract_model_backend_prefix() {
+        assert_eq!(
+            CliExecDriver::extract_model("codex/gpt-5.4", "codex"),
+            "gpt-5.4"
+        );
+    }
+
+    #[test]
+    fn test_extract_model_raw() {
+        assert_eq!(
+            CliExecDriver::extract_model("opus", "claude-code"),
+            "opus"
+        );
+    }
+
+    #[test]
+    fn test_extract_model_claude_code() {
+        assert_eq!(
+            CliExecDriver::extract_model("cli-exec/claude-code/opus", "claude-code"),
+            "opus"
+        );
+    }
+
+    #[test]
+    fn test_build_prompt() {
+        let request = CompletionRequest {
+            model: "test".into(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::text("Hello"),
+            }],
+            tools: vec![],
+            max_tokens: 1024,
+            temperature: 0.7,
+            system: Some("Be helpful.".into()),
+            thinking: None,
+        };
+
+        let prompt = CliExecDriver::build_prompt(&request);
+        assert!(prompt.contains("[System]"));
+        assert!(prompt.contains("Be helpful."));
+        assert!(prompt.contains("[User]"));
+        assert!(prompt.contains("Hello"));
+    }
+
+    #[test]
+    fn test_extract_json_text() {
+        let driver = CliExecDriver::new(test_config());
+        let value = serde_json::json!({"result": "Hello world", "other": 42});
+        assert_eq!(driver.extract_json_text(&value), Some("Hello world".into()));
+    }
+
+    #[test]
+    fn test_extract_json_text_fallback_field() {
+        let driver = CliExecDriver::new(test_config());
+        let value = serde_json::json!({"text": "Fallback text"});
+        assert_eq!(driver.extract_json_text(&value), Some("Fallback text".into()));
+    }
+
+    #[test]
+    fn test_extract_json_text_none() {
+        let driver = CliExecDriver::new(test_config());
+        let value = serde_json::json!({"unrelated": "data"});
+        assert_eq!(driver.extract_json_text(&value), None);
+    }
+
+    #[test]
+    fn test_detect_missing_binary() {
+        assert!(!CliExecDriver::detect("nonexistent_binary_xxx_12345"));
+    }
+
+    #[test]
+    fn test_new_from_config() {
+        let config = test_config();
+        let driver = CliExecDriver::new(config.clone());
+        assert_eq!(driver.config.id, "test-cli");
+        assert_eq!(driver.config.command, "echo");
+    }
+
+    #[tokio::test]
+    async fn test_complete_with_echo() {
+        let config = CliBackendConfig {
+            id: "echo-test".into(),
+            command: "echo".into(),
+            args: vec![],
+            output: CliOutputFormat::Text,
+            input: CliInputMode::Arg,
+            model_arg: String::new(),
+            json_text_fields: vec![],
+            timeout_secs: 5,
+        };
+        let driver = CliExecDriver::new(config);
+
+        let request = CompletionRequest {
+            model: "test".into(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::text("hello world"),
+            }],
+            tools: vec![],
+            max_tokens: 100,
+            temperature: 0.0,
+            system: None,
+            thinking: None,
+        };
+
+        let response = driver.complete(request).await.unwrap();
+        let text = response.text();
+        assert!(text.contains("hello world"));
+    }
+
+    /// Live integration test with real claude CLI.
+    /// Run with: OPENFANG_LIVE_CLI_TEST=1 cargo test -p openfang-runtime test_live_claude_cli -- --nocapture
+    #[tokio::test]
+    async fn test_live_claude_cli() {
+        if std::env::var("OPENFANG_LIVE_CLI_TEST").is_err() {
+            eprintln!("OPENFANG_LIVE_CLI_TEST not set, skipping live CLI test");
+            return;
+        }
+
+        let backends = super::builtin_backends();
+        let claude_config = backends
+            .into_iter()
+            .find(|b| b.id == "claude-code")
+            .expect("claude-code backend should exist");
+
+        let driver = CliExecDriver::new(claude_config);
+
+        let request = CompletionRequest {
+            model: "cli-exec/claude-code/claude-sonnet-4-6".into(),
+            messages: vec![Message {
+                role: Role::User,
+                content: MessageContent::text("Respond with exactly one word: PONG"),
+            }],
+            tools: vec![],
+            max_tokens: 50,
+            temperature: 0.0,
+            system: Some("You respond with exactly the word requested, nothing else.".into()),
+            thinking: None,
+        };
+
+        let response = driver.complete(request).await;
+        assert!(response.is_ok(), "Claude CLI should succeed: {:?}", response.err());
+        let resp = response.unwrap();
+        let text = resp.text();
+        eprintln!("Claude CLI response: {text:?}");
+        assert!(!text.is_empty(), "Response should not be empty");
+        assert!(
+            text.to_uppercase().contains("PONG"),
+            "Response should contain PONG, got: {text}"
+        );
+    }
+}

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod anthropic;
 pub mod claude_code;
+pub mod cli_exec;
 pub mod copilot;
 pub mod fallback;
 pub mod gemini;
@@ -146,6 +147,11 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
             key_required: true,
         }),
         "claude-code" => Some(ProviderDefaults {
+            base_url: "",
+            api_key_env: "",
+            key_required: false,
+        }),
+        "cli-exec" => Some(ProviderDefaults {
             base_url: "",
             api_key_env: "",
             key_required: false,
@@ -295,6 +301,19 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
         return Ok(Arc::new(claude_code::ClaudeCodeDriver::new(cli_path)));
     }
 
+    // Generic CLI exec — configurable subprocess-based provider
+    if provider == "cli-exec" {
+        let backend_config = config.cli_backend_config.clone().ok_or_else(|| {
+            LlmError::Api {
+                status: 0,
+                message: "cli-exec provider requires a cli_backend_config. \
+                    Configure [[cli_backends]] in config.toml and set \
+                    cli_backend = \"<id>\" in [default_model].".to_string(),
+            }
+        })?;
+        return Ok(Arc::new(cli_exec::CliExecDriver::new(backend_config)));
+    }
+
     // GitHub Copilot — wraps OpenAI-compatible driver with automatic token exchange.
     // The CopilotDriver exchanges the GitHub PAT for a Copilot API token on demand,
     // caches it, and refreshes when expired.
@@ -428,6 +447,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "venice",
         "codex",
         "claude-code",
+        "cli-exec",
     ]
 }
 
@@ -467,6 +487,7 @@ mod tests {
             provider: "my-custom-llm".to_string(),
             api_key: Some("test".to_string()),
             base_url: Some("http://localhost:9999/v1".to_string()),
+            cli_backend_config: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -478,6 +499,7 @@ mod tests {
             provider: "nonexistent".to_string(),
             api_key: None,
             base_url: None,
+            cli_backend_config: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -524,7 +546,8 @@ mod tests {
         assert!(providers.contains(&"volcengine"));
         assert!(providers.contains(&"codex"));
         assert!(providers.contains(&"claude-code"));
-        assert_eq!(providers.len(), 31);
+        assert!(providers.contains(&"cli-exec"));
+        assert_eq!(providers.len(), 32);
     }
 
     #[test]

--- a/crates/openfang-runtime/src/embedding.rs
+++ b/crates/openfang-runtime/src/embedding.rs
@@ -192,6 +192,7 @@ pub fn create_embedding_driver(
         .map(|u| u.to_string())
         .unwrap_or_else(|| match provider {
             "openai" => OPENAI_BASE_URL.to_string(),
+            "openrouter" => "https://openrouter.ai/api/v1".to_string(),
             "groq" => GROQ_BASE_URL.to_string(),
             "together" => TOGETHER_BASE_URL.to_string(),
             "fireworks" => FIREWORKS_BASE_URL.to_string(),

--- a/crates/openfang-runtime/src/llm_driver.rs
+++ b/crates/openfang-runtime/src/llm_driver.rs
@@ -167,6 +167,9 @@ pub struct DriverConfig {
     pub api_key: Option<String>,
     /// Base URL override.
     pub base_url: Option<String>,
+    /// CLI backend configuration (only used when provider = "cli-exec").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli_backend_config: Option<openfang_types::config::CliBackendConfig>,
 }
 
 /// SECURITY: Custom Debug impl redacts the API key.
@@ -176,6 +179,7 @@ impl std::fmt::Debug for DriverConfig {
             .field("provider", &self.provider)
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .field("base_url", &self.base_url)
+            .field("cli_backend_config", &self.cli_backend_config.as_ref().map(|c| &c.id))
             .finish()
     }
 }

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -404,6 +404,75 @@ pub struct FallbackProviderConfig {
     pub base_url: Option<String>,
 }
 
+/// CLI output format.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliOutputFormat {
+    /// Plain text output — use stdout as-is.
+    #[default]
+    Text,
+    /// JSON output — parse and extract text field.
+    Json,
+}
+
+/// How the prompt is passed to the CLI.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliInputMode {
+    /// Pass prompt as a positional argument (last arg).
+    #[default]
+    Arg,
+    /// Send prompt via stdin.
+    Stdin,
+}
+
+/// Configuration for a CLI-based LLM backend.
+///
+/// Configure in config.toml:
+/// ```toml
+/// [[cli_backends]]
+/// id = "codex"
+/// command = "codex"
+/// args = ["exec"]
+/// output = "text"
+/// input = "arg"
+/// model_arg = "--model"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliBackendConfig {
+    /// Unique identifier (used in model refs: "cli-exec/<id>/<model>").
+    pub id: String,
+    /// Command to execute (binary name or absolute path).
+    pub command: String,
+    /// Default arguments passed before the prompt.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Output format: "text" or "json".
+    #[serde(default)]
+    pub output: CliOutputFormat,
+    /// Input mode: "arg" (prompt as last CLI arg) or "stdin" (prompt piped to stdin).
+    #[serde(default)]
+    pub input: CliInputMode,
+    /// CLI flag for specifying the model (e.g., "--model"). Empty = don't pass model.
+    #[serde(default)]
+    pub model_arg: String,
+    /// JSON field names to extract text from when output = "json".
+    /// Tried in order; first non-null wins.
+    #[serde(default = "default_json_text_fields")]
+    pub json_text_fields: Vec<String>,
+    /// Optional timeout in seconds (0 = no timeout). Default: 300.
+    #[serde(default = "default_cli_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_json_text_fields() -> Vec<String> {
+    vec!["result".into(), "content".into(), "text".into()]
+}
+
+fn default_cli_timeout() -> u64 {
+    300
+}
+
 /// Text-to-speech configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1065,6 +1134,9 @@ pub struct KernelConfig {
     /// OAuth client ID overrides for PKCE flows.
     #[serde(default)]
     pub oauth: OAuthConfig,
+    /// CLI backend configurations for the "cli-exec" provider.
+    #[serde(default)]
+    pub cli_backends: Vec<CliBackendConfig>,
 }
 
 /// OAuth client ID overrides for PKCE flows.
@@ -1236,6 +1308,7 @@ impl Default for KernelConfig {
             budget: BudgetConfig::default(),
             provider_urls: HashMap::new(),
             oauth: OAuthConfig::default(),
+            cli_backends: Vec::new(),
         }
     }
 }
@@ -1348,7 +1421,7 @@ fn openfang_home_dir() -> PathBuf {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DefaultModelConfig {
-    /// Provider name (e.g., "anthropic", "openai").
+    /// Provider name (e.g., "anthropic", "openai", "cli-exec").
     pub provider: String,
     /// Model identifier.
     pub model: String,
@@ -1356,6 +1429,9 @@ pub struct DefaultModelConfig {
     pub api_key_env: String,
     /// Optional base URL override.
     pub base_url: Option<String>,
+    /// CLI backend ID when provider = "cli-exec".
+    #[serde(default)]
+    pub cli_backend: Option<String>,
 }
 
 impl Default for DefaultModelConfig {
@@ -1365,6 +1441,7 @@ impl Default for DefaultModelConfig {
             model: "claude-sonnet-4-20250514".to_string(),
             api_key_env: "ANTHROPIC_API_KEY".to_string(),
             base_url: None,
+            cli_backend: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **New `CliExecDriver`** — spawns CLI tools (claude, codex, gemini) as LLM provider subprocesses, bypassing direct API keys entirely. The CLI handles its own OAuth/token authentication.
- **Builtin presets** for `claude-code`, `codex`, `gemini` with configurable command, args, input mode (stdin/arg), output format (text/json), timeout.
- **`CliBackendConfig`** type in `openfang-types` with full serde support, integrated into `KernelConfig` and `DefaultModelConfig`.
- **OpenRouter** added as embedding provider for memory/RAG vector search.

## Config example

```toml
[default_model]
provider = "cli-exec"
model = "claude-opus-4-6"
cli_backend = "claude-code"

# Or switch to codex/gemini by changing cli_backend and model:
# cli_backend = "codex"
# model = "gpt-5.4"
```

## Test plan

- [x] `cargo test -p openfang-runtime` — 684 passed, 0 failed
- [x] `cargo test -p openfang-kernel -p openfang-api` — 289 passed, 0 failed
- [x] `cargo clippy --workspace` — 0 warnings
- [x] Live test: `CliExecDriver` → `claude --print` → PONG response
- [x] E2E daemon: HTTP API → kernel → cli-exec → claude CLI → Opus 4.6 → Telegram bot response
- [x] Embedding via OpenRouter — no more 401 errors