### PR TITLE
fix: make tool allowlist/blocklist matching case-insensitive

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5164,10 +5164,10 @@ impl OpenFangKernel {
             .unwrap_or_default();
 
         if !tool_allowlist.is_empty() {
-            all_tools.retain(|t| tool_allowlist.iter().any(|a| a == &t.name));
+            all_tools.retain(|t| tool_allowlist.iter().any(|a| a.to_lowercase() == t.name.to_lowercase()));
         }
         if !tool_blocklist.is_empty() {
-            all_tools.retain(|t| !tool_blocklist.iter().any(|b| b == &t.name));
+            all_tools.retain(|t| !tool_blocklist.iter().any(|b| b.to_lowercase() == t.name.to_lowercase()));
         }
 
         // Step 5: Remove shell_exec if exec_policy denies it.


### PR DESCRIPTION
## Problem

Tool names stored via the dashboard can arrive in any case (e.g. `FILE_READ` vs the internally-registered name `file_read`). The previous case-sensitive `==` comparison in `available_tools()` caused allowlisted tools to silently match nothing, giving the agent an empty effective tool set with no error or warning.

This is particularly easy to trigger: the dashboard's Tool Filters UI displays tool names in uppercase, and a user adding tools to an allowlist by typing them will naturally use the same case they see on screen.

## Fix

Normalise both sides with `.to_lowercase()` before comparing:

```rust
// before
all_tools.retain(|t| tool_allowlist.iter().any(|a| a == &t.name));

// after
all_tools.retain(|t| tool_allowlist.iter().any(|a| a.to_lowercase() == t.name.to_lowercase()));
```

Same change applied to the blocklist retain. Two lines changed, no behaviour change for correctly-cased names.

## Impact

Without this fix, an agent with a non-empty allowlist containing uppercase names silently receives zero tools — nothing in the logs indicates the filter matched nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)