### PR TITLE
Handle existing Chrome installs in browser setup

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -3972,9 +3972,7 @@ pub async fn install_hand_deps(
         } else {
             // On Windows, winget may return non-zero even on success (e.g., already installed)
             let combined = format!("{stdout}{stderr}");
-            let likely_ok = combined.contains("already installed")
-                || combined.contains("No applicable update")
-                || combined.contains("No available upgrade");
+            let likely_ok = install_command_effectively_succeeded(&combined);
             results.push(serde_json::json!({
                 "key": req.key,
                 "status": if likely_ok { "installed" } else { "error" },
@@ -4073,6 +4071,13 @@ pub async fn install_hand_deps(
             }).collect::<Vec<_>>(),
         })),
     )
+}
+
+fn install_command_effectively_succeeded(output: &str) -> bool {
+    output.contains("already installed")
+        || output.contains("No applicable update")
+        || output.contains("No available upgrade")
+        || output.contains("already an App at")
 }
 
 /// POST /api/hands/install — Install a hand from TOML content.
@@ -10864,4 +10869,23 @@ fn remove_toml_section(content: &str, section: &str) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_command_effectively_succeeded_detects_existing_cask_app() {
+        let output = "Error: It seems there is already an App at '/Applications/Google Chrome.app'.";
+        assert!(install_command_effectively_succeeded(output));
+    }
+
+    #[test]
+    fn remove_toml_section_strips_target_block() {
+        let input = "a = 1\n[foo]\nx = 1\n[bar]\ny = 2\n";
+        let result = remove_toml_section(input, "foo");
+        assert!(!result.contains("[foo]"));
+        assert!(result.contains("[bar]"));
+    }
 }

--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -2101,18 +2101,14 @@ fn cmd_doctor(json: bool, repair: bool) {
                             ui::check_ok(".env file (permissions fixed to 0600)");
                         }
                         repaired = true;
-                    } else {
-                        if !json {
-                            ui::check_warn(&format!(
-                                ".env file has loose permissions ({:o}), should be 0600",
-                                mode
-                            ));
-                        }
+                    } else if !json {
+                        ui::check_warn(&format!(
+                            ".env file has loose permissions ({:o}), should be 0600",
+                            mode
+                        ));
                     }
-                } else {
-                    if !json {
-                        ui::check_ok(".env file");
-                    }
+                } else if !json {
+                    ui::check_ok(".env file");
                 }
             }
             #[cfg(not(unix))]

--- a/crates/openfang-kernel/src/whatsapp_gateway.rs
+++ b/crates/openfang-kernel/src/whatsapp_gateway.rs
@@ -270,8 +270,6 @@ mod tests {
 
     #[test]
     fn test_embedded_files_not_empty() {
-        assert!(!GATEWAY_INDEX_JS.is_empty());
-        assert!(!GATEWAY_PACKAGE_JSON.is_empty());
         assert!(GATEWAY_INDEX_JS.contains("WhatsApp"));
         assert!(GATEWAY_PACKAGE_JSON.contains("@openfang/whatsapp-gateway"));
     }

--- a/crates/openfang-runtime/src/copilot_oauth.rs
+++ b/crates/openfang-runtime/src/copilot_oauth.rs
@@ -150,6 +150,6 @@ mod tests {
     fn test_constants() {
         assert!(GITHUB_DEVICE_CODE_URL.starts_with("https://"));
         assert!(GITHUB_TOKEN_URL.starts_with("https://"));
-        assert!(!COPILOT_CLIENT_ID.is_empty());
+        assert!(COPILOT_CLIENT_ID.starts_with("Iv1."));
     }
 }


### PR DESCRIPTION
## Summary

Improves browser setup handling so existing Chrome installs are detected and managed correctly.

## Changes

- Update API route handling for browser setup around existing Chrome installs.
- Improve setup behavior when Chrome is already present on the machine.
- Preserve the existing browser-hand flow while tightening install detection.

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries

Fixes: #611 