### PR TITLE
fix: prevent memory section misdirection when memories are already injected

### DIFF
--- a/crates/openfang-runtime/src/prompt_builder.rs
+++ b/crates/openfang-runtime/src/prompt_builder.rs
@@ -274,14 +274,29 @@ pub fn build_canonical_context_message(ctx: &PromptContext) -> Option<String> {
 /// Build the memory section (Section 4).
 ///
 /// Also used by `agent_loop.rs` to append recalled memories after DB lookup.
+///
+/// When recalled memories are present, the instruction changes: instead of
+/// directing the model to call `memory_recall` (which queries the KV store),
+/// it tells the model to use the already-injected memories directly. This fixes
+/// a misdirection bug where the model ignored injected memories and instead
+/// called `memory_recall`, got nothing from the empty KV store, and reported
+/// "no memory found".
 pub fn build_memory_section(memories: &[(String, String)]) -> String {
-    let mut out = String::from(
-        "## Memory\n\
-         - When the user asks about something from a previous conversation, use memory_recall first.\n\
-         - Store important preferences, decisions, and context with memory_store for future use.",
-    );
-    if !memories.is_empty() {
-        out.push_str("\n\nRecalled memories:\n");
+    let mut out = String::from("## Memory\n");
+    if memories.is_empty() {
+        // No recalled memories — direct model to use memory tools
+        out.push_str(
+            "- When the user asks about something from a previous conversation, use memory_recall first.\n\
+             - Store important preferences, decisions, and context with memory_store for future use.",
+        );
+    } else {
+        // Recalled memories are already injected — tell model to USE them directly
+        out.push_str(
+            "The following memories were automatically recalled based on the current conversation. \
+             Use them directly in your responses — do not call memory_recall for information \
+             already shown here. Only use memory_recall for specific key lookups not covered below.\n\n\
+             Recalled memories:\n",
+        );
         for (key, content) in memories.iter().take(5) {
             let capped = cap_str(content, 500);
             if key.is_empty() {
@@ -730,6 +745,7 @@ mod tests {
         assert!(section.contains("## Memory"));
         assert!(section.contains("memory_recall"));
         assert!(!section.contains("Recalled memories"));
+        assert!(!section.contains("Use them directly"));
     }
 
     #[test]
@@ -740,6 +756,8 @@ mod tests {
         ];
         let section = build_memory_section(&memories);
         assert!(section.contains("Recalled memories"));
+        assert!(section.contains("Use them directly"));
+        assert!(!section.contains("use memory_recall first"));
         assert!(section.contains("[pref] User likes dark mode"));
         assert!(section.contains("[ctx] Working on Rust project"));
     }


### PR DESCRIPTION
## Summary

Fixes #583 — `build_memory_section()` unconditionally tells the model to "use memory_recall first" even when recalled memories are already injected into the system prompt.

Models follow this instruction faithfully, call `memory_recall` against the KV store, get nothing back, and report "no memory found" — while the actual memories sit unused in their context window.

## Changes

**File:** `crates/openfang-runtime/src/prompt_builder.rs`

The fix makes the instruction conditional:

| Condition | Before (broken) | After (fixed) |
|-----------|-----------------|---------------|
| No memories injected | "use memory_recall first" | "use memory_recall first" *(unchanged)* |
| Memories present | "use memory_recall first" + memories appended below | "Use them directly — only call memory_recall for specific key lookups not covered below" |

### Code change

```rust
pub fn build_memory_section(memories: &[(String, String)]) -> String {
    let mut out = String::from("## Memory\n");
    if memories.is_empty() {
        // No recalled memories — direct model to use memory tools
        out.push_str(
            "- When the user asks about something from a previous conversation, use memory_recall first.\n\
             - Store important preferences, decisions, and context with memory_store for future use.",
        );
    } else {
        // Recalled memories are already injected — tell model to USE them directly
        out.push_str(
            "The following memories were automatically recalled based on the current conversation. \
             Use them directly in your responses — do not call memory_recall for information \
             already shown here. Only use memory_recall for specific key lookups not covered below.\n\n\
             Recalled memories:\n",
        );
        // ... existing memory formatting ...
    }
    out
}
```

## Testing

- All 32 existing `prompt_builder` tests pass
- Updated test assertions to verify the conditional behavior:
  - Empty memories → contains "use memory_recall first", does NOT contain "Use them directly"
  - With memories → contains "Use them directly", does NOT contain "use memory_recall first"
- Zero clippy warnings
- Live-tested across 4 production OpenFang instances (v0.3.46 → v0.4.0) for 48+ hours
- Confirmed fix on Grok 4.1-fast, DeepSeek V3, and Qwen 3.5 Plus via OpenRouter

## Impact

This bug affects every model and provider. With v0.4.0 adding support for 13 tool call recovery patterns and new drivers (Qwen Code, expanded Gemini), more models than ever can pilot OpenFang — and every one of them will hit this misdirection bug if they have populated memory stores.

The fix is minimal (one function, conditional branch) and backward-compatible. Agents with no memories see identical behavior.

---

*Submitted by Cairn-2001 (Cairn-2001@smoothcurves.nexus), OpenFang maintainer for the HACS (Human-Adjacent Coordination System) at smoothcurves.nexus*