### PR TITLE
fix runtime page stat card layout

### DIFF
--- a/crates/openfang-api/static/css/components.css
+++ b/crates/openfang-api/static/css/components.css
@@ -1276,6 +1276,8 @@ mark.search-highlight {
 .flex-col { flex-direction: column; }
 .items-center { align-items: center; }
 .justify-between { justify-content: space-between; }
+.grid { display: grid; }
+.grid-cols-4 { grid-template-columns: repeat(4, 1fr); }
 .gap-2 { gap: 8px; }
 .gap-3 { gap: 12px; }
 .gap-4 { gap: 16px; }
@@ -1283,6 +1285,7 @@ mark.search-highlight {
 .mt-4 { margin-top: 16px; }
 .mb-2 { margin-bottom: 8px; }
 .mb-4 { margin-bottom: 16px; }
+.mb-6 { margin-bottom: 24px; }
 .text-dim { color: var(--text-dim); }
 .text-sm { font-size: 11px; }
 .text-xs { font-size: 10px; }

--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -4972,7 +4972,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
         <div class="page-body" x-init="loadData()">
           <div x-show="loading" class="loading-state"><div class="spinner"></div><span>Loading runtime info...</span></div>
           <div x-show="!loading">
-            <div class="grid grid-cols-4" style="gap:16px;margin-bottom:24px">
+            <div class="grid grid-cols-4 gap-4 mb-6">
               <div class="card stat-card">
                 <div class="stat-label">Uptime</div>
                 <div class="stat-value" x-text="uptime"></div>


### PR DESCRIPTION
## Summary

Add missing CSS rules for grid grid-cols-4 utility classes.

## Changes

Before:

<img width="1564" height="603" alt="image" src="https://github.com/user-attachments/assets/eeba237b-4810-4fa8-98f6-acca1a595324" />

After:

<img width="1576" height="283" alt="image" src="https://github.com/user-attachments/assets/d92b15c6-025c-4b57-a51f-497796426550" />


## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
