### PR TITLE
feat: full Claude Code OAuth provider support

### DIFF
--- a/crates/openfang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/init_wizard.rs
@@ -280,6 +280,19 @@ enum KeyTestState {
     Warn,
 }
 
+/// Sub-state for the Anthropic auth method picker (shown before key entry).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AnthropicAuthMode {
+    /// Show "API key / Claude Code OAuth" choice list.
+    Pick,
+    /// User chose API key — show the key entry UI.
+    EnterKey,
+    /// User chose OAuth and the credentials file is present.
+    OAuthReady,
+    /// User chose OAuth but the credentials file is missing.
+    OAuthMissing,
+}
+
 /// A model entry for list display.
 struct ModelEntry {
     id: String,
@@ -314,9 +327,12 @@ struct State {
     provider_order: Vec<usize>,
     selected_provider: Option<usize>,
 
-    // API key
+    // API key / auth method
+    anthropic_auth_mode: AnthropicAuthMode,
+    anthropic_auth_list: ListState,
     api_key_input: String,
     api_key_from_env: bool,
+    use_claude_code_oauth: bool,
     key_test: KeyTestState,
     key_test_started: Option<Instant>,
 
@@ -359,8 +375,11 @@ impl State {
             provider_list: ListState::default(),
             provider_order: Vec::new(),
             selected_provider: None,
+            anthropic_auth_mode: AnthropicAuthMode::Pick,
+            anthropic_auth_list: ListState::default(),
             api_key_input: String::new(),
             api_key_from_env: false,
+            use_claude_code_oauth: false,
             key_test: KeyTestState::Idle,
             key_test_started: None,
             model_input: String::new(),
@@ -451,6 +470,8 @@ impl State {
         }
         (!p.env_var.is_empty() && std::env::var(p.env_var).is_ok())
             || (p.name == "gemini" && std::env::var("GOOGLE_API_KEY").is_ok())
+            || (p.name == "anthropic"
+                && openfang_runtime::model_catalog::read_claude_oauth_token().is_some())
     }
 
     /// Populate model_entries from the catalog for the selected provider.
@@ -493,6 +514,39 @@ impl State {
             });
         }
 
+        self.model_list.select(Some(default_idx));
+    }
+
+    /// Populate model_entries from the catalog for an arbitrary provider name string.
+    fn load_models_for_provider_name(&mut self, provider_name: &str) {
+        self.model_entries.clear();
+        let models = self.model_catalog.models_by_provider(provider_name);
+        let mut default_idx = 0usize;
+        for (i, m) in models.iter().enumerate() {
+            let tier = tier_label(m.tier);
+            let cost = if m.input_cost_per_m == 0.0 && m.output_cost_per_m == 0.0 {
+                "free".to_string()
+            } else {
+                format!("${:.2}/${:.2}", m.input_cost_per_m, m.output_cost_per_m)
+            };
+            if i == 0 {
+                default_idx = 0;
+            }
+            self.model_entries.push(ModelEntry {
+                id: m.id.clone(),
+                display_name: m.display_name.clone(),
+                tier,
+                cost,
+            });
+        }
+        if self.model_entries.is_empty() {
+            self.model_entries.push(ModelEntry {
+                id: "claude-sonnet-4-20250514".to_string(),
+                display_name: "claude-sonnet-4-20250514".to_string(),
+                tier: "default",
+                cost: String::new(),
+            });
+        }
         self.model_list.select(Some(default_idx));
     }
 
@@ -744,16 +798,37 @@ pub fn run() -> InitResult {
 
                                 if !p.needs_key {
                                     state.api_key_from_env = false;
+                                    state.use_claude_code_oauth = false;
                                     state.load_models_for_provider();
+                                    state.step = Step::Model;
+                                } else if p.name == "anthropic"
+                                    && std::env::var(p.env_var)
+                                        .ok()
+                                        .filter(|v| !v.is_empty())
+                                        .is_none()
+                                    && openfang_runtime::model_catalog::read_claude_oauth_token()
+                                        .is_some()
+                                {
+                                    // Detected via OAuth token only — route through claude-code
+                                    state.use_claude_code_oauth = true;
+                                    state.api_key_from_env = false;
+                                    state.load_models_for_provider_name("claude-code");
                                     state.step = Step::Model;
                                 } else if state.is_provider_detected(prov_idx) {
                                     state.api_key_from_env = true;
+                                    state.use_claude_code_oauth = false;
                                     state.load_models_for_provider();
                                     state.step = Step::Model;
                                 } else {
                                     state.api_key_from_env = false;
+                                    state.use_claude_code_oauth = false;
                                     state.api_key_input.clear();
                                     state.key_test = KeyTestState::Idle;
+                                    // Anthropic supports OAuth — show method picker first.
+                                    if p.name == "anthropic" {
+                                        state.anthropic_auth_mode = AnthropicAuthMode::Pick;
+                                        state.anthropic_auth_list.select(Some(0));
+                                    }
                                     state.step = Step::ApiKey;
                                 }
                             }
@@ -762,6 +837,88 @@ pub fn run() -> InitResult {
                     },
 
                     Step::ApiKey => {
+                        // ── Anthropic auth-method picker ──
+                        let is_anthropic = state
+                            .provider()
+                            .map(|p| p.name == "anthropic")
+                            .unwrap_or(false);
+                        if is_anthropic
+                            && state.anthropic_auth_mode == AnthropicAuthMode::Pick
+                        {
+                            match key.code {
+                                KeyCode::Esc => {
+                                    state.step = Step::Provider;
+                                }
+                                KeyCode::Up | KeyCode::Char('k') => {
+                                    let i =
+                                        state.anthropic_auth_list.selected().unwrap_or(0);
+                                    state.anthropic_auth_list.select(Some(if i == 0 { 1 } else { 0 }));
+                                }
+                                KeyCode::Down | KeyCode::Char('j') => {
+                                    let i =
+                                        state.anthropic_auth_list.selected().unwrap_or(0);
+                                    state.anthropic_auth_list.select(Some(if i == 0 { 1 } else { 0 }));
+                                }
+                                KeyCode::Enter => {
+                                    match state.anthropic_auth_list.selected() {
+                                        Some(0) => {
+                                            // API key
+                                            state.anthropic_auth_mode =
+                                                AnthropicAuthMode::EnterKey;
+                                        }
+                                        _ => {
+                                            // OAuth
+                                            if openfang_runtime::model_catalog::read_claude_oauth_token()
+                                                .is_some()
+                                            {
+                                                state.anthropic_auth_mode =
+                                                    AnthropicAuthMode::OAuthReady;
+                                            } else {
+                                                state.anthropic_auth_mode =
+                                                    AnthropicAuthMode::OAuthMissing;
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
+
+                        // ── OAuth ready — just confirm and advance ──
+                        if is_anthropic
+                            && matches!(
+                                state.anthropic_auth_mode,
+                                AnthropicAuthMode::OAuthReady | AnthropicAuthMode::OAuthMissing
+                            )
+                        {
+                            match key.code {
+                                KeyCode::Esc => {
+                                    state.use_claude_code_oauth = false;
+                                    state.anthropic_auth_mode = AnthropicAuthMode::Pick;
+                                }
+                                KeyCode::Enter => {
+                                    if state.anthropic_auth_mode == AnthropicAuthMode::OAuthReady {
+                                        state.use_claude_code_oauth = true;
+                                        state.api_key_from_env = false;
+                                        state.load_models_for_provider_name("claude-code");
+                                        state.step = Step::Model;
+                                    } else {
+                                        // Re-check in case the user just ran `claude`
+                                        if openfang_runtime::model_catalog::read_claude_oauth_token()
+                                            .is_some()
+                                        {
+                                            state.anthropic_auth_mode =
+                                                AnthropicAuthMode::OAuthReady;
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
+
+                        // ── Regular API key entry ──
                         if matches!(state.key_test, KeyTestState::Ok | KeyTestState::Warn) {
                             continue;
                         }
@@ -769,7 +926,11 @@ pub fn run() -> InitResult {
                         match key.code {
                             KeyCode::Esc => {
                                 state.key_test = KeyTestState::Idle;
-                                state.step = Step::Provider;
+                                if is_anthropic {
+                                    state.anthropic_auth_mode = AnthropicAuthMode::Pick;
+                                } else {
+                                    state.step = Step::Provider;
+                                }
                             }
                             KeyCode::Enter => {
                                 if !state.api_key_input.is_empty()
@@ -1110,10 +1271,15 @@ complex_threshold = 500
     };
 
     let config_path = openfang_dir.join("config.toml");
-    let api_key_line = if p.env_var.is_empty() {
+    let (provider_str, env_var_str) = if state.use_claude_code_oauth {
+        ("claude-code".to_string(), String::new())
+    } else {
+        (p.name.to_string(), p.env_var.to_string())
+    };
+    let api_key_line = if env_var_str.is_empty() {
         String::new()
     } else {
-        format!("api_key_env = \"{}\"", p.env_var)
+        format!("api_key_env = \"{}\"", env_var_str)
     };
 
     let config = format!(
@@ -1130,7 +1296,7 @@ model = "{model}"
 [memory]
 decay_rate = 0.05
 {routing_section}"#,
-        provider = p.name,
+        provider = provider_str,
     );
 
     match std::fs::write(&config_path, &config) {
@@ -1734,7 +1900,14 @@ fn draw_provider(f: &mut Frame, area: Rect, state: &mut State) {
                     "no API key needed".to_string()
                 }
             } else if detected {
-                format!("{} detected", p.env_var)
+                if p.name == "anthropic"
+                    && std::env::var(p.env_var).is_err()
+                    && openfang_runtime::model_catalog::read_claude_oauth_token().is_some()
+                {
+                    "Claude Code OAuth detected".to_string()
+                } else {
+                    format!("{} detected", p.env_var)
+                }
             } else if !p.needs_key {
                 "local, no key needed".to_string()
             } else if !p.hint.is_empty() {
@@ -1768,6 +1941,24 @@ fn draw_api_key(f: &mut Frame, area: Rect, state: &mut State) {
         None => return,
     };
 
+    // ── Anthropic: auth method picker ──────────────────────────────────────
+    if p.name == "anthropic" && state.anthropic_auth_mode == AnthropicAuthMode::Pick {
+        draw_anthropic_auth_pick(f, area, state);
+        return;
+    }
+
+    // ── Anthropic: OAuth status screens ────────────────────────────────────
+    if p.name == "anthropic"
+        && matches!(
+            state.anthropic_auth_mode,
+            AnthropicAuthMode::OAuthReady | AnthropicAuthMode::OAuthMissing
+        )
+    {
+        draw_anthropic_oauth_status(f, area, state);
+        return;
+    }
+
+    // ── Standard API key entry ──────────────────────────────────────────────
     let chunks = Layout::vertical([
         Constraint::Length(2),
         Constraint::Length(1),
@@ -1853,6 +2044,127 @@ fn draw_api_key(f: &mut Frame, area: Rect, state: &mut State) {
             theme::hint_style(),
         )])),
         chunks[5],
+    );
+}
+
+fn draw_anthropic_auth_pick(f: &mut Frame, area: Rect, state: &mut State) {
+    let chunks = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(2),
+        Constraint::Length(1),
+    ])
+    .split(area);
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::raw(
+            "  How do you want to authenticate with Anthropic?",
+        )])),
+        chunks[0],
+    );
+
+    let oauth_available =
+        openfang_runtime::model_catalog::read_claude_oauth_token().is_some();
+    let oauth_hint = if oauth_available {
+        "token found in ~/.claude/.credentials.json"
+    } else {
+        "requires Claude Code to be signed in"
+    };
+
+    let options: &[(&str, &str)] = &[
+        ("API key", "paste your ANTHROPIC_API_KEY"),
+        ("Claude Code OAuth", oauth_hint),
+    ];
+
+    let items: Vec<ListItem> = options
+        .iter()
+        .map(|(label, hint)| {
+            ListItem::new(Line::from(vec![
+                Span::raw(format!("  {:<22}", label)),
+                Span::styled(*hint, theme::dim_style()),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .highlight_style(theme::selected_style())
+        .highlight_symbol("\u{25b8} ");
+    f.render_stateful_widget(list, chunks[1], &mut state.anthropic_auth_list);
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "  [\u{2191}\u{2193}/jk] Navigate  [Enter] Select  [Esc] Back",
+            theme::hint_style(),
+        )])),
+        chunks[2],
+    );
+}
+
+fn draw_anthropic_oauth_status(f: &mut Frame, area: Rect, state: &State) {
+    let chunks = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(area);
+
+    if state.anthropic_auth_mode == AnthropicAuthMode::OAuthReady {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::raw(
+                "  Claude Code OAuth",
+            )])),
+            chunks[0],
+        );
+        f.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("  \u{2714} ", Style::default().fg(theme::GREEN)),
+                Span::styled(
+                    "Token found in ~/.claude/.credentials.json",
+                    Style::default().fg(theme::GREEN),
+                ),
+            ])),
+            chunks[1],
+        );
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                "    Press Enter to continue",
+                theme::dim_style(),
+            )])),
+            chunks[2],
+        );
+    } else {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::raw(
+                "  Claude Code OAuth",
+            )])),
+            chunks[0],
+        );
+        f.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("  \u{26a0} ", Style::default().fg(theme::YELLOW)),
+                Span::styled(
+                    "~/.claude/.credentials.json not found",
+                    Style::default().fg(theme::YELLOW),
+                ),
+            ])),
+            chunks[1],
+        );
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                "    Run `claude` in another terminal to authenticate, then press Enter to retry",
+                theme::dim_style(),
+            )])),
+            chunks[2],
+        );
+    }
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "  [Enter] Confirm  [Esc] Back",
+            theme::hint_style(),
+        )])),
+        chunks[4],
     );
 }
 

--- a/crates/openfang-runtime/src/drivers/anthropic.rs
+++ b/crates/openfang-runtime/src/drivers/anthropic.rs
@@ -14,23 +14,38 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
+/// Authentication mode for the Anthropic driver.
+enum AuthMode {
+    /// Standard API key authentication via `x-api-key` header.
+    ApiKey(Zeroizing<String>),
+}
+
 /// Anthropic Claude API driver.
 pub struct AnthropicDriver {
-    api_key: Zeroizing<String>,
+    auth: AuthMode,
     base_url: String,
     client: reqwest::Client,
 }
 
 impl AnthropicDriver {
-    /// Create a new Anthropic driver.
+    /// Create a new Anthropic driver using an API key.
     pub fn new(api_key: String, base_url: String) -> Self {
         Self {
-            api_key: Zeroizing::new(api_key),
+            auth: AuthMode::ApiKey(Zeroizing::new(api_key)),
             base_url,
             client: reqwest::Client::builder()
                 .user_agent(crate::USER_AGENT)
                 .build()
                 .unwrap_or_default(),
+        }
+    }
+
+    /// Apply authentication headers to a request builder.
+    fn apply_auth_headers(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.auth {
+            AuthMode::ApiKey(k) => builder
+                .header("x-api-key", k.as_str())
+                .header("anthropic-version", "2023-06-01"),
         }
     }
 }
@@ -205,10 +220,7 @@ impl LlmDriver for AnthropicDriver {
             debug!(url = %url, attempt, "Sending Anthropic API request");
 
             let resp = self
-                .client
-                .post(&url)
-                .header("x-api-key", self.api_key.as_str())
-                .header("anthropic-version", "2023-06-01")
+                .apply_auth_headers(self.client.post(&url))
                 .header("content-type", "application/json")
                 .json(&api_request)
                 .send()
@@ -312,10 +324,7 @@ impl LlmDriver for AnthropicDriver {
             debug!(url = %url, attempt, "Sending Anthropic streaming request");
 
             let resp = self
-                .client
-                .post(&url)
-                .header("x-api-key", self.api_key.as_str())
-                .header("anthropic-version", "2023-06-01")
+                .apply_auth_headers(self.client.post(&url))
                 .header("content-type", "application/json")
                 .json(&api_request)
                 .send()

--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -140,13 +140,13 @@ impl ClaudeCodeDriver {
 
 /// JSON output from `claude -p --output-format json`.
 ///
-/// The CLI may return the response text in different fields depending on
-/// version: `result`, `content`, or `text`. We try all three.
+/// Current CLI emits: {"type":"result","result":"...","usage":{...}}
+/// Older versions used `content` or `text`.
 #[derive(Debug, Deserialize)]
 struct ClaudeJsonOutput {
     result: Option<String>,
     #[serde(default)]
-    content: Option<String>,
+    content: Option<serde_json::Value>,
     #[serde(default)]
     text: Option<String>,
     #[serde(default)]
@@ -170,8 +170,12 @@ struct ClaudeUsage {
 struct ClaudeStreamEvent {
     #[serde(default)]
     r#type: String,
+    /// Flat content string (older CLI versions)
     #[serde(default)]
     content: Option<String>,
+    /// Nested assistant message (current CLI: {"role":"assistant","content":[{"type":"text","text":"..."}]})
+    #[serde(default)]
+    message: Option<serde_json::Value>,
     #[serde(default)]
     result: Option<String>,
     #[serde(default)]
@@ -201,6 +205,7 @@ impl LlmDriver for ClaudeCodeDriver {
 
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
+        cmd.env_remove("CLAUDECODE");
 
         debug!(cli = %self.cli_path, "Spawning Claude Code CLI");
 
@@ -249,10 +254,25 @@ impl LlmDriver for ClaudeCodeDriver {
 
         // Try JSON parse first
         if let Ok(parsed) = serde_json::from_str::<ClaudeJsonOutput>(&stdout) {
-            let text = parsed.result
-                .or(parsed.content)
-                .or(parsed.text)
-                .unwrap_or_default();
+            // content may be a string or an array of blocks [{type:"text",text:"..."}]
+            let content_text = parsed.content.and_then(|v| {
+                v.as_str().map(str::to_string).or_else(|| {
+                    v.as_array().map(|blocks| {
+                        blocks
+                            .iter()
+                            .filter_map(|b| {
+                                if b["type"].as_str() == Some("text") {
+                                    b["text"].as_str().map(str::to_string)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("")
+                    })
+                })
+            });
+            let text = parsed.result.or(content_text).or(parsed.text).unwrap_or_default();
             let usage = parsed.usage.unwrap_or_default();
             return Ok(CompletionResponse {
                 content: vec![ContentBlock::Text { text: text.clone() }],
@@ -301,6 +321,7 @@ impl LlmDriver for ClaudeCodeDriver {
 
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
+        cmd.env_remove("CLAUDECODE");
 
         debug!(cli = %self.cli_path, "Spawning Claude Code CLI (streaming)");
 
@@ -334,7 +355,7 @@ impl LlmDriver for ClaudeCodeDriver {
             match serde_json::from_str::<ClaudeStreamEvent>(&line) {
                 Ok(event) => {
                     match event.r#type.as_str() {
-                        "content" | "text" | "assistant" | "content_block_delta" => {
+                        "content" | "text" | "content_block_delta" => {
                             if let Some(ref content) = event.content {
                                 full_text.push_str(content);
                                 let _ = tx
@@ -342,6 +363,33 @@ impl LlmDriver for ClaudeCodeDriver {
                                         text: content.clone(),
                                     })
                                     .await;
+                            }
+                        }
+                        "assistant" => {
+                            // Current CLI: message.content is [{type:"text",text:"..."}]
+                            let text = if let Some(ref msg) = event.message {
+                                msg["content"]
+                                    .as_array()
+                                    .map(|blocks| {
+                                        blocks
+                                            .iter()
+                                            .filter_map(|b| {
+                                                if b["type"].as_str() == Some("text") {
+                                                    b["text"].as_str().map(str::to_string)
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            .collect::<Vec<_>>()
+                                            .join("")
+                                    })
+                                    .unwrap_or_default()
+                            } else {
+                                event.content.clone().unwrap_or_default()
+                            };
+                            if !text.is_empty() {
+                                full_text.push_str(&text);
+                                let _ = tx.send(StreamEvent::TextDelta { text }).await;
                             }
                         }
                         "result" | "done" | "complete" => {

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -248,18 +248,24 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
 
     // Anthropic uses a different API format — special case
     if provider == "anthropic" {
-        let api_key = config
-            .api_key
-            .clone()
-            .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
-            .ok_or_else(|| {
-                LlmError::MissingApiKey("Set ANTHROPIC_API_KEY environment variable".to_string())
-            })?;
         let base_url = config
             .base_url
             .clone()
             .unwrap_or_else(|| ANTHROPIC_BASE_URL.to_string());
-        return Ok(Arc::new(anthropic::AnthropicDriver::new(api_key, base_url)));
+
+        // Priority 1: explicit api_key in DriverConfig
+        if let Some(key) = config.api_key.clone() {
+            return Ok(Arc::new(anthropic::AnthropicDriver::new(key, base_url)));
+        }
+        // Priority 2: ANTHROPIC_API_KEY env var
+        if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+            if !key.is_empty() {
+                return Ok(Arc::new(anthropic::AnthropicDriver::new(key, base_url)));
+            }
+        }
+        return Err(LlmError::MissingApiKey(
+            "Set ANTHROPIC_API_KEY environment variable".to_string(),
+        ));
     }
 
     // Gemini uses a different API format — special case


### PR DESCRIPTION
## What this PR does

Adds full Anthropic support **beyond the direct API key** — specifically, users who authenticate via Claude Code (OAuth) can now use their existing Claude Code session as the LLM backend, without needing a separate `ANTHROPIC_API_KEY`.

Previously the only way to use Anthropic models was a raw API key. This PR adds a second path: if you have Claude Code installed and authenticated, OpenFang can delegate all LLM calls to the `claude` CLI subprocess, which handles auth internally.

## How it works

When the user selects Anthropic in the init wizard and chooses "Claude Code OAuth", the wizard now writes `provider = "claude-code"` to config instead of `provider = "anthropic"`. This routes all requests through `ClaudeCodeDriver` (which shells out to `claude -p`) rather than hitting `api.anthropic.com` directly with a Bearer token — which Anthropic's API rejects.

## Changes

- **`init_wizard.rs`** — OAuth auth method picker (API key vs Claude Code OAuth), `use_claude_code_oauth` state flag, correct provider written to config, auto-detection of existing Claude Code credentials
- **`drivers/mod.rs`** — remove the OAuth token fallback from the `anthropic` branch (it never worked; `AnthropicDriver` only supports API keys)
- **`drivers/anthropic.rs`** — remove dead `AuthMode::OAuth` / `new_oauth()` / Bearer header code
- **`drivers/claude_code.rs`** — three runtime fixes required to make the driver actually work:
  - Unset `CLAUDECODE` env var before spawning (CLI refuses to run in nested sessions)
  - Fix stream parser: current CLI emits `message.content[{type,text}]` blocks, not a flat string
  - Fix `complete()` parser: same nested block-array format for JSON output

## Test plan

- [ ] `openfang init` → Anthropic → Claude Code OAuth → model list shows claude-code models
- [ ] `~/.openfang/config.toml` has `provider = "claude-code"`
- [ ] Messages return responses (no "OAuth not supported" error)
- [ ] Anthropic with `ANTHROPIC_API_KEY` still works normally