### PR TITLE
build: Add optional Docker build args to speed up Cargo builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ COPY crates ./crates
 COPY xtask ./xtask
 COPY agents ./agents
 COPY packages ./packages
+# Optional build args for dev environments to speed up compilation
+# Example: docker build --build-arg LTO=false --build-arg CODEGEN_UNITS=16 .
+ARG LTO=true
+ARG CODEGEN_UNITS=1
+ENV CARGO_PROFILE_RELEASE_LTO=${LTO} \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CODEGEN_UNITS}
 RUN cargo build --release --bin openfang
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
This adds optional build arguments (`LTO` and `CODEGEN_UNITS`) to the `Dockerfile`, defaulting to the existing production-optimized profile settings.

These parameters allow developers who are frequently rebuilding the Docker image to skip Link Time Optimization and increase codegen units using `--build-arg`, massively speeding up the container build times without affecting the default optimized release binary.

## Details
- `ARG LTO=true` and `ARG CODEGEN_UNITS=1` added to keep parity with `Cargo.toml` `[profile.release]` default.
- Developers can now use `docker build --build-arg LTO=false --build-arg CODEGEN_UNITS=16 .` for ultra-fast iteration.

## Checklist
- [x] Keeps default behavior intact
- [x] No secrets or API keys in diff