### PR TITLE
feat(feishu): add WebSocket receive mode with protobuf framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -120,15 +120,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -464,6 +464,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -797,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -807,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -819,18 +834,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -840,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -855,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1267,6 +1282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,36 +1352,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1371,22 +1375,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1458,6 +1451,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1584,6 +1598,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9c2e7f1d22d0f2ce07626d259b8a55f4a47cb0938d4006dd8ae037f17d585e"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.36.1",
+ "precomputed-hash",
+ "selectors 0.35.0",
+ "tendril",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,9 +1697,9 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+checksum = "47ec73ddcf6b7f23173d5c3c5a32b5507dc0a734de7730aa14abc5d5e296bb5f"
 dependencies = [
  "cc",
  "memchr",
@@ -1869,6 +1898,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2465,7 +2500,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -2545,8 +2580,18 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+dependencies = [
+ "log",
+ "markup5ever 0.36.1",
 ]
 
 [[package]]
@@ -2820,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2913,7 +2958,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3120,10 +3165,10 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap 2.13.0",
- "selectors",
+ "selectors 0.24.0",
 ]
 
 [[package]]
@@ -3305,9 +3350,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c889829df2867fd6a043c5932c641fcf7fe9d4329317326af08df14747ab9a97"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
 dependencies = [
  "cc",
  "objc2",
@@ -3344,9 +3389,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
  "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -3451,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3596,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -3611,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3621,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -3781,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3869,6 +3925,7 @@ dependencies = [
  "mailparse",
  "native-tls",
  "openfang-types",
+ "prost",
  "regex-lite",
  "reqwest 0.12.28",
  "roxmltree",
@@ -4160,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4192,9 +4249,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -4418,6 +4475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4503,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4468,6 +4546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4577,19 @@ checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4526,6 +4627,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -4764,6 +4874,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5509,9 +5642,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -5603,14 +5736,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
- "derive_more",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc 0.4.3",
  "smallvec",
 ]
 
@@ -5744,9 +5896,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5763,11 +5915,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5815,6 +5967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
  "stable_deref_trait",
 ]
 
@@ -6092,6 +6253,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6099,6 +6272,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -6627,7 +6812,7 @@ dependencies = [
  "ctor",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
@@ -6678,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -6760,9 +6945,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6775,15 +6960,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6801,9 +6986,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7128,9 +7313,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -7232,9 +7417,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
@@ -8004,6 +8189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8715,24 +8912,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "a24eda84b5d488f99344e54b807138896cee8df0b2d16c793f1f6b80e6d8df1f"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
  "objc2",
@@ -8902,18 +9098,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ bytes = "1"
 
 # Futures
 futures = "0.3"
+prost = "0.13"
 
 # WebSocket client (for Discord/Slack gateway)
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }

--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -30,6 +30,7 @@ use openfang_channels::messenger::MessengerAdapter;
 use openfang_channels::reddit::RedditAdapter;
 use openfang_channels::revolt::RevoltAdapter;
 use openfang_channels::viber::ViberAdapter;
+use openfang_types::config::FeishuMode;
 // Wave 4
 use openfang_channels::flock::FlockAdapter;
 use openfang_channels::guilded::GuildedAdapter;
@@ -1429,16 +1430,22 @@ pub async fn start_channel_bridge_with_config(
                 .encrypt_key_env
                 .as_ref()
                 .and_then(|env| read_token(env, "Feishu encrypt_key"));
-            let adapter = Arc::new(FeishuAdapter::with_config(
-                fs_config.app_id.clone(),
-                secret,
-                fs_config.webhook_port,
-                region,
-                Some(fs_config.webhook_path.clone()),
-                fs_config.verification_token.clone(),
-                encrypt_key,
-                fs_config.bot_names.clone(),
-            ));
+            let adapter = match fs_config.mode {
+                FeishuMode::Webhook => Arc::new(FeishuAdapter::with_config(
+                    fs_config.app_id.clone(),
+                    secret,
+                    fs_config.webhook_port,
+                    region,
+                    Some(fs_config.webhook_path.clone()),
+                    fs_config.verification_token.clone(),
+                    encrypt_key,
+                    fs_config.bot_names.clone(),
+                )),
+                FeishuMode::Websocket => Arc::new(FeishuAdapter::new_websocket(
+                    fs_config.app_id.clone(),
+                    secret,
+                )),
+            };
             adapters.push((adapter, fs_config.default_agent.clone()));
         }
     }
@@ -1872,5 +1879,36 @@ mod tests {
         assert!(config.channels.gotify.is_none());
         assert!(config.channels.webhook.is_none());
         assert!(config.channels.linkedin.is_none());
+    }
+
+    #[test]
+    fn test_feishu_bridge_mode_defaults_to_websocket() {
+        let config: openfang_types::config::KernelConfig = toml::from_str(
+            r#"
+            [channels.feishu]
+            app_id = "cli_test"
+            app_secret_env = "FEISHU_APP_SECRET"
+            "#,
+        )
+        .unwrap();
+
+        let feishu = config.channels.feishu.expect("feishu config should exist");
+        assert_eq!(feishu.mode, openfang_types::config::FeishuMode::Websocket);
+    }
+
+    #[test]
+    fn test_feishu_bridge_mode_supports_websocket() {
+        let config: openfang_types::config::KernelConfig = toml::from_str(
+            r#"
+            [channels.feishu]
+            app_id = "cli_test"
+            app_secret_env = "FEISHU_APP_SECRET"
+            mode = "websocket"
+            "#,
+        )
+        .unwrap();
+
+        let feishu = config.channels.feishu.expect("feishu config should exist");
+        assert_eq!(feishu.mode, openfang_types::config::FeishuMode::Websocket);
     }
 }

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -1858,6 +1858,7 @@ const CHANNEL_REGISTRY: &[ChannelMeta] = &[
             ChannelField { key: "app_id", label: "App ID", field_type: FieldType::Text, env_var: None, required: true, placeholder: "cli_abc123", advanced: false },
             ChannelField { key: "app_secret_env", label: "App Secret", field_type: FieldType::Secret, env_var: Some("FEISHU_APP_SECRET"), required: true, placeholder: "abc123...", advanced: false },
             ChannelField { key: "region", label: "Region", field_type: FieldType::Text, env_var: None, required: false, placeholder: "cn or intl", advanced: false },
+            ChannelField { key: "mode", label: "Receive Mode", field_type: FieldType::Text, env_var: None, required: false, placeholder: "webhook|websocket", advanced: true },
             ChannelField { key: "webhook_port", label: "Webhook Port", field_type: FieldType::Number, env_var: None, required: false, placeholder: "8453", advanced: true },
             ChannelField { key: "webhook_path", label: "Webhook Path", field_type: FieldType::Text, env_var: None, required: false, placeholder: "/feishu/webhook", advanced: true },
             ChannelField { key: "verification_token", label: "Verification Token", field_type: FieldType::Text, env_var: None, required: false, placeholder: "verify-token", advanced: true },
@@ -1866,7 +1867,7 @@ const CHANNEL_REGISTRY: &[ChannelMeta] = &[
             ChannelField { key: "default_agent", label: "Default Agent", field_type: FieldType::Text, env_var: None, required: false, placeholder: "assistant", advanced: true },
         ],
         setup_steps: &["Create an app at open.feishu.cn (CN) or open.larksuite.com (International)", "Copy App ID and Secret", "Set region: cn (Feishu) or intl (Lark)"],
-        config_template: "[channels.feishu]\napp_id = \"\"\napp_secret_env = \"FEISHU_APP_SECRET\"\nregion = \"cn\"",
+        config_template: "[channels.feishu]\napp_id = \"\"\napp_secret_env = \"FEISHU_APP_SECRET\"\nregion = \"cn\"\nmode = \"websocket\"",
     },
     ChannelMeta {
         name: "dingtalk", display_name: "DingTalk", icon: "DT",
@@ -2285,6 +2286,23 @@ fn build_field_json(
 /// Find a channel definition by name.
 fn find_channel_meta(name: &str) -> Option<&'static ChannelMeta> {
     CHANNEL_REGISTRY.iter().find(|c| c.name == name)
+}
+
+#[cfg(test)]
+mod channel_meta_tests {
+    use super::*;
+
+    #[test]
+    fn feishu_channel_meta_includes_mode_field() {
+        let meta = find_channel_meta("feishu").expect("feishu channel meta should exist");
+        assert!(meta.fields.iter().any(|f| f.key == "mode"));
+    }
+
+    #[test]
+    fn feishu_channel_meta_template_includes_websocket_mode_default() {
+        let meta = find_channel_meta("feishu").expect("feishu channel meta should exist");
+        assert!(meta.config_template.contains("mode = \"websocket\""));
+    }
 }
 
 /// Serialize a channel's config to a JSON Value for pre-populating dashboard forms.

--- a/crates/openfang-channels/Cargo.toml
+++ b/crates/openfang-channels/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { workspace = true }
 dashmap = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
+prost = { workspace = true }
 reqwest = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }

--- a/crates/openfang-channels/src/feishu.rs
+++ b/crates/openfang-channels/src/feishu.rs
@@ -11,19 +11,23 @@
 //! - Rich text (post) message parsing
 //! - Event encryption/decryption support (AES-256-CBC)
 //! - Tenant access token caching with auto-refresh
+//! - WebSocket mode: Long connection receives events (no public IP required)
 
 use crate::types::{
     split_message, ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use futures::Stream;
+use futures::{SinkExt, Stream, StreamExt};
+use prost::Message as ProstMessage;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, RwLock};
-use tracing::{info, warn};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tracing::{debug, error, info, warn};
+use url::Url;
 use zeroize::Zeroizing;
 
 // ─── Region-based API endpoints ─────────────────────────────────────────────
@@ -37,6 +41,51 @@ const MAX_MESSAGE_LEN: usize = 4000;
 
 /// Token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
+
+/// Feishu websocket endpoint discovery API.
+const FEISHU_WS_ENDPOINT_URL: &str = "https://open.feishu.cn/callback/ws/endpoint";
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+const DEFAULT_WS_PING_INTERVAL_SECS: u64 = 30;
+
+/// Feishu websocket frame header.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct FeishuWsHeader {
+    #[prost(string, tag = "1")]
+    key: String,
+    #[prost(string, tag = "2")]
+    value: String,
+}
+
+/// Feishu websocket frame (pbbp2.proto compatible).
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct FeishuWsFrame {
+    #[prost(uint64, tag = "1")]
+    seq_id: u64,
+    #[prost(uint64, tag = "2")]
+    log_id: u64,
+    #[prost(int32, tag = "3")]
+    service: i32,
+    #[prost(int32, tag = "4")]
+    method: i32,
+    #[prost(message, repeated, tag = "5")]
+    headers: Vec<FeishuWsHeader>,
+    #[prost(string, optional, tag = "6")]
+    payload_encoding: Option<String>,
+    #[prost(string, optional, tag = "7")]
+    payload_type: Option<String>,
+    #[prost(bytes, optional, tag = "8")]
+    payload: Option<Vec<u8>>,
+    #[prost(string, optional, tag = "9")]
+    log_id_new: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct FeishuWsEndpoint {
+    url: String,
+    ping_interval_secs: u64,
+}
 
 /// Maximum cached message/event IDs for deduplication.
 const DEDUP_CACHE_SIZE: usize = 1000;
@@ -82,6 +131,17 @@ impl FeishuRegion {
     }
 }
 
+// ─── Connection Mode ──────────────────────────────────────────────────────
+
+/// Feishu connection mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeishuConnectionMode {
+    /// Webhook mode: HTTP server receives event callbacks.
+    Webhook,
+    /// WebSocket mode: Long connection receives events (no public IP required).
+    WebSocket,
+}
+
 // ─── Deduplication ──────────────────────────────────────────────────────────
 
 /// Simple ring-buffer deduplication cache.
@@ -117,15 +177,17 @@ impl DedupCache {
 
 /// Feishu/Lark Open Platform adapter.
 ///
-/// Inbound messages arrive via a webhook HTTP server that receives event
-/// callbacks from the platform. Outbound messages are sent via the IM API
+/// Inbound messages arrive via a webhook HTTP server or WebSocket long connection.
+/// Outbound messages are sent via the IM API
 /// with a tenant access token for authentication.
 pub struct FeishuAdapter {
     /// Feishu/Lark app ID.
     app_id: String,
     /// SECURITY: App secret, zeroized on drop.
     app_secret: Zeroizing<String>,
-    /// Port on which the inbound webhook HTTP server listens.
+    /// Connection mode (Webhook or WebSocket).
+    connection_mode: FeishuConnectionMode,
+    /// Port on which the inbound webhook HTTP server listens (Webhook mode only).
     webhook_port: u16,
     /// Region (CN or International).
     region: FeishuRegion,
@@ -157,6 +219,7 @@ impl FeishuAdapter {
         Self {
             app_id,
             app_secret: Zeroizing::new(app_secret),
+            connection_mode: FeishuConnectionMode::Webhook,
             webhook_port,
             region: FeishuRegion::Cn,
             webhook_path: "/feishu/webhook".to_string(),
@@ -193,6 +256,30 @@ impl FeishuAdapter {
         adapter.encrypt_key = encrypt_key;
         adapter.bot_names = bot_names;
         adapter
+    }
+
+    /// Create a new Feishu adapter in WebSocket mode.
+    ///
+    /// WebSocket mode does not require a public IP or webhook configuration.
+    pub fn new_websocket(app_id: String, app_secret: String) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            app_id,
+            app_secret: Zeroizing::new(app_secret),
+            connection_mode: FeishuConnectionMode::WebSocket,
+            webhook_port: 0,
+            region: FeishuRegion::Cn,
+            webhook_path: String::new(),
+            verification_token: None,
+            encrypt_key: None,
+            bot_names: Vec::new(),
+            client: reqwest::Client::new(),
+            shutdown_tx: Arc::new(shutdown_tx),
+            shutdown_rx,
+            cached_token: Arc::new(RwLock::new(None)),
+            message_dedup: Arc::new(DedupCache::new(DEDUP_CACHE_SIZE)),
+            event_dedup: Arc::new(DedupCache::new(DEDUP_CACHE_SIZE)),
+        }
     }
 
     /// API URL for a given path suffix.
@@ -368,6 +455,629 @@ impl FeishuAdapter {
         }
 
         Ok(())
+    }
+
+    /// Start webhook server (Webhook mode).
+    async fn start_webhook(
+        &self,
+        tx: mpsc::Sender<ChannelMessage>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let port = self.webhook_port;
+        let webhook_path = self.webhook_path.clone();
+        let verification_token = self.verification_token.clone();
+        let encrypt_key = self.encrypt_key.clone();
+        let bot_names = self.bot_names.clone();
+        let channel_name = self.region.channel_name().to_string();
+        let region_label = self.region.label().to_string();
+        let message_dedup = Arc::clone(&self.message_dedup);
+        let event_dedup = Arc::clone(&self.event_dedup);
+        let mut shutdown_rx = self.shutdown_rx.clone();
+
+        tokio::spawn(async move {
+            let verification_token = Arc::new(verification_token);
+            let encrypt_key = Arc::new(encrypt_key);
+            let tx = Arc::new(tx);
+            let bot_names = Arc::new(bot_names);
+            let channel_name = Arc::new(channel_name);
+            let region_label = Arc::new(region_label);
+
+            let app = axum::Router::new().route(
+                &webhook_path,
+                axum::routing::post({
+                    let vt = Arc::clone(&verification_token);
+                    let ek = Arc::clone(&encrypt_key);
+                    let tx = Arc::clone(&tx);
+                    let bot_names = Arc::clone(&bot_names);
+                    let channel_name = Arc::clone(&channel_name);
+                    let region_label = Arc::clone(&region_label);
+                    let message_dedup = Arc::clone(&message_dedup);
+                    let event_dedup = Arc::clone(&event_dedup);
+                    move |body: axum::extract::Json<serde_json::Value>| {
+                        let vt = Arc::clone(&vt);
+                        let ek = Arc::clone(&ek);
+                        let tx = Arc::clone(&tx);
+                        let bot_names = Arc::clone(&bot_names);
+                        let channel_name = Arc::clone(&channel_name);
+                        let region_label = Arc::clone(&region_label);
+                        let message_dedup = Arc::clone(&message_dedup);
+                        let event_dedup = Arc::clone(&event_dedup);
+                        async move {
+                            let mut event_data = body.0.clone();
+
+                            if let Some(encrypted) = body.0.get("encrypt").and_then(|v| v.as_str())
+                            {
+                                if let Some(ref key) = *ek {
+                                    match decrypt_event(encrypted, key) {
+                                        Ok(decrypted) => event_data = decrypted,
+                                        Err(e) => {
+                                            warn!("{region_label}: decrypt failed: {e}");
+                                            return (
+                                                axum::http::StatusCode::BAD_REQUEST,
+                                                axum::Json(
+                                                    serde_json::json!({"error": "decrypt failed"}),
+                                                ),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
+                            if event_data.get("type").and_then(|v| v.as_str())
+                                == Some("url_verification")
+                            {
+                                if let Some(ref expected_token) = *vt {
+                                    let token = event_data["token"].as_str().unwrap_or("");
+                                    if token != expected_token {
+                                        warn!("{region_label}: invalid verification token");
+                                        return (
+                                            axum::http::StatusCode::FORBIDDEN,
+                                            axum::Json(serde_json::json!({})),
+                                        );
+                                    }
+                                }
+                                if let Some(challenge) = body.0.get("challenge") {
+                                    return (
+                                        axum::http::StatusCode::OK,
+                                        axum::Json(serde_json::json!({
+                                            "challenge": challenge,
+                                        })),
+                                    );
+                                }
+                                let challenge = event_data
+                                    .get("challenge")
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::String(String::new()));
+                                return (
+                                    axum::http::StatusCode::OK,
+                                    axum::Json(serde_json::json!({
+                                        "challenge": challenge,
+                                    })),
+                                );
+                            }
+
+                            if let Some(event_id) = event_data
+                                .get("header")
+                                .and_then(|h| h.get("event_id"))
+                                .and_then(|v| v.as_str())
+                            {
+                                if event_dedup.check_and_insert(event_id) {
+                                    return (
+                                        axum::http::StatusCode::OK,
+                                        axum::Json(serde_json::json!({"code": 0})),
+                                    );
+                                }
+                            }
+
+                            let schema = event_data.get("schema").and_then(|v| v.as_str());
+                            if schema == Some("2.0") {
+                                if let Some(msg) =
+                                    parse_event(&event_data, &bot_names, &channel_name)
+                                {
+                                    if !message_dedup.check_and_insert(&msg.platform_message_id) {
+                                        let _ = tx.send(msg).await;
+                                    }
+                                }
+                            } else {
+                                let event_type = event_data["event"]["type"].as_str().unwrap_or("");
+                                if event_type == "message" {
+                                    let event = &event_data["event"];
+                                    let text = event["text"].as_str().unwrap_or("");
+                                    if !text.is_empty() {
+                                        let open_id =
+                                            event["open_id"].as_str().unwrap_or("").to_string();
+                                        let chat_id = event["open_chat_id"]
+                                            .as_str()
+                                            .unwrap_or("")
+                                            .to_string();
+                                        let msg_id = event["open_message_id"]
+                                            .as_str()
+                                            .unwrap_or("")
+                                            .to_string();
+                                        let is_group =
+                                            event["chat_type"].as_str().unwrap_or("") == "group";
+
+                                        if !message_dedup.check_and_insert(&msg_id) {
+                                            let content = if text.starts_with('/') {
+                                                let parts: Vec<&str> =
+                                                    text.splitn(2, ' ').collect();
+                                                let cmd = parts[0].trim_start_matches('/');
+                                                let args: Vec<String> = parts
+                                                    .get(1)
+                                                    .map(|a| {
+                                                        a.split_whitespace()
+                                                            .map(String::from)
+                                                            .collect()
+                                                    })
+                                                    .unwrap_or_default();
+                                                ChannelContent::Command {
+                                                    name: cmd.to_string(),
+                                                    args,
+                                                }
+                                            } else {
+                                                ChannelContent::Text(text.to_string())
+                                            };
+
+                                            let channel_msg = ChannelMessage {
+                                                channel: ChannelType::Custom(
+                                                    channel_name.to_string(),
+                                                ),
+                                                platform_message_id: msg_id,
+                                                sender: ChannelUser {
+                                                    platform_id: chat_id,
+                                                    display_name: open_id,
+                                                    openfang_user: None,
+                                                },
+                                                content,
+                                                target_agent: None,
+                                                timestamp: Utc::now(),
+                                                is_group,
+                                                thread_id: None,
+                                                metadata: HashMap::new(),
+                                            };
+
+                                            let _ = tx.send(channel_msg).await;
+                                        }
+                                    }
+                                }
+                            }
+
+                            (
+                                axum::http::StatusCode::OK,
+                                axum::Json(serde_json::json!({"code": 0})),
+                            )
+                        }
+                    }
+                }),
+            );
+
+            let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+            info!("{} webhook server listening on {addr}", *region_label);
+
+            let listener = match tokio::net::TcpListener::bind(addr).await {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!("{} webhook bind failed: {e}", *region_label);
+                    return;
+                }
+            };
+
+            let server = axum::serve(listener, app);
+
+            tokio::select! {
+                result = server => {
+                    if let Err(e) = result {
+                        warn!("{} webhook server error: {e}", *region_label);
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    info!("{} adapter shutting down", *region_label);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Start WebSocket connection loop (WebSocket mode).
+    async fn start_websocket_loop(
+        &self,
+        tx: mpsc::Sender<ChannelMessage>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let adapter = Arc::new(self.clone_adapter());
+
+        tokio::spawn(async move {
+            let label = adapter.region.label();
+            info!("Starting {label} WebSocket mode");
+            let mut shutdown_rx = adapter.shutdown_rx.clone();
+            let mut backoff = INITIAL_BACKOFF;
+
+            loop {
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+
+                if let Err(e) = Self::run_websocket_inner(adapter.clone(), tx.clone()).await {
+                    error!("{label} WebSocket error: {e}");
+                } else {
+                    info!("{label} WebSocket connection closed");
+                }
+
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+
+                warn!("{label} WebSocket reconnecting in {backoff:?}");
+                tokio::select! {
+                    _ = tokio::time::sleep(backoff) => {}
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+
+            info!("{label} WebSocket loop stopped");
+        });
+
+        Ok(())
+    }
+
+    fn clone_adapter(&self) -> FeishuAdapterClone {
+        FeishuAdapterClone {
+            app_id: self.app_id.clone(),
+            app_secret: self.app_secret.clone(),
+            region: self.region,
+            client: self.client.clone(),
+            shutdown_rx: self.shutdown_rx.clone(),
+            bot_names: self.bot_names.clone(),
+            message_dedup: Arc::clone(&self.message_dedup),
+            event_dedup: Arc::clone(&self.event_dedup),
+        }
+    }
+
+    async fn run_websocket_inner(
+        adapter: Arc<FeishuAdapterClone>,
+        tx: mpsc::Sender<ChannelMessage>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let label = adapter.region.label();
+        let endpoint = adapter.get_websocket_endpoint().await?;
+        let ws_url = endpoint.url;
+        let service_id = parse_service_id(&ws_url);
+
+        info!("Connecting to {label} WebSocket endpoint: {ws_url}");
+        let (ws_stream, _) = connect_async(&ws_url).await?;
+        info!("{label} WebSocket connected successfully");
+
+        let (mut write, mut read) = ws_stream.split();
+        let mut shutdown_rx = adapter.shutdown_rx.clone();
+        let mut ping_interval =
+            tokio::time::interval(Duration::from_secs(endpoint.ping_interval_secs));
+        ping_interval.tick().await;
+
+        let channel_name = adapter.region.channel_name().to_string();
+        let mut frame_parts: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+
+        loop {
+            tokio::select! {
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Binary(data))) => {
+                            let frame = match FeishuWsFrame::decode(data.as_slice()) {
+                                Ok(f) => f,
+                                Err(e) => {
+                                    warn!("{label} WS decode frame failed: {e}");
+                                    continue;
+                                }
+                            };
+
+                            match frame.method {
+                                0 => {
+                                    if let Some(new_interval) = parse_pong_interval(&frame) {
+                                        if new_interval > 0 {
+                                            debug!("{label} WS update ping interval to {}s", new_interval);
+                                            ping_interval = tokio::time::interval(Duration::from_secs(new_interval));
+                                            ping_interval.tick().await;
+                                        }
+                                    }
+                                }
+                                1 => {
+                                    Self::handle_data_frame(frame, &mut write, &tx, &adapter.bot_names, &channel_name, &adapter.message_dedup, &adapter.event_dedup, &mut frame_parts).await?;
+                                }
+                                method => {
+                                    debug!("{label} WS unhandled frame method: {method}");
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Text(text))) => {
+                            debug!("{label} WS unexpected text message: {text}");
+                        }
+                        Some(Ok(Message::Close(frame))) => {
+                            info!("{label} WebSocket closed by server: {frame:?}");
+                            break;
+                        }
+                        Some(Ok(Message::Ping(payload))) => {
+                            let _ = write.send(Message::Pong(payload)).await;
+                        }
+                        Some(Ok(Message::Pong(_))) => {
+                            debug!("{label} WebSocket pong");
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(e)) => return Err(format!("{label} WebSocket stream error: {e}").into()),
+                        None => break,
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    let ping_frame = build_ping_frame(service_id);
+                    write.send(Message::Binary(ping_frame.encode_to_vec())).await?;
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("{label} WebSocket shutting down");
+                        let _ = write.close().await;
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_data_frame<S>(
+        mut frame: FeishuWsFrame,
+        write: &mut S,
+        tx: &mpsc::Sender<ChannelMessage>,
+        bot_names: &[String],
+        channel_name: &str,
+        message_dedup: &DedupCache,
+        event_dedup: &DedupCache,
+        frame_parts: &mut HashMap<String, Vec<Vec<u8>>>,
+    ) -> Result<(), Box<dyn std::error::Error>>
+    where
+        S: SinkExt<Message> + Unpin,
+        <S as futures::Sink<Message>>::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let frame_type = ws_header(&frame.headers, "type").unwrap_or_default();
+        if frame_type != "event" {
+            return Ok(());
+        }
+
+        let payload = match frame.payload.take() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let payload = match combine_payload(&frame.headers, payload, frame_parts) {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let mut code = 200;
+        match serde_json::from_slice::<serde_json::Value>(&payload) {
+            Ok(event) => {
+                if let Some(event_id) = event
+                    .get("header")
+                    .and_then(|h| h.get("event_id"))
+                    .and_then(|v| v.as_str())
+                {
+                    if event_dedup.check_and_insert(event_id) {
+                        let ack_frame = build_ack_frame(&frame, code);
+                        write
+                            .send(Message::Binary(ack_frame.encode_to_vec()))
+                            .await?;
+                        return Ok(());
+                    }
+                }
+                if let Some(msg) = parse_event(&event, bot_names, channel_name) {
+                    if !message_dedup.check_and_insert(&msg.platform_message_id)
+                        && tx.send(msg).await.is_err()
+                    {
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("WS event payload parse failed: {e}");
+                code = 500;
+            }
+        }
+
+        let ack_frame = build_ack_frame(&frame, code);
+        write
+            .send(Message::Binary(ack_frame.encode_to_vec()))
+            .await?;
+        Ok(())
+    }
+}
+
+// ─── WebSocket adapter clone ────────────────────────────────────────────────
+
+/// Cloneable Feishu adapter parts for use in async WebSocket tasks.
+struct FeishuAdapterClone {
+    app_id: String,
+    app_secret: Zeroizing<String>,
+    region: FeishuRegion,
+    client: reqwest::Client,
+    shutdown_rx: watch::Receiver<bool>,
+    bot_names: Vec<String>,
+    message_dedup: Arc<DedupCache>,
+    event_dedup: Arc<DedupCache>,
+}
+
+impl FeishuAdapterClone {
+    /// Get WebSocket endpoint from Feishu API.
+    async fn get_websocket_endpoint(&self) -> Result<FeishuWsEndpoint, Box<dyn std::error::Error>> {
+        let resp = self
+            .client
+            .post(FEISHU_WS_ENDPOINT_URL)
+            .json(&serde_json::json!({
+                "AppID": self.app_id,
+                "AppSecret": self.app_secret.as_str(),
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let resp_body = resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "{} WebSocket endpoint request failed {status}: {resp_body}",
+                self.region.label()
+            )
+            .into());
+        }
+
+        let resp_body: serde_json::Value = resp.json().await?;
+        parse_ws_endpoint_response(&resp_body)
+    }
+}
+
+// ─── WebSocket helper functions ─────────────────────────────────────────────
+
+fn parse_ws_endpoint_response(
+    resp_body: &serde_json::Value,
+) -> Result<FeishuWsEndpoint, Box<dyn std::error::Error>> {
+    let code = resp_body["code"].as_i64().unwrap_or(-1);
+    if code != 0 {
+        let msg = resp_body["msg"].as_str().unwrap_or("unknown error");
+        return Err(format!("Feishu WebSocket endpoint error: {msg}").into());
+    }
+
+    let data = &resp_body["data"];
+    let ws_url = data
+        .get("url")
+        .or_else(|| data.get("URL"))
+        .and_then(|v| v.as_str())
+        .ok_or("Missing WebSocket URL in response")?
+        .to_string();
+
+    let ping_interval = data
+        .get("client_config")
+        .or_else(|| data.get("ClientConfig"))
+        .and_then(|cfg| cfg.get("ping_interval").or_else(|| cfg.get("PingInterval")))
+        .and_then(|v| v.as_u64())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_WS_PING_INTERVAL_SECS);
+
+    Ok(FeishuWsEndpoint {
+        url: ws_url,
+        ping_interval_secs: ping_interval,
+    })
+}
+
+fn parse_service_id(ws_url: &str) -> i32 {
+    Url::parse(ws_url)
+        .ok()
+        .and_then(|u| {
+            u.query_pairs()
+                .find(|(k, _)| k == "service_id")
+                .and_then(|(_, v)| v.parse::<i32>().ok())
+        })
+        .unwrap_or(0)
+}
+
+fn ws_header(headers: &[FeishuWsHeader], key: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|h| h.key == key)
+        .map(|h| h.value.clone())
+}
+
+fn parse_pong_interval(frame: &FeishuWsFrame) -> Option<u64> {
+    let frame_type = ws_header(&frame.headers, "type")?;
+    if frame_type != "pong" {
+        return None;
+    }
+
+    let payload = frame.payload.as_ref()?;
+    let value: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    value
+        .get("ping_interval")
+        .or_else(|| value.get("PingInterval"))
+        .and_then(|v| v.as_u64())
+}
+
+fn combine_payload(
+    headers: &[FeishuWsHeader],
+    payload: Vec<u8>,
+    frame_parts: &mut HashMap<String, Vec<Vec<u8>>>,
+) -> Option<Vec<u8>> {
+    let sum = ws_header(headers, "sum")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1);
+    if sum <= 1 {
+        return Some(payload);
+    }
+
+    let seq = ws_header(headers, "seq")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    let msg_id = ws_header(headers, "message_id")?;
+
+    if seq >= sum {
+        return None;
+    }
+
+    let entry = frame_parts
+        .entry(msg_id.clone())
+        .or_insert_with(|| vec![Vec::new(); sum]);
+
+    if entry.len() != sum {
+        *entry = vec![Vec::new(); sum];
+    }
+
+    entry[seq] = payload;
+
+    if entry.iter().any(|part| part.is_empty()) {
+        return None;
+    }
+
+    let mut combined = Vec::new();
+    for part in entry.iter() {
+        combined.extend_from_slice(part);
+    }
+    frame_parts.remove(&msg_id);
+    Some(combined)
+}
+
+fn build_ping_frame(service_id: i32) -> FeishuWsFrame {
+    FeishuWsFrame {
+        seq_id: 0,
+        log_id: 0,
+        service: service_id,
+        method: 0,
+        headers: vec![FeishuWsHeader {
+            key: "type".to_string(),
+            value: "ping".to_string(),
+        }],
+        payload_encoding: None,
+        payload_type: None,
+        payload: None,
+        log_id_new: None,
+    }
+}
+
+fn build_ack_frame(request: &FeishuWsFrame, code: u16) -> FeishuWsFrame {
+    let payload = serde_json::json!({
+        "code": code,
+        "headers": {},
+        "data": []
+    });
+
+    FeishuWsFrame {
+        seq_id: request.seq_id,
+        log_id: request.log_id,
+        service: request.service,
+        method: request.method,
+        headers: request.headers.clone(),
+        payload_encoding: None,
+        payload_type: None,
+        payload: Some(serde_json::to_vec(&payload).unwrap_or_default()),
+        log_id_new: request.log_id_new.clone(),
     }
 }
 
@@ -634,226 +1344,11 @@ impl ChannelAdapter for FeishuAdapter {
         info!("{label} adapter authenticated as {bot_name}");
 
         let (tx, rx) = mpsc::channel::<ChannelMessage>(256);
-        let port = self.webhook_port;
-        let webhook_path = self.webhook_path.clone();
-        let verification_token = self.verification_token.clone();
-        let encrypt_key = self.encrypt_key.clone();
-        let bot_names = self.bot_names.clone();
-        let channel_name = self.region.channel_name().to_string();
-        let region_label = self.region.label().to_string();
-        let message_dedup = Arc::clone(&self.message_dedup);
-        let event_dedup = Arc::clone(&self.event_dedup);
-        let mut shutdown_rx = self.shutdown_rx.clone();
 
-        tokio::spawn(async move {
-            let verification_token = Arc::new(verification_token);
-            let encrypt_key = Arc::new(encrypt_key);
-            let tx = Arc::new(tx);
-            let bot_names = Arc::new(bot_names);
-            let channel_name = Arc::new(channel_name);
-            let region_label = Arc::new(region_label);
-
-            let app = axum::Router::new().route(
-                &webhook_path,
-                axum::routing::post({
-                    let vt = Arc::clone(&verification_token);
-                    let ek = Arc::clone(&encrypt_key);
-                    let tx = Arc::clone(&tx);
-                    let bot_names = Arc::clone(&bot_names);
-                    let channel_name = Arc::clone(&channel_name);
-                    let region_label = Arc::clone(&region_label);
-                    let message_dedup = Arc::clone(&message_dedup);
-                    let event_dedup = Arc::clone(&event_dedup);
-                    move |body: axum::extract::Json<serde_json::Value>| {
-                        let vt = Arc::clone(&vt);
-                        let ek = Arc::clone(&ek);
-                        let tx = Arc::clone(&tx);
-                        let bot_names = Arc::clone(&bot_names);
-                        let channel_name = Arc::clone(&channel_name);
-                        let region_label = Arc::clone(&region_label);
-                        let message_dedup = Arc::clone(&message_dedup);
-                        let event_dedup = Arc::clone(&event_dedup);
-                        async move {
-                            let mut event_data = body.0.clone();
-
-                            // Step 1: Decrypt if encrypted
-                            if let Some(encrypted) = body.0.get("encrypt").and_then(|v| v.as_str())
-                            {
-                                if let Some(ref key) = *ek {
-                                    match decrypt_event(encrypted, key) {
-                                        Ok(decrypted) => {
-                                            event_data = decrypted;
-                                        }
-                                        Err(e) => {
-                                            warn!("{region_label}: decrypt failed: {e}");
-                                            return (
-                                                axum::http::StatusCode::BAD_REQUEST,
-                                                axum::Json(
-                                                    serde_json::json!({"error": "decrypt failed"}),
-                                                ),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Step 2: URL verification challenge
-                            if event_data.get("type").and_then(|v| v.as_str())
-                                == Some("url_verification")
-                            {
-                                if let Some(ref expected_token) = *vt {
-                                    let token = event_data["token"].as_str().unwrap_or("");
-                                    if token != expected_token {
-                                        warn!("{region_label}: invalid verification token");
-                                        return (
-                                            axum::http::StatusCode::FORBIDDEN,
-                                            axum::Json(serde_json::json!({})),
-                                        );
-                                    }
-                                }
-                                // Also handle v2 challenge format
-                                if let Some(challenge) = body.0.get("challenge") {
-                                    return (
-                                        axum::http::StatusCode::OK,
-                                        axum::Json(serde_json::json!({
-                                            "challenge": challenge,
-                                        })),
-                                    );
-                                }
-                                let challenge = event_data
-                                    .get("challenge")
-                                    .cloned()
-                                    .unwrap_or(serde_json::Value::String(String::new()));
-                                return (
-                                    axum::http::StatusCode::OK,
-                                    axum::Json(serde_json::json!({
-                                        "challenge": challenge,
-                                    })),
-                                );
-                            }
-
-                            // Step 3: Event deduplication
-                            if let Some(event_id) = event_data
-                                .get("header")
-                                .and_then(|h| h.get("event_id"))
-                                .and_then(|v| v.as_str())
-                            {
-                                if event_dedup.check_and_insert(event_id) {
-                                    return (
-                                        axum::http::StatusCode::OK,
-                                        axum::Json(serde_json::json!({"code": 0})),
-                                    );
-                                }
-                            }
-
-                            // Step 4: Parse V2 event
-                            let schema = event_data.get("schema").and_then(|v| v.as_str());
-                            if schema == Some("2.0") {
-                                if let Some(msg) =
-                                    parse_event(&event_data, &bot_names, &channel_name)
-                                {
-                                    if !message_dedup.check_and_insert(&msg.platform_message_id) {
-                                        let _ = tx.send(msg).await;
-                                    }
-                                }
-                            } else {
-                                // V1 legacy event format
-                                let event_type = event_data["event"]["type"].as_str().unwrap_or("");
-                                if event_type == "message" {
-                                    let event = &event_data["event"];
-                                    let text = event["text"].as_str().unwrap_or("");
-                                    if !text.is_empty() {
-                                        let open_id =
-                                            event["open_id"].as_str().unwrap_or("").to_string();
-                                        let chat_id = event["open_chat_id"]
-                                            .as_str()
-                                            .unwrap_or("")
-                                            .to_string();
-                                        let msg_id = event["open_message_id"]
-                                            .as_str()
-                                            .unwrap_or("")
-                                            .to_string();
-                                        let is_group =
-                                            event["chat_type"].as_str().unwrap_or("") == "group";
-
-                                        if !message_dedup.check_and_insert(&msg_id) {
-                                            let content = if text.starts_with('/') {
-                                                let parts: Vec<&str> =
-                                                    text.splitn(2, ' ').collect();
-                                                let cmd = parts[0].trim_start_matches('/');
-                                                let args: Vec<String> = parts
-                                                    .get(1)
-                                                    .map(|a| {
-                                                        a.split_whitespace()
-                                                            .map(String::from)
-                                                            .collect()
-                                                    })
-                                                    .unwrap_or_default();
-                                                ChannelContent::Command {
-                                                    name: cmd.to_string(),
-                                                    args,
-                                                }
-                                            } else {
-                                                ChannelContent::Text(text.to_string())
-                                            };
-
-                                            let channel_msg = ChannelMessage {
-                                                channel: ChannelType::Custom(
-                                                    channel_name.to_string(),
-                                                ),
-                                                platform_message_id: msg_id,
-                                                sender: ChannelUser {
-                                                    platform_id: chat_id,
-                                                    display_name: open_id,
-                                                    openfang_user: None,
-                                                },
-                                                content,
-                                                target_agent: None,
-                                                timestamp: Utc::now(),
-                                                is_group,
-                                                thread_id: None,
-                                                metadata: HashMap::new(),
-                                            };
-
-                                            let _ = tx.send(channel_msg).await;
-                                        }
-                                    }
-                                }
-                            }
-
-                            (
-                                axum::http::StatusCode::OK,
-                                axum::Json(serde_json::json!({"code": 0})),
-                            )
-                        }
-                    }
-                }),
-            );
-
-            let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-            info!("{} webhook server listening on {addr}", *region_label);
-
-            let listener = match tokio::net::TcpListener::bind(addr).await {
-                Ok(l) => l,
-                Err(e) => {
-                    warn!("{} webhook bind failed: {e}", *region_label);
-                    return;
-                }
-            };
-
-            let server = axum::serve(listener, app);
-
-            tokio::select! {
-                result = server => {
-                    if let Err(e) = result {
-                        warn!("{} webhook server error: {e}", *region_label);
-                    }
-                }
-                _ = shutdown_rx.changed() => {
-                    info!("{} adapter shutting down", *region_label);
-                }
-            }
-        });
+        match self.connection_mode {
+            FeishuConnectionMode::Webhook => self.start_webhook(tx).await?,
+            FeishuConnectionMode::WebSocket => self.start_websocket_loop(tx).await?,
+        }
 
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
@@ -1291,5 +1786,117 @@ mod tests {
 
         let msg = parse_event(&event, &[], "feishu").unwrap();
         assert_eq!(msg.thread_id, Some("om_root1".to_string()));
+    }
+
+    // ─── WebSocket mode tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_feishu_websocket_adapter_creation() {
+        let adapter = FeishuAdapter::new_websocket(
+            "cli_abc123".to_string(),
+            "app-secret-456".to_string(),
+        );
+        assert_eq!(adapter.name(), "feishu");
+        assert_eq!(adapter.connection_mode, FeishuConnectionMode::WebSocket);
+        assert_eq!(adapter.webhook_port, 0); // not used in WS mode
+    }
+
+    #[test]
+    fn test_connection_mode_default_is_webhook() {
+        let adapter =
+            FeishuAdapter::new("cli_abc123".to_string(), "secret".to_string(), 9000);
+        assert_eq!(adapter.connection_mode, FeishuConnectionMode::Webhook);
+    }
+
+    #[test]
+    fn test_ws_endpoint_parsing() {
+        let resp = serde_json::json!({
+            "code": 0,
+            "data": {
+                "URL": "wss://open.feishu.cn/callback/ws/endpoint?token=abc123"
+            }
+        });
+        let url = resp
+            .get("data")
+            .and_then(|d| d.get("URL"))
+            .and_then(|u| u.as_str())
+            .unwrap();
+        assert!(url.starts_with("wss://"));
+        assert!(url.contains("token=abc123"));
+    }
+
+    #[test]
+    fn test_combine_payload_single_part() {
+        let headers = vec![];
+        let mut parts = HashMap::new();
+        let result = combine_payload(&headers, b"hello world".to_vec(), &mut parts);
+        assert_eq!(result, Some(b"hello world".to_vec()));
+    }
+
+    #[test]
+    fn test_combine_payload_multi_part() {
+        let headers_seq0 = vec![
+            FeishuWsHeader { key: "sum".to_string(), value: "2".to_string() },
+            FeishuWsHeader { key: "seq".to_string(), value: "0".to_string() },
+            FeishuWsHeader { key: "message_id".to_string(), value: "msg1".to_string() },
+        ];
+        let headers_seq1 = vec![
+            FeishuWsHeader { key: "sum".to_string(), value: "2".to_string() },
+            FeishuWsHeader { key: "seq".to_string(), value: "1".to_string() },
+            FeishuWsHeader { key: "message_id".to_string(), value: "msg1".to_string() },
+        ];
+        let mut parts = HashMap::new();
+        // First part — not yet complete
+        let r1 = combine_payload(&headers_seq0, b"hello ".to_vec(), &mut parts);
+        assert!(r1.is_none());
+        // Second part — now complete
+        let r2 = combine_payload(&headers_seq1, b"world".to_vec(), &mut parts);
+        assert_eq!(r2, Some(b"hello world".to_vec()));
+    }
+
+    #[test]
+    fn test_ws_header_lookup() {
+        let headers = vec![
+            FeishuWsHeader { key: "service_id".to_string(), value: "svc_123".to_string() },
+        ];
+        assert_eq!(ws_header(&headers, "service_id"), Some("svc_123".to_string()));
+        assert_eq!(ws_header(&headers, "missing"), None);
+    }
+
+    #[test]
+    fn test_build_ping_frame() {
+        let frame = build_ping_frame(42);
+        assert_eq!(frame.method, 0); // ping method
+        assert_eq!(frame.service, 42);
+        assert_eq!(frame.headers.len(), 1);
+        assert_eq!(frame.headers[0].key, "type");
+        assert_eq!(frame.headers[0].value, "ping");
+    }
+
+    #[test]
+    fn test_build_ack_frame() {
+        let data_frame = FeishuWsFrame {
+            seq_id: 100,
+            log_id: 200,
+            service: 1,
+            method: 2,
+            headers: vec![
+                FeishuWsHeader { key: "log_id".to_string(), value: "log_abc".to_string() },
+                FeishuWsHeader { key: "type".to_string(), value: "event".to_string() },
+            ],
+            payload: Some(vec![]),
+            payload_encoding: None,
+            payload_type: None,
+            log_id_new: None,
+        };
+        let ack = build_ack_frame(&data_frame, 0);
+        assert_eq!(ack.seq_id, 100);
+        assert_eq!(ack.log_id, 200);
+        assert_eq!(ack.service, 1);
+        assert_eq!(ack.method, 2);
+        assert_eq!(ack.headers.len(), data_frame.headers.len());
+        // Payload should contain JSON with code
+        let payload_str = String::from_utf8(ack.payload.unwrap()).unwrap();
+        assert!(payload_str.contains("\"code\":0"));
     }
 }

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -2372,6 +2372,17 @@ impl Default for BlueskyConfig {
     }
 }
 
+/// Feishu inbound event receive mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum FeishuMode {
+    /// Receive events via HTTP webhook callback.
+    Webhook,
+    /// Receive events via WebSocket long connection.
+    #[default]
+    Websocket,
+}
+
 /// Feishu/Lark Open Platform channel adapter configuration.
 ///
 /// Supports both Feishu (China domestic, `open.feishu.cn`) and Lark
@@ -2383,6 +2394,8 @@ pub struct FeishuConfig {
     pub app_id: String,
     /// Env var name holding the app secret.
     pub app_secret_env: String,
+    /// Inbound receive mode (`webhook` or `websocket`).
+    pub mode: FeishuMode,
     /// Port for the incoming webhook.
     pub webhook_port: u16,
     /// Region: "cn" for Feishu (open.feishu.cn), "intl" for Lark (open.larksuite.com).
@@ -2408,6 +2421,7 @@ impl Default for FeishuConfig {
         Self {
             app_id: String::new(),
             app_secret_env: "FEISHU_APP_SECRET".to_string(),
+            mode: FeishuMode::Websocket,
             webhook_port: 8453,
             region: "cn".to_string(),
             webhook_path: "/feishu/webhook".to_string(),
@@ -3916,6 +3930,31 @@ mod tests {
         assert_eq!(config.browser.max_sessions, browser_sessions);
         assert_eq!(config.web.fetch.max_response_bytes, fetch_bytes);
         assert_eq!(config.web.fetch.timeout_secs, fetch_timeout);
+    }
+
+    #[test]
+    fn test_feishu_mode_defaults_to_websocket() {
+        let toml_str = r#"
+            [channels.feishu]
+            app_id = "cli_test"
+            app_secret_env = "FEISHU_APP_SECRET"
+        "#;
+        let config: KernelConfig = toml::from_str(toml_str).unwrap();
+        let feishu = config.channels.feishu.unwrap();
+        assert_eq!(feishu.mode, FeishuMode::Websocket);
+    }
+
+    #[test]
+    fn test_feishu_mode_parses_websocket() {
+        let toml_str = r#"
+            [channels.feishu]
+            app_id = "cli_test"
+            app_secret_env = "FEISHU_APP_SECRET"
+            mode = "websocket"
+        "#;
+        let config: KernelConfig = toml::from_str(toml_str).unwrap();
+        let feishu = config.channels.feishu.unwrap();
+        assert_eq!(feishu.mode, FeishuMode::Websocket);
     }
 
     #[test]

--- a/docs/channel-adapters.md
+++ b/docs/channel-adapters.md
@@ -14,6 +14,7 @@ All adapters share a common foundation: graceful shutdown via `watch::channel`, 
 - [Discord](#discord)
 - [Slack](#slack)
 - [WhatsApp](#whatsapp)
+- [Feishu / Lark](#feishu--lark)
 - [Signal](#signal)
 - [Matrix](#matrix)
 - [Email](#email)
@@ -45,7 +46,7 @@ All adapters share a common foundation: graceful shutdown via `watch::channel`, 
 | Mattermost | WebSocket + REST v4 | `MATTERMOST_TOKEN`, `MATTERMOST_URL` | `Mattermost` |
 | Google Chat | Service account webhook | `GOOGLE_CHAT_SA_KEY`, `GOOGLE_CHAT_SPACE` | `Custom("google_chat")` |
 | Webex | Bot SDK WebSocket | `WEBEX_BOT_TOKEN` | `Custom("webex")` |
-| Feishu / Lark | Open Platform webhook | `FEISHU_APP_ID`, `FEISHU_APP_SECRET` | `Custom("feishu")` |
+| Feishu / Lark | Open Platform Webhook / WebSocket | `FEISHU_APP_ID`, `FEISHU_APP_SECRET` | `Custom("feishu")` |
 | Rocket.Chat | REST polling | `ROCKETCHAT_TOKEN`, `ROCKETCHAT_URL` | `Custom("rocketchat")` |
 | Zulip | Event queue long-polling | `ZULIP_EMAIL`, `ZULIP_API_KEY`, `ZULIP_URL` | `Custom("zulip")` |
 | XMPP | XMPP protocol (stub) | `XMPP_JID`, `XMPP_PASSWORD`, `XMPP_SERVER` | `Custom("xmpp")` |
@@ -430,6 +431,60 @@ default_agent = "assistant"
 ### How It Works
 
 The WhatsApp adapter runs an HTTP server (on the configured `webhook_port`) that receives incoming webhooks from the WhatsApp Cloud API. It handles webhook verification (GET) and message reception (POST). Responses are sent via the Cloud API's `messages` endpoint.
+
+---
+
+## Feishu / Lark
+
+### Prerequisites
+
+- A Feishu/Lark app created in [open.feishu.cn](https://open.feishu.cn/)
+- App ID and App Secret
+
+### Setup
+
+1. Create a custom app in Feishu Open Platform.
+2. Enable the IM message event subscription for your app.
+3. Set environment variable:
+
+```bash
+export FEISHU_APP_SECRET=cli_xxx_secret
+```
+
+4. Add to config (default: `websocket` mode):
+
+```toml
+[channels.feishu]
+app_id = "cli_xxx"
+app_secret_env = "FEISHU_APP_SECRET"
+mode = "websocket"
+default_agent = "assistant"
+```
+
+5. Restart the daemon.
+
+### Webhook Compatibility Mode
+
+If you need the legacy callback flow, switch to `webhook` and expose a public callback URL:
+
+```toml
+[channels.feishu]
+app_id = "cli_xxx"
+app_secret_env = "FEISHU_APP_SECRET"
+mode = "webhook"
+webhook_port = 8453
+default_agent = "assistant"
+```
+
+Then configure Feishu event callback to:
+
+`https://<your-domain>:8453/feishu/webhook`
+
+### How It Works
+
+- **websocket mode**: OpenFang obtains endpoint from Feishu and receives events via long connection (no public inbound webhook needed).
+- **webhook mode**: OpenFang starts an HTTP callback server and receives Feishu push events.
+- **send path (both modes)**: outbound messages still go through Feishu OpenAPI HTTP `im/v1/messages`.
 
 ---
 


### PR DESCRIPTION
## Summary

  Add WebSocket long-connection receive mode for the Feishu/Lark adapter as an alternative to webhook callbacks. WebSocket mode is enabled by default — no public IP or domain required, lowering the deployment barrier.

  - New `FeishuConnectionMode` enum (Webhook / WebSocket) with mode dispatch in `start()`
  - Protobuf binary frame parsing based on Feishu's pbbp2 protocol (`prost`)
  - WebSocket connection management: auto-reconnect, ping/pong heartbeat, ACK, multi-part payload combination
  - `handle_data_frame` reuses the existing `parse_event()` pipeline, preserving dedup, group chat filtering, and rich text parsing
  - New `FeishuMode` enum and `mode` field in config (default: `websocket`); bridge layer creates the appropriate adapter per mode

  ## Changed Files

  | File | Change |
  |------|--------|
  | `openfang-types/config.rs` | Add `FeishuMode` enum + `mode` field to `FeishuConfig` |
  | `openfang-api/channel_bridge.rs` | Dispatch adapter creation by mode (Webhook / WebSocket) |
  | `openfang-api/routes.rs` | Expose `mode` field in channel metadata |
  | `openfang-channels/Cargo.toml` | Add `prost` dependency |
  | `openfang-channels/feishu.rs` | Core: protobuf frame structs, WS connection loop, mode dispatch |
  | `docs/channel-adapters.md` | Documentation update |

  ## Config Example

  ```toml
  [channels.feishu]
  app_id = "cli_xxx"
  app_secret_env = "FEISHU_APP_SECRET"
  mode = "websocket"  # or "webhook", default: websocket

  Test Plan

  - 31 feishu unit tests pass (including 8 new WebSocket tests)
  - Full workspace builds cleanly
  - Clippy zero warnings (excluding pre-existing CLI issues)
  - Live Feishu WebSocket integration test