### PR TITLE
feat(telegram): Reply-to-message context for quoted messages

### DIFF
--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -434,6 +434,29 @@ async fn send_lifecycle_reaction(
     let _ = adapter.send_reaction(user, message_id, &reaction).await;
 }
 
+/// Build a contextual prefix when the user is replying to a previous message.
+///
+/// Returns `Some("[Replying to <sender>: <text>]\n\n")` if reply metadata exists.
+fn build_reply_context(metadata: &std::collections::HashMap<String, serde_json::Value>) -> Option<String> {
+    // Need at least some quoted content
+    let quoted = metadata
+        .get("reply_to_text")
+        .and_then(|v| v.as_str())
+        .or_else(|| metadata.get("reply_to_caption").and_then(|v| v.as_str()));
+    let quoted = quoted?;
+    let sender = metadata
+        .get("reply_to_sender")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unknown");
+    // Truncate very long quoted messages to keep context manageable
+    let truncated = if quoted.len() > 500 {
+        format!("{}…", &quoted[..500])
+    } else {
+        quoted.to_string()
+    };
+    Some(format!("[Replying to {sender}: {truncated}]\n\n"))
+}
+
 /// Dispatch a single incoming message — handles bot commands or routes to an agent.
 ///
 /// Applies per-channel policies (DM/group filtering, rate limiting, formatting, threading).
@@ -530,8 +553,15 @@ async fn dispatch_message(
 
     // For images: download, base64 encode, and send as multimodal content blocks
     if let ChannelContent::Image { ref url, ref caption } = message.content {
-        let blocks = download_image_to_blocks(url, caption.as_deref()).await;
+        let mut blocks = download_image_to_blocks(url, caption.as_deref()).await;
         if blocks.iter().any(|b| matches!(b, ContentBlock::Image { .. })) {
+            // Prepend reply context if this is a reply to a previous message
+            if let Some(reply_ctx) = build_reply_context(&message.metadata) {
+                blocks.insert(0, ContentBlock::Text {
+                    text: reply_ctx,
+                    provider_metadata: None,
+                });
+            }
             // We have actual image data — send as structured blocks for vision
             dispatch_with_blocks(
                 blocks,
@@ -571,6 +601,12 @@ async fn dispatch_message(
         ChannelContent::FileData { ref filename, .. } => {
             format!("[User sent a local file: {filename}]")
         }
+    };
+
+    // Prepend reply context if this is a reply to a previous message
+    let text = match build_reply_context(&message.metadata) {
+        Some(ctx) => format!("{ctx}{text}"),
+        None => text,
     };
 
     // Check if it's a slash command embedded in text (e.g. "/agents")

--- a/crates/openfang-channels/src/telegram.rs
+++ b/crates/openfang-channels/src/telegram.rs
@@ -825,6 +825,33 @@ async fn parse_telegram_update(
         }
     }
 
+    // Extract reply_to_message context so agents can see what the user is replying to.
+    if let Some(reply_msg) = message.get("reply_to_message") {
+        if let Some(reply_text) = reply_msg["text"].as_str() {
+            metadata.insert("reply_to_text".to_string(), serde_json::json!(reply_text));
+        }
+        if let Some(reply_caption) = reply_msg["caption"].as_str() {
+            metadata.insert(
+                "reply_to_caption".to_string(),
+                serde_json::json!(reply_caption),
+            );
+        }
+        if let Some(reply_id) = reply_msg["message_id"].as_i64() {
+            metadata.insert(
+                "reply_to_message_id".to_string(),
+                serde_json::json!(reply_id),
+            );
+        }
+        // Sender of the quoted message
+        let reply_sender = reply_msg["from"]["first_name"]
+            .as_str()
+            .unwrap_or("Unknown");
+        metadata.insert(
+            "reply_to_sender".to_string(),
+            serde_json::json!(reply_sender),
+        );
+    }
+
     Some(ChannelMessage {
         channel: ChannelType::Telegram,
         platform_message_id: message_id.to_string(),


### PR DESCRIPTION
## Summary
- Extracts `reply_to_message` metadata from Telegram updates (text, caption, sender, message_id)
- Prepends reply context as a contextual prefix when dispatching to agents
- Supports both text and image message paths

## Motivation
When users reply/quote a previous message in Telegram, the agent should see what message is being referenced to provide contextually relevant responses.

Closes #564

## Test plan
- [x] Reply to a message in Telegram — agent sees the quoted content
- [x] Reply to own message — context correctly shows sender name
- [x] Image with reply — reply context prepended before image blocks
- [x] Regular messages (no reply) — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)