### PR TITLE
fix(docs): correct search_provider value for DuckDuckGo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,7 +126,7 @@ shared_secret = ""                   # Required when network_enabled = true
 
 # --- Web Tools ---
 [web]
-search_provider = "auto"             # auto | brave | tavily | perplexity | duckduckgo
+search_provider = "auto"             # auto | brave | tavily | perplexity | duck_duck_go
 cache_ttl_minutes = 15
 
 [web.brave]
@@ -341,7 +341,7 @@ cache_ttl_minutes = 15
 | `brave` | Brave Search API. Requires `BRAVE_API_KEY`. |
 | `tavily` | Tavily AI-native search. Requires `TAVILY_API_KEY`. |
 | `perplexity` | Perplexity AI search. Requires `PERPLEXITY_API_KEY`. |
-| `duckduckgo` | DuckDuckGo HTML scraping. No API key needed. |
+| `duck_duck_go` | DuckDuckGo HTML scraping. No API key needed. |
 
 #### `[web.brave]`
 
@@ -1419,7 +1419,7 @@ For **web search providers**, the validator checks:
 | `brave` | `web.brave.api_key_env` |
 | `tavily` | `web.tavily.api_key_env` |
 | `perplexity` | `web.perplexity.api_key_env` |
-| `duckduckgo` | (no check -- no API key needed) |
+| `duck_duck_go` | (no check -- no API key needed) |
 | `auto` | (no check -- cascading fallback handles missing keys) |
 
 ### What is NOT validated


### PR DESCRIPTION
## Summary

The docs listed `duckduckgo` as the TOML config value for DuckDuckGo search, but the actual deserialised value is `duck_duck_go`.

The `SearchProvider` enum uses `#[serde(rename_all = "snake_case")]`, which converts the `DuckDuckGo` variant to `duck_duck_go` — inserting underscores at each word boundary. A user following the docs and writing `search_provider = "duckduckgo"` would silently fall back to `auto` instead of getting the intended provider.

Three occurrences corrected in `docs/configuration.md`:
- The annotated example snippet (line 129)
- The provider reference table (line 344)
- The config validation table (line 1422)

## Verification

```rust
// openfang-types/src/config.rs
#[derive(Serialize, Deserialize)]
#[serde(rename_all = "snake_case")]
pub enum SearchProvider {
    DuckDuckGo,  // serialises as "duck_duck_go", not "duckduckgo"
    // ...
}
```

## Test plan
- [ ] Confirm `search_provider = "duck_duck_go"` in a local config correctly selects DuckDuckGo (no fallback to `auto`)
- [ ] Confirm `search_provider = "duckduckgo"` (old docs value) does NOT match and falls through to `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)