### PR TITLE
fix(whatsapp-gateway): reconnect on all non-logout disconnections

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -20,6 +20,8 @@ let qrDataUrl = '';       // latest QR code as data:image/png;base64,...
 let connStatus = 'disconnected'; // disconnected | qr_ready | connected
 let qrExpired = false;
 let statusMessage = 'Not started';
+let reconnectAttempts = 0; // track consecutive reconnection attempts
+const MAX_RECONNECT_DELAY = 60_000; // cap backoff at 60s
 
 // ---------------------------------------------------------------------------
 // Baileys connection
@@ -84,6 +86,7 @@ async function startConnection() {
         statusMessage = 'Logged out. Generate a new QR code to reconnect.';
         qrDataUrl = '';
         sock = null;
+        reconnectAttempts = 0;
         // Remove auth store so next connect gets a fresh QR
         const fs = require('node:fs');
         const path = require('node:path');
@@ -91,18 +94,17 @@ async function startConnection() {
         if (fs.existsSync(authPath)) {
           fs.rmSync(authPath, { recursive: true, force: true });
         }
-      } else if (statusCode === DisconnectReason.restartRequired ||
-                 statusCode === DisconnectReason.timedOut) {
-        // Recoverable — reconnect automatically
-        console.log('[gateway] Reconnecting...');
-        statusMessage = 'Reconnecting...';
-        setTimeout(() => startConnection(), 2000);
       } else {
-        // QR expired or other non-recoverable close
-        qrExpired = true;
+        // All other close reasons are recoverable — reconnect with backoff.
+        // This includes: connectionClosed (428), connectionLost (408),
+        // connectionReplaced (440), restartRequired (515), timedOut (408),
+        // multideviceMismatch, and QR expiry.
+        reconnectAttempts++;
+        const delay = Math.min(2000 * Math.pow(1.5, reconnectAttempts - 1), MAX_RECONNECT_DELAY);
+        console.log(`[gateway] Reconnecting in ${Math.round(delay / 1000)}s (attempt ${reconnectAttempts})...`);
         connStatus = 'disconnected';
-        statusMessage = 'QR code expired. Click "Generate New QR" to retry.';
-        qrDataUrl = '';
+        statusMessage = `Reconnecting (attempt ${reconnectAttempts})...`;
+        setTimeout(() => startConnection(), delay);
       }
     }
 
@@ -110,6 +112,7 @@ async function startConnection() {
       connStatus = 'connected';
       qrExpired = false;
       qrDataUrl = '';
+      reconnectAttempts = 0;
       statusMessage = 'Connected to WhatsApp';
       console.log('[gateway] Connected to WhatsApp!');
     }
@@ -332,11 +335,24 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, '127.0.0.1', () => {
+server.listen(PORT, '127.0.0.1', async () => {
   console.log(`[gateway] WhatsApp Web gateway listening on http://127.0.0.1:${PORT}`);
   console.log(`[gateway] OpenFang URL: ${OPENFANG_URL}`);
   console.log(`[gateway] Default agent: ${DEFAULT_AGENT}`);
-  console.log('[gateway] Waiting for POST /login/start to begin QR flow...');
+
+  // Auto-connect if auth credentials already exist (previous session)
+  const fs = require('node:fs');
+  const authPath = require('node:path').join(__dirname, 'auth_store', 'creds.json');
+  if (fs.existsSync(authPath)) {
+    console.log('[gateway] Found existing auth — auto-connecting...');
+    try {
+      await startConnection();
+    } catch (err) {
+      console.error('[gateway] Auto-connect failed:', err.message);
+    }
+  } else {
+    console.log('[gateway] No auth found — waiting for POST /login/start to begin QR flow...');
+  }
 });
 
 // Graceful shutdown


### PR DESCRIPTION
## Summary

- **Treat all disconnect reasons except `loggedOut` as recoverable** — the gateway now reconnects automatically on `connectionClosed` (428), `connectionLost` (408), `connectionReplaced` (440), `badSession`, and all other Baileys disconnect codes
- **Exponential backoff** (2s → 3s → 4.5s → ... capped at 60s) replaces the fixed 2s retry delay, with counter reset on successful connection
- **Auto-connect on startup** when `auth_store/creds.json` exists from a previous session, eliminating the need for a manual `POST /login/start` after process restarts

## Problem

The gateway only reconnected on `restartRequired` and `timedOut`. All other disconnect codes silently killed the connection permanently. Combined with no auto-connect on startup, any transient network issue or process restart meant permanent disconnection until manual intervention.

Real-world impact: the gateway would show `connected: false` on `/health` but never recover, silently dropping all incoming WhatsApp messages.

Closes #555

## Test plan

- [ ] Start gateway with existing `auth_store/` credentials → should auto-connect without `POST /login/start`
- [ ] Simulate network interruption (e.g., block WhatsApp IPs briefly) → gateway should reconnect with increasing delays visible in logs
- [ ] Verify backoff resets to 0 after successful reconnection
- [ ] Verify `loggedOut` still clears auth store and stops (no reconnect loop)
- [ ] Verify `/health` endpoint reflects correct `connected` status during reconnection attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)