### PR TITLE
fix list style in message bubble

### DIFF
--- a/crates/openfang-api/static/css/components.css
+++ b/crates/openfang-api/static/css/components.css
@@ -647,6 +647,11 @@ mark.search-highlight {
   color: var(--text);
 }
 
+.message-bubble.markdown-body ul,
+.message-bubble.markdown-body ol {
+  padding-left: 2em;
+}
+
 .copy-btn {
   position: absolute;
   top: 6px;


### PR DESCRIPTION
## Summary

Fixed list indentation in message bubbles by adding padding-left to ensure list markers are properly separated from the container edge.

## Changes

Before:

<img width="1148" height="467" alt="screenshot-20260317-165914" src="https://github.com/user-attachments/assets/73181e5f-e70c-402f-8165-c2a692b1fbeb" />

After:

<img width="1108" height="394" alt="screenshot-20260317-171119" src="https://github.com/user-attachments/assets/a0b72def-e7be-45e9-8f53-f30fa21e088e" />

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [ ] No new unsafe code
- [ ] No secrets or API keys in diff
- [ ] User input validated at boundaries
