### PR TITLE
fix: concurrent message dispatch to prevent voice message loss

### DIFF
--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -306,13 +306,23 @@ impl BridgeManager {
                     msg = stream.next() => {
                         match msg {
                             Some(message) => {
-                                dispatch_message(
-                                    &message,
-                                    &handle,
-                                    &router,
-                                    adapter_clone.as_ref(),
-                                    &rate_limiter,
-                                ).await;
+                                // Spawn each dispatch concurrently so that slow LLM calls
+                                // don't block subsequent messages in the stream.
+                                // Fixes: multiple messages sent in quick succession being
+                                // effectively lost because dispatch was sequential.
+                                let h = handle.clone();
+                                let r = router.clone();
+                                let a = adapter_clone.clone();
+                                let rl = rate_limiter.clone();
+                                tokio::spawn(async move {
+                                    dispatch_message(
+                                        &message,
+                                        &h,
+                                        &r,
+                                        a.as_ref(),
+                                        &rl,
+                                    ).await;
+                                });
                             }
                             None => {
                                 info!("Channel adapter {} stream ended", adapter_clone.name());


### PR DESCRIPTION
## Summary

- **Spawns `dispatch_message` as a concurrent task** instead of awaiting it sequentially in the stream loop
- Prevents messages from being lost when multiple arrive in quick succession (e.g. 3 voice messages within seconds)
- Each dispatch runs independently so slow LLM calls (10-30s+) don't block the polling loop

## Problem

`dispatch_message()` in `bridge.rs` was awaited inline, blocking the stream loop. When a user sends 3 voice messages rapidly, message 1 triggers an LLM call that takes ~20s. Messages 2 and 3 sit in the mpsc buffer and are only processed after the LLM finishes — making them appear "lost" from the user's perspective.

## Changes

- `crates/openfang-channels/src/bridge.rs`: Clone `Arc` handles and spawn dispatch as a `tokio::spawn` task

## Test plan

- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Manual test: send 3 voice messages in quick succession via Telegram, verify all 3 get responses

Fixes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)