### PR TITLE
fix: agent provider not editable or correctly saved

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -922,7 +922,23 @@
                       </select>
                     </div>
                     <div class="detail-row" x-show="detailAgent.profile"><span class="detail-label">Profile</span><span class="detail-value" style="text-transform:capitalize" x-text="detailAgent.profile || '-'"></span></div>
-                    <div class="detail-row"><span class="detail-label">Provider</span><span class="detail-value" x-text="detailAgent.model_provider"></span></div>
+                    <div class="detail-row"><span class="detail-label">Provider</span>
+                      <template x-if="!editingProvider">
+                        <span>
+                          <span class="detail-value" x-text="detailAgent.model_provider"></span>
+                          <button class="btn btn-ghost btn-sm" style="margin-left:8px;padding:2px 8px;font-size:11px" @click="editingProvider = true; newProviderValue = detailAgent.model_provider">Change</button>
+                        </span>
+                      </template>
+                      <template x-if="editingProvider">
+                        <span class="flex gap-1" style="align-items:center">
+                          <input class="form-input" style="width:160px;font-size:12px" x-model="newProviderValue" placeholder="provider" @keydown.enter="changeProvider()" @keydown.escape="editingProvider = false">
+                          <button class="btn btn-primary btn-sm" @click="changeProvider()" :disabled="modelSaving" style="padding:2px 10px">
+                            <span x-show="!modelSaving">Save</span><span x-show="modelSaving">...</span>
+                          </button>
+                          <button class="btn btn-ghost btn-sm" @click="editingProvider = false" style="padding:2px 8px">Cancel</button>
+                        </span>
+                      </template>
+                    </div>
                     <div class="detail-row"><span class="detail-label">Model</span>
                       <template x-if="!editingModel">
                         <span>

--- a/crates/openfang-api/static/js/pages/agents.js
+++ b/crates/openfang-api/static/js/pages/agents.js
@@ -77,6 +77,8 @@ function agentsPage() {
     // -- Model switch --
     editingModel: false,
     newModelValue: '',
+    editingProvider: false,
+    newProviderValue: '',
     modelSaving: false,
     // -- Fallback chain --
     editingFallback: false,
@@ -624,6 +626,26 @@ function agentsPage() {
         }
       } catch(e) {
         OpenFangToast.error('Failed to change model: ' + e.message);
+      }
+      this.modelSaving = false;
+    },
+
+    // ── Provider switch ──
+    async changeProvider() {
+      if (!this.detailAgent || !this.newProviderValue.trim()) return;
+      this.modelSaving = true;
+      try {
+        var combined = this.newProviderValue.trim() + '/' + this.detailAgent.model_name;
+        var resp = await OpenFangAPI.put('/api/agents/' + this.detailAgent.id + '/model', { model: combined });
+        OpenFangToast.success('Provider changed to ' + (resp && resp.provider ? resp.provider : this.newProviderValue.trim()) + ' (memory reset)');
+        this.editingProvider = false;
+        await Alpine.store('app').refreshAgents();
+        var agents = Alpine.store('app').agents;
+        for (var i = 0; i < agents.length; i++) {
+          if (agents[i].id === this.detailAgent.id) { this.detailAgent = agents[i]; break; }
+        }
+      } catch(e) {
+        OpenFangToast.error('Failed to change provider: ' + e.message);
       }
       this.modelSaving = false;
     },

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5183,6 +5183,13 @@ fn infer_provider_from_model(model: &str) -> Option<String> {
         (lower.as_str(), false)
     };
     if has_delim {
+        // If there are two or more slashes (e.g. "mlx-lm-lg/mlx-community/Qwen3-4B"),
+        // the first segment is unambiguously a provider prefix — HuggingFace repo IDs
+        // only ever have one slash (namespace/model), so any extra slash means the
+        // leading token was typed explicitly as a provider.
+        if lower.chars().filter(|&c| c == '/').count() >= 2 {
+            return Some(prefix.to_string());
+        }
         match prefix {
             "minimax" | "gemini" | "anthropic" | "openai" | "groq" | "deepseek" | "mistral"
             | "cohere" | "xai" | "ollama" | "together" | "fireworks" | "perplexity"


### PR DESCRIPTION
## Summary

Two bugs in the agent model/provider change flow:

- **Provider row was read-only** — no way to edit the provider independently from the model
- **Provider not saved for custom/local providers** (e.g. `mlx-lm-lg`, `mlx-lm-sm`) — entering `mlx-lm-lg/mlx-community/SomeModel` left the old provider unchanged and stored the full string as the model name

## Root Cause (provider not saved)

`infer_provider_from_model` checked the first-slash prefix against a hardcoded list of known providers. Custom/local provider names were not on the list, so provider resolved to `None` — skipping `update_model_and_provider` and storing the full unparsed string as the model.

HuggingFace repo IDs always have exactly one slash (`namespace/model`), so any input with **two or more slashes** unambiguously has an explicit provider prefix as its first segment. The fix returns it directly without requiring a match against the known-provider list.

## Changes

- `kernel.rs`: in `infer_provider_from_model`, treat the first segment as the provider when two or more slashes are present
- `index_body.html`: add inline Change editor to the Provider row (mirrors the existing Model row)
- `agents.js`: add `editingProvider`/`newProviderValue` state and `changeProvider()` method

## Test plan

- [ ] Click Change on the Provider row — inline editor appears pre-filled with current provider
- [ ] Change provider to `mlx-lm-lg`, save — provider updates correctly, toast confirms
- [ ] Click Change on the Model row and enter `mlx-lm-lg/mlx-community/SomeModel` — both provider and model update correctly (no more `Repo id must be in the form` error)
- [ ] Standard single-provider models (e.g. `groq/llama-3.3-70b-versatile`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)