### PR TITLE
fix: Resolve channel default_agent by name at message-time instead of caching UUID at startup

### DIFF
--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -1603,7 +1603,7 @@ pub async fn start_channel_bridge_with_config(
                     "{} default agent: {name} ({agent_id}) [channel: {channel_key}]",
                     adapter.name()
                 );
-                router.set_channel_default(channel_key, agent_id);
+                router.set_channel_default_with_name(channel_key, agent_id, name.clone());
                 // First configured default also becomes system-wide fallback
                 if !system_default_set {
                     router.set_default(agent_id);

--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -434,6 +434,65 @@ async fn send_lifecycle_reaction(
     let _ = adapter.send_reaction(user, message_id, &reaction).await;
 }
 
+/// Attempt to re-resolve an agent by channel default name after an "Agent not found" error.
+///
+/// When an agent is killed and respawned, it gets a new UUID. The router's cached ID
+/// becomes stale. This function:
+/// 1. Checks if the error indicates the agent was not found.
+/// 2. Looks up the channel's configured default agent name.
+/// 3. Calls `find_agent_by_name()` to get the new UUID.
+/// 4. Updates the router's channel default cache.
+/// 5. Returns the new AgentId if successful, None otherwise.
+///
+/// This is the fallback path -- only called when the primary send fails. The hot path
+/// (cached UUID is valid) never hits this function.
+async fn try_reresolution(
+    error: &str,
+    channel_key: &str,
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    router: &Arc<AgentRouter>,
+) -> Option<AgentId> {
+    // Only attempt re-resolution for "Agent not found" errors
+    if !error.contains("Agent not found") {
+        return None;
+    }
+
+    // Check if we have a configured name for this channel's default agent
+    let agent_name = router.channel_default_name(channel_key)?;
+
+    info!(
+        channel = channel_key,
+        agent_name = %agent_name,
+        "Cached agent UUID is stale -- attempting re-resolution by name"
+    );
+
+    // Try to find the agent by name (it may have been respawned with a new UUID)
+    match handle.find_agent_by_name(&agent_name).await {
+        Ok(Some(new_id)) => {
+            info!(
+                channel = channel_key,
+                agent_name = %agent_name,
+                new_id = %new_id,
+                "Re-resolved agent by name -- updating router cache"
+            );
+            router.update_channel_default(channel_key, new_id);
+            Some(new_id)
+        }
+        Ok(None) => {
+            warn!(
+                channel = channel_key,
+                agent_name = %agent_name,
+                "Agent not found by name during re-resolution -- agent may not be running"
+            );
+            None
+        }
+        Err(e) => {
+            warn!(channel = channel_key, error = %e, "Error during agent re-resolution");
+            None
+        }
+    }
+}
+
 /// Dispatch a single incoming message — handles bot commands or routes to an agent.
 ///
 /// Applies per-channel policies (DM/group filtering, rate limiting, formatting, threading).
@@ -692,6 +751,8 @@ async fn dispatch_message(
         &message.sender.platform_id,
         message.sender.openfang_user.as_deref(),
     );
+    // Capture channel key for potential re-resolution after agent kill+respawn
+    let channel_key = format!("{:?}", message.channel);
 
     let agent_id = match agent_id {
         Some(id) => id,
@@ -770,6 +831,33 @@ async fn dispatch_message(
                 .await;
         }
         Err(e) => {
+            // Try re-resolving by name if the agent UUID is stale (killed + respawned).
+            // This only fires on "Agent not found" errors -- all other errors fall through.
+            if let Some(new_id) = try_reresolution(&e, &channel_key, handle, router).await {
+                // Retry with the newly resolved agent ID
+                send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+                match handle.send_message(new_id, &text).await {
+                    Ok(response) => {
+                        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+                        send_response(adapter, &message.sender, response, thread_id, output_format).await;
+                        handle
+                            .record_delivery(new_id, ct_str, &message.sender.platform_id, true, None, thread_id)
+                            .await;
+                    }
+                    Err(e2) => {
+                        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
+                        warn!("Agent error for {new_id} (after re-resolution): {e2}");
+                        let err_msg = format!("Agent error: {e2}");
+                        send_response(adapter, &message.sender, err_msg.clone(), thread_id, output_format).await;
+                        handle
+                            .record_delivery(new_id, ct_str, &message.sender.platform_id, false, Some(&err_msg), thread_id)
+                            .await;
+                    }
+                }
+                return;
+            }
+
+            // No re-resolution possible -- report the original error
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
             warn!("Agent error for {agent_id}: {e}");
             let err_msg = format!("Agent error: {e}");
@@ -931,6 +1019,8 @@ async fn dispatch_with_blocks(
         &message.sender.platform_id,
         message.sender.openfang_user.as_deref(),
     );
+    // Capture channel key for potential re-resolution after agent kill+respawn
+    let channel_key = format!("{:?}", message.channel);
 
     let agent_id = match agent_id {
         Some(id) => id,
@@ -986,7 +1076,7 @@ async fn dispatch_with_blocks(
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
     send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
 
-    match handle.send_message_with_blocks(agent_id, blocks).await {
+    match handle.send_message_with_blocks(agent_id, blocks.clone()).await {
         Ok(response) => {
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
             send_response(adapter, &message.sender, response, thread_id, output_format).await;
@@ -995,6 +1085,33 @@ async fn dispatch_with_blocks(
                 .await;
         }
         Err(e) => {
+            // Try re-resolving by name if the agent UUID is stale (killed + respawned).
+            // This only fires on "Agent not found" errors -- all other errors fall through.
+            if let Some(new_id) = try_reresolution(&e, &channel_key, handle, router).await {
+                // Retry with the newly resolved agent ID
+                send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+                match handle.send_message_with_blocks(new_id, blocks).await {
+                    Ok(response) => {
+                        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+                        send_response(adapter, &message.sender, response, thread_id, output_format).await;
+                        handle
+                            .record_delivery(new_id, ct_str, &message.sender.platform_id, true, None, thread_id)
+                            .await;
+                    }
+                    Err(e2) => {
+                        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
+                        warn!("Agent error for {new_id} (after re-resolution): {e2}");
+                        let err_msg = format!("Agent error: {e2}");
+                        send_response(adapter, &message.sender, err_msg.clone(), thread_id, output_format).await;
+                        handle
+                            .record_delivery(new_id, ct_str, &message.sender.platform_id, false, Some(&err_msg), thread_id)
+                            .await;
+                    }
+                }
+                return;
+            }
+
+            // No re-resolution possible -- report the original error
             send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
             warn!("Agent error for {agent_id}: {e}");
             let err_msg = format!("Agent error: {e}");

--- a/crates/openfang-channels/src/router.rs
+++ b/crates/openfang-channels/src/router.rs
@@ -34,6 +34,8 @@ pub struct AgentRouter {
     default_agent: Option<AgentId>,
     /// Per-channel-type default agent (e.g., Telegram -> agent_a, Discord -> agent_b).
     channel_defaults: DashMap<String, AgentId>,
+    /// Per-channel-type default agent NAME (for re-resolution after agent kill+respawn).
+    channel_default_names: DashMap<String, String>,
     /// Sorted bindings (most specific first). Uses Mutex for runtime updates via Arc.
     bindings: Mutex<Vec<(AgentBinding, String)>>,
     /// Broadcast configuration. Uses Mutex for runtime updates via Arc.
@@ -50,6 +52,7 @@ impl AgentRouter {
             direct_routes: DashMap::new(),
             default_agent: None,
             channel_defaults: DashMap::new(),
+            channel_default_names: DashMap::new(),
             bindings: Mutex::new(Vec::new()),
             broadcast: Mutex::new(BroadcastConfig::default()),
             agent_name_cache: DashMap::new(),
@@ -64,6 +67,20 @@ impl AgentRouter {
     /// Set a per-channel-type default agent (e.g., "Telegram" -> agent_id).
     pub fn set_channel_default(&self, channel_key: String, agent_id: AgentId) {
         self.channel_defaults.insert(channel_key, agent_id);
+    }
+
+    /// Set a per-channel-type default agent with its name for later re-resolution.
+    ///
+    /// When an agent is killed and respawned (new UUID), the bridge can use the
+    /// stored name to re-resolve the agent by calling `find_agent_by_name()`.
+    pub fn set_channel_default_with_name(&self, channel_key: String, agent_id: AgentId, agent_name: String) {
+        self.channel_default_names.insert(channel_key.clone(), agent_name);
+        self.channel_defaults.insert(channel_key, agent_id);
+    }
+
+    /// Get the configured default agent name for a channel type (if set via `set_channel_default_with_name`).
+    pub fn channel_default_name(&self, channel_key: &str) -> Option<String> {
+        self.channel_default_names.get(channel_key).map(|r| r.clone())
     }
 
     /// Set a user's default agent.
@@ -105,6 +122,13 @@ impl AgentRouter {
     /// Register an agent name -> ID mapping for binding resolution.
     pub fn register_agent(&self, name: String, id: AgentId) {
         self.agent_name_cache.insert(name, id);
+    }
+
+    /// Update a channel default agent ID (used when re-resolving after agent respawn).
+    ///
+    /// Only updates the cached AgentId -- the name remains unchanged.
+    pub fn update_channel_default(&self, channel_key: &str, new_agent_id: AgentId) {
+        self.channel_defaults.insert(channel_key.to_string(), new_agent_id);
     }
 
     /// Resolve which agent should handle a message.


### PR DESCRIPTION
## Problem

When a channel's `default_agent` is resolved at startup, the UUID gets cached in the `AgentRouter`. Kill + respawn assigns a new UUID, but the router still holds the old one. Every message after that fails with `Agent not found: <old-uuid>` until you restart the whole process.

I kept hitting this while iterating on agent manifests:
1. Edit manifest (tweak system prompt, change model, etc)
2. `agent kill foo` + `agent spawn foo`
3. Agent comes back with a new UUID
4. Telegram messages all break — router is still pointing at the dead UUID
5. Have to restart the entire container to fix it

## Fix

Lazy re-resolution fallback in the bridge dispatch path. When `send_message()` gets an "Agent not found" error:

1. Look up the channel's configured default agent **name** (not UUID)
2. Call `find_agent_by_name()` to get the current UUID
3. Update the router cache
4. Retry the message

The cached UUID is still checked first so there's no overhead in the normal case. Re-resolution only kicks in when the send actually fails.

## Changes

### `crates/openfang-channels/src/router.rs` (+24 lines)
- `channel_default_names: DashMap<String, String>` field — stores the configured agent name next to the cached UUID
- `set_channel_default_with_name()` — stores both name and ID
- `channel_default_name()` — getter for the stored name
- `update_channel_default()` — swap out just the cached UUID after re-resolution

### `crates/openfang-channels/src/bridge.rs` (+117 lines)
- `try_reresolution()` — checks for "Agent not found", looks up name from router, calls `find_agent_by_name()`, updates cache, returns new ID
- `dispatch_message()` error path — on "Agent not found", tries re-resolution + one retry
- `dispatch_with_blocks()` — same logic for multimodal messages
- `blocks` → `blocks.clone()` so blocks can be reused on retry

### `crates/openfang-api/src/channel_bridge.rs` (1 line)
- `set_channel_default()` → `set_channel_default_with_name()` at startup so the name is preserved

## Backwards compat

- `set_channel_default()` is untouched — only the startup path uses the new `_with_name` variant
- No new trait methods — uses existing `find_agent_by_name()`
- No config or API changes
- New fields on `AgentRouter` are private
- Existing tests pass as-is

## Testing

1. Configure a channel with `default_agent = "foo"`
2. Send a message — works fine
3. `agent kill foo` → `agent spawn foo`
4. Send another message
5. Before: `Agent error: Agent not found: ...`
6. After: message goes through, logs show re-resolution happened
7. Subsequent messages hit the updated cache with no re-resolution

Edge cases:
- Agent killed but not respawned → falls through to the original error
- Non-"Agent not found" errors (model API failures etc) → no re-resolution triggered
- Multiple channels with different defaults → each re-resolves independently
- Multimodal messages → retry works with cloned blocks