### PR TITLE
feat: Configurable lifecycle_reactions flag for Telegram bridge

### DIFF
--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -756,14 +756,22 @@ async fn dispatch_message(
     let _ = adapter.send_typing(&message.sender).await;
 
     // Lifecycle reaction: ⏳ Queued → 🤔 Thinking → ✅ Done / ❌ Error
+    let lifecycle_reactions = overrides
+        .as_ref()
+        .map(|o| o.lifecycle_reactions)
+        .unwrap_or(true);
     let msg_id = &message.platform_message_id;
-    send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
-    send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+    if lifecycle_reactions {
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+    }
 
     // Send to agent and relay response
     match handle.send_message(agent_id, &text).await {
         Ok(response) => {
-            send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+            if lifecycle_reactions {
+                send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+            }
             send_response(adapter, &message.sender, response, thread_id, output_format).await;
             handle
                 .record_delivery(agent_id, ct_str, &message.sender.platform_id, true, None, thread_id)
@@ -982,20 +990,31 @@ async fn dispatch_with_blocks(
     let _ = adapter.send_typing(&message.sender).await;
 
     // Lifecycle reaction: ⏳ Queued → 🤔 Thinking → ✅ Done / ❌ Error
+    let lifecycle_reactions = handle
+        .channel_overrides(ct_str)
+        .await
+        .map(|o| o.lifecycle_reactions)
+        .unwrap_or(true);
     let msg_id = &message.platform_message_id;
-    send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
-    send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+    if lifecycle_reactions {
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Queued).await;
+        send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Thinking).await;
+    }
 
     match handle.send_message_with_blocks(agent_id, blocks).await {
         Ok(response) => {
-            send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+            if lifecycle_reactions {
+                send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Done).await;
+            }
             send_response(adapter, &message.sender, response, thread_id, output_format).await;
             handle
                 .record_delivery(agent_id, ct_str, &message.sender.platform_id, true, None, thread_id)
                 .await;
         }
         Err(e) => {
-            send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
+            if lifecycle_reactions {
+                send_lifecycle_reaction(adapter, &message.sender, msg_id, AgentPhase::Error).await;
+            }
             warn!("Agent error for {agent_id}: {e}");
             let err_msg = format!("Agent error: {e}");
             send_response(

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -68,7 +68,7 @@ pub enum OutputFormat {
 }
 
 /// Per-channel behavior overrides.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ChannelOverrides {
     /// Model override (uses agent's default if None).
@@ -89,6 +89,27 @@ pub struct ChannelOverrides {
     pub usage_footer: Option<UsageFooterMode>,
     /// Typing indicator mode override.
     pub typing_mode: Option<TypingMode>,
+    /// Enable lifecycle emoji reactions on messages (⏳→🤔→✅/❌).
+    /// Defaults to true; set to false to disable.
+    #[serde(default = "default_true")]
+    pub lifecycle_reactions: bool,
+}
+
+impl Default for ChannelOverrides {
+    fn default() -> Self {
+        Self {
+            model: None,
+            system_prompt: None,
+            dm_policy: DmPolicy::default(),
+            group_policy: GroupPolicy::default(),
+            rate_limit_per_user: 0,
+            threading: false,
+            output_format: None,
+            usage_footer: None,
+            typing_mode: None,
+            lifecycle_reactions: true,
+        }
+    }
 }
 
 /// Controls what usage info appears in response footers.
@@ -3595,6 +3616,7 @@ mod tests {
         assert!(!ov.threading);
         assert!(ov.output_format.is_none());
         assert!(ov.model.is_none());
+        assert!(ov.lifecycle_reactions);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a `lifecycle_reactions` boolean to `ChannelOverrides` (default: `true`)
- When set to `false`, suppresses the ⏳→🤔→✅/❌ emoji reactions on incoming messages
- Applies to both text and multimodal dispatch paths

## Motivation
Some users find the lifecycle emoji reactions noisy or distracting. This flag lets channel operators disable them per-channel without code changes.

Closes #563

## Test plan
- [x] Set `lifecycle_reactions = false` in `config.toml` channel overrides
- [x] Verified no reactions appear on incoming Telegram messages
- [x] Verified reactions still work when flag is `true` (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)