### PR TITLE
fix error while loading shared libraries: libssl.so.1.0.0 #475

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,6 +4179,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # Email (SMTP + IMAP)
 lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 imap = "2"
-native-tls = "0.2"
+native-tls = { version = "0.2", features = ["vendored"] }
 mailparse = "0.15"
 
 # Testing


### PR DESCRIPTION
## Summary
fix error while loading shared libraries: libssl.so.1.0.0  on aarch64 linux #475

## Changes
Changed Cargo.toml  [workspace.dependencies]
native-tls = "0.2"  
to
native-tls = { version = "0.2", features = ["vendored"] }

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [ ] No new unsafe code
- [ ] No secrets or API keys in diff
- [ ] User input validated at boundaries
