### PR TITLE
fix: codex add id_token

### DIFF
--- a/crates/openfang-runtime/src/model_catalog.rs
+++ b/crates/openfang-runtime/src/model_catalog.rs
@@ -393,6 +393,7 @@ pub fn read_codex_credential() -> Option<String> {
     parsed
         .get("api_key")
         .or_else(|| parsed.get("token"))
+        .or_else(|| parsed.get("tokens").and_then(|t| t.get("id_token")))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())


### PR DESCRIPTION
### Summary

Fix Codex CLI credential detection for OAuth-based authentication. When users log in via codex login using ChatGPT/OAuth flow, the CLI stores the token in a nested tokens.id_token field, but OpenFang only checked top-level api_key and token fields, causing the provider to incorrectly show as "needs configuration".

### Changes

Updated read_codex_credential() in model_catalog.rs to also check tokens.id_token nested field
Maintains backward compatibility with legacy api_key and token top-level formats

### Testing

- [x]  cargo clippy --workspace --all-targets -- -D warnings passes
- [x]  cargo test --workspace passes (1 pre-existing permission failure unrelated to this change)
- [x]  Live integration tested (if applicable)

### Security

- [x]  No new unsafe code
- [x]  No secrets or API keys in diff
- [x]  User input validated at boundaries