### PR TITLE
fix: make heartbeat interval configurable and reduce researcher max_iterations

### DIFF
--- a/crates/openfang-hands/bundled/researcher/HAND.toml
+++ b/crates/openfang-hands/bundled/researcher/HAND.toml
@@ -161,7 +161,10 @@ provider = "default"
 model = "default"
 max_tokens = 16384
 temperature = 0.3
-max_iterations = 80
+max_iterations = 25
+# Researcher makes long LLM calls; 30s (kernel default) causes false-positive
+# recovery triggers. 120s matches typical deep-research call latency.
+heartbeat_interval_secs = 120
 system_prompt = """You are Researcher Hand — an autonomous deep research agent that conducts exhaustive investigations, cross-references sources, fact-checks claims, and produces comprehensive structured reports.
 
 ## Phase 0 — Platform Detection & Context (ALWAYS DO THIS FIRST)

--- a/crates/openfang-hands/src/lib.rs
+++ b/crates/openfang-hands/src/lib.rs
@@ -288,6 +288,11 @@ pub struct HandAgentConfig {
     pub system_prompt: String,
     #[serde(default)]
     pub max_iterations: Option<u32>,
+    /// Heartbeat interval in seconds for autonomous agents. Overrides the
+    /// AutonomousConfig default (30s), which is too aggressive for agents
+    /// making long LLM calls. Omit to use the kernel default.
+    #[serde(default)]
+    pub heartbeat_interval_secs: Option<u64>,
 }
 
 fn default_module() -> String {

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -3252,6 +3252,10 @@ impl OpenFangKernel {
             ],
             autonomous: def.agent.max_iterations.map(|max_iter| AutonomousConfig {
                 max_iterations: max_iter,
+                // Use the hand-declared heartbeat interval if provided.
+                // The kernel default (30s) is too aggressive for hands making long LLM calls;
+                // HAND.toml authors should set this to reflect expected call latency.
+                heartbeat_interval_secs: def.agent.heartbeat_interval_secs.unwrap_or(30),
                 ..Default::default()
             }),
             // Autonomous hands must run in Continuous mode so the background loop picks them up.


### PR DESCRIPTION
## Problems

### 1. `heartbeat_interval_secs` hardcoded at 30s for all Hands

`AutonomousConfig` defaults to a 30s heartbeat interval, and `activate_hand()` spread `..Default::default()` with no way to override this from `HAND.toml`. For Hands that make long LLM calls (researcher, analyst, etc.), 30s causes false-positive recovery triggers during normal operation — the heartbeat fires mid-inference and incorrectly concludes the agent is stuck.

### 2. researcher Hand `max_iterations = 80` causes guaranteed context overflow on local models

The researcher Hand was designed for cloud LLMs with 200K context windows. Its system prompt instructs exhaustive research (50+ sources) and `max_iterations = 80`. On any model with ≤32K context, the structural overhead alone (system prompt ~4-5K tokens + tool schemas ~8K tokens) leaves minimal room for conversation history. At 80 iterations the context overflows before the task can complete, causing the agent to crash in a restart loop.

## Fix

**`HandAgentConfig` in `openfang-hands/src/lib.rs`**: add optional `heartbeat_interval_secs` field so each Hand can declare an appropriate interval.

**`activate_hand()` in `openfang-kernel/src/kernel.rs`**: wire the field into `AutonomousConfig`, falling back to 30 if not set (preserves existing behaviour for Hands that don't declare it).

**`researcher/HAND.toml`**:
- `max_iterations`: 80 → 25 (sufficient for thorough research within 32K; exhaustive runs can be triggered by user instruction)
- `heartbeat_interval_secs = 120` (matches typical deep-research LLM call latency)

## No breaking changes

- Hands that don't declare `heartbeat_interval_secs` continue to use the 30s default
- `max_iterations = 25` still allows substantial research; it just doesn't guarantee overflow on local models

🤖 Generated with [Claude Code](https://claude.com/claude-code)