### PR TITLE
feat: add release-fast Cargo profile for faster dev builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,16 @@ Tests that require a real LLM key will skip gracefully if the env var is absent.
 cargo build --workspace
 ```
 
+### Fast Release Build (for development)
+
+The default `--release` profile uses full LTO and single-codegen-unit, which produces the smallest/fastest binary but is slow to compile. For iterating locally, use the `release-fast` profile instead:
+
+```bash
+cargo build --profile release-fast -p openfang-cli
+```
+
+This cuts link time significantly (thin LTO, 8 codegen units, `opt-level=2`) while still producing a binary fast enough to run integration tests against. Use `--release` only for final binaries or CI.
+
 ### Run All Tests
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,3 +147,10 @@ lto = true
 codegen-units = 1
 strip = true
 opt-level = 3
+
+[profile.release-fast]
+inherits = "release"
+lto = "thin"
+codegen-units = 8
+opt-level = 2
+strip = false


### PR DESCRIPTION
## Summary

- Adds a `release-fast` Cargo profile to `Cargo.toml` for faster iteration during development
- Documents it in `CONTRIBUTING.md` under the Building and Testing section

## What it does

The default `--release` profile uses `lto = true` (full LTO) and `codegen-units = 1`, which produces the most optimised binary but is slow to link. `release-fast` inherits from `release` but overrides:

| Setting | `release` | `release-fast` |
|---|---|---|
| `lto` | `true` (full) | `"thin"` |
| `codegen-units` | `1` | `8` |
| `opt-level` | `3` | `2` |
| `strip` | `true` | `false` |

This cuts link time significantly while still producing a binary fast enough for live integration testing against a running daemon.

## Usage

```bash
cargo build --profile release-fast -p openfang-cli
```

## Test plan

- [x] `cargo build --profile release-fast -p openfang-cli` compiles successfully
- [x] Resulting binary boots and passes `curl http://127.0.0.1:4200/api/health`
- [x] `cargo build --release` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)