### PR TITLE
fix: suppress agent error posts on public broadcast channels (Mastodon)

### DIFF
--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -770,14 +770,16 @@ async fn dispatch_message(
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
             warn!("Agent error for {agent_id}: {e}");
             let err_msg = format!("Agent error: {e}");
-            send_response(
-                adapter,
-                &message.sender,
-                err_msg.clone(),
-                thread_id,
-                output_format,
-            )
-            .await;
+            if !adapter.suppress_error_responses() {
+                send_response(
+                    adapter,
+                    &message.sender,
+                    err_msg.clone(),
+                    thread_id,
+                    output_format,
+                )
+                .await;
+            }
             handle
                 .record_delivery(
                     agent_id,
@@ -959,14 +961,16 @@ async fn dispatch_with_blocks(
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
             warn!("Agent error for {agent_id}: {e}");
             let err_msg = format!("Agent error: {e}");
-            send_response(
-                adapter,
-                &message.sender,
-                err_msg.clone(),
-                thread_id,
-                output_format,
-            )
-            .await;
+            if !adapter.suppress_error_responses() {
+                send_response(
+                    adapter,
+                    &message.sender,
+                    err_msg.clone(),
+                    thread_id,
+                    output_format,
+                )
+                .await;
+            }
             handle
                 .record_delivery(
                     agent_id,

--- a/crates/openfang-channels/src/mastodon.rs
+++ b/crates/openfang-channels/src/mastodon.rs
@@ -518,6 +518,12 @@ impl ChannelAdapter for MastodonAdapter {
         Ok(())
     }
 
+    fn suppress_error_responses(&self) -> bool {
+        // Mastodon is a public broadcast channel — posting agent errors as statuses
+        // would expose internal system errors publicly, even at "unlisted" visibility.
+        true
+    }
+
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error>> {
         let _ = self.shutdown_tx.send(true);
         Ok(())

--- a/crates/openfang-channels/src/types.rs
+++ b/crates/openfang-channels/src/types.rs
@@ -261,6 +261,15 @@ pub trait ChannelAdapter: Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.send(user, content).await
     }
+
+    /// Whether this adapter should suppress sending internal agent errors back to the user.
+    ///
+    /// Returns `true` for public broadcast channels (e.g. Mastodon, Bluesky) where posting
+    /// an error message would create a public or semi-public status update. Errors are always
+    /// logged regardless of this setting.
+    fn suppress_error_responses(&self) -> bool {
+        false
+    }
 }
 
 /// Split a message into chunks of at most `max_len` characters,


### PR DESCRIPTION
## Summary

- Adds `suppress_error_responses() -> bool` to the `ChannelAdapter` trait (default `false`)
- `MastodonAdapter` overrides to `true` — agent errors are logged internally but not posted as statuses
- Both `dispatch_text_message` and `dispatch_multimodal_message` error branches respect this flag

## Problem

When an agent hit a resource quota (e.g. token limit exceeded), the error was passed to `send_response()` which on Mastodon means calling `api_post_status()`. This caused hundreds of `"Agent error: Resource quota exceeded: Token limit exceeded"` posts to be published to a user's Mastodon account in a burst, all within the same second.

Errors are still logged via `warn!()` and recorded in delivery history — they're just no longer broadcast as public/unlisted statuses.

## Why this approach

Adding a trait method keeps the fix localized to adapters that opt in. All existing adapters (Telegram, Slack, Discord, etc.) are unaffected. Any future public broadcast adapters (e.g. Bluesky) can override `suppress_error_responses()` to `true` the same way.

## Test plan

- [ ] Verify `cargo build -p openfang-channels` passes cleanly
- [ ] Trigger an agent token-limit error with Mastodon channel enabled — confirm no status is posted
- [ ] Confirm the error is still present in delivery history / logs
- [ ] Verify Telegram/Slack/Discord still receive error responses as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)