### PR TITLE
Fix GHCR package visibility for public pulls (v2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,17 +223,34 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/rightnow-ai/openfang
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/rightnow-ai/openfang:latest
-            ghcr.io/rightnow-ai/openfang:${{ steps.version.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # Ensure the GHCR package is public (prevents #12 recurrence).
+      # Requires packages:admin — fails gracefully if GITHUB_TOKEN lacks sufficient scope.
+      - name: Set GHCR package visibility to public
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            /orgs/rightnow-ai/packages/container/openfang/visibility \
+            -f visibility=public

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /build/agents /opt/openfang/agents
 
 # OCI labels — org.opencontainers.image.source links the GHCR package to this
 # repository so the package can inherit the repo's public visibility.
-LABEL org.opencontainers.image.source="https://github.com/RightNow-AI/openfang" \
+LABEL org.opencontainers.image.source="https://github.com/rightnow-ai/openfang" \
       org.opencontainers.image.description="OpenFang — Open-Source Agent Operating System" \
       org.opencontainers.image.licenses="Apache-2.0 OR MIT"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /build/target/release/openfang /usr/local/bin/
 COPY --from=builder /build/agents /opt/openfang/agents
+
+# OCI labels — org.opencontainers.image.source links the GHCR package to this
+# repository so the package can inherit the repo's public visibility.
+LABEL org.opencontainers.image.source="https://github.com/RightNow-AI/openfang" \
+      org.opencontainers.image.description="OpenFang — Open-Source Agent Operating System" \
+      org.opencontainers.image.licenses="Apache-2.0 OR MIT"
+
 EXPOSE 4200
 VOLUME /data
 ENV OPENFANG_HOME=/data


### PR DESCRIPTION
## What changed

- **Dockerfile** — Added OCI labels (`org.opencontainers.image.source`, `org.opencontainers.image.description`, `org.opencontainers.image.licenses`) to the runtime stage. The `source` label is the critical one: GHCR uses it to auto-link the container package to the source repository, enabling public visibility inheritance.

- **.github/workflows/release.yml** — Replaced the manual `Extract version` step with `docker/metadata-action@v5`, which generates standardized OCI labels and tags. The `latest` tag is managed automatically via `flavor: latest=auto` (skips `latest` for pre-release tags). Added a post-push step that calls the GitHub API to explicitly set the GHCR package visibility to public (`continue-on-error: true` so it fails gracefully if the `GITHUB_TOKEN` lacks sufficient permissions).

## Why

Fixes #12. The GHCR package was inaccessible to unauthenticated/external users because package visibility is a separate setting from repo visibility on GitHub. Without the `org.opencontainers.image.source` label, GHCR cannot auto-link the package to the repository, preventing visibility inheritance.

**Note:** A one-time manual toggle in GitHub Package Settings (Package Settings → Change visibility → Public) is still required by a repo admin to resolve the immediate issue. These CI/Dockerfile changes prevent recurrence on future releases.

## How verified

- YAML syntax validated manually
- Dockerfile syntax reviewed (no Rust code changes)
- No impact on `cargo build`, `cargo test`, or `cargo clippy` — changes are Docker/CI-only

## Tradeoffs / risks

- The post-push `gh api` visibility step may fail if `GITHUB_TOKEN` lacks `packages:admin` scope — mitigated with `continue-on-error: true`
- `docker/metadata-action@v5` replaces manual version extraction — this is a well-established action (widely used in Docker ecosystem) and produces semver tags; `latest` is managed automatically

## Scope notes

Changes are strictly limited to the GHCR visibility issue (#12). No Rust code, docs, or other workflow changes.

---

*Resubmitted fresh against current `main` as requested in [#126 (comment)](https://github.com/RightNow-AI/openfang/pull/126#issuecomment-4063471938).*