### PR TITLE
fix: preserve API-patched tool filters across Hand respawn

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -3216,6 +3216,18 @@ impl OpenFangKernel {
                 other => KernelError::OpenFang(OpenFangError::Internal(other.to_string())),
             })?;
 
+        // Capture any API-patched tool filters from the existing agent before respawn so that
+        // changes made via PUT /api/agents/{id}/tools persist across daemon restarts and
+        // hand reactivations. The manifest rebuild below overwrites everything from HAND.toml,
+        // so we save and reapply these fields explicitly.
+        let existing_tool_filters: (Vec<String>, Vec<String>) = self
+            .registry
+            .list()
+            .into_iter()
+            .find(|e| e.name == def.agent.name)
+            .map(|e| (e.manifest.tool_allowlist.clone(), e.manifest.tool_blocklist.clone()))
+            .unwrap_or_default();
+
         // Build an agent manifest from the hand definition.
         // If the hand declares provider/model as "default", inherit the kernel's configured LLM.
         let hand_provider = if def.agent.provider == "default" {
@@ -3286,6 +3298,16 @@ impl OpenFangKernel {
             },
             ..Default::default()
         };
+
+        // Restore API-patched tool filters so they survive respawn.
+        // Only apply if non-empty — an empty saved list means "no override set", not "block all".
+        let (saved_allowlist, saved_blocklist) = existing_tool_filters;
+        if !saved_allowlist.is_empty() {
+            manifest.tool_allowlist = saved_allowlist;
+        }
+        if !saved_blocklist.is_empty() {
+            manifest.tool_blocklist = saved_blocklist;
+        }
 
         // Resolve hand settings → prompt block + env vars
         let resolved = openfang_hands::resolve_settings(&def.settings, &instance.config);


### PR DESCRIPTION
## Problem

When a Hand agent is respawned (on daemon restart or reactivation), `activate_hand()` rebuilds the manifest entirely from `HAND.toml`, silently discarding any `tool_allowlist`/`tool_blocklist` changes made via `PUT /api/agents/{id}/tools`. The API returned `{"status":"ok"}` for these updates, creating a broken contract: changes appeared to succeed but were lost on the next restart.

This affects any user who configures tool restrictions through the dashboard or API, expecting them to be permanent.

## Fix

Before rebuilding the manifest, capture the existing agent's `tool_allowlist` and `tool_blocklist`. After the manifest is constructed from `HAND.toml`, reapply the saved filters:

```rust
// Capture before rebuild
let existing_tool_filters: (Vec<String>, Vec<String>) = self
    .registry
    .list()
    .into_iter()
    .find(|e| e.name == def.agent.name)
    .map(|e| (e.manifest.tool_allowlist.clone(), e.manifest.tool_blocklist.clone()))
    .unwrap_or_default();

// ... manifest built from HAND.toml ...

// Restore after rebuild
let (saved_allowlist, saved_blocklist) = existing_tool_filters;
if !saved_allowlist.is_empty() {
    manifest.tool_allowlist = saved_allowlist;
}
if !saved_blocklist.is_empty() {
    manifest.tool_blocklist = saved_blocklist;
}
```

Empty saved filters are treated as "no override set" (not "block all"), so Hands with no API-set filters continue to receive the full tool list from `HAND.toml`.

## Behaviour

- First activation (no existing agent): no saved filters → full HAND.toml tool list, unchanged
- Respawn after API patch: saved filters reapplied → patch survives
- `HAND.toml` tool list changes still take effect on first activation of a fresh instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)