### PR TITLE
fix: use dynamic providers in agent spawn form

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -1154,12 +1154,9 @@
                     <div class="form-group">
                       <label>Provider</label>
                       <select class="form-select" x-model="spawnForm.provider">
-                        <option value="anthropic">Anthropic</option><option value="openai">OpenAI</option>
-                        <option value="groq">Groq</option><option value="ollama">Ollama</option>
-                        <option value="google">Google</option><option value="mistral">Mistral</option>
-                        <option value="xai">xAI</option><option value="deepseek">DeepSeek</option>
-                        <option value="cerebras">Cerebras</option><option value="sambanova">SambaNova</option>
-                        <option value="together">Together</option>
+                        <template x-for="p in spawnProviders" :key="p.id">
+                          <option :value="p.id" x-text="p.display_name"></option>
+                        </template>
                       </select>
                     </div>
                     <div class="form-group">

--- a/crates/openfang-api/static/js/pages/agents.js
+++ b/crates/openfang-api/static/js/pages/agents.js
@@ -40,6 +40,7 @@ function agentsPage() {
     },
 
     // -- Multi-step wizard state --
+    spawnProviders: [],
     spawnStep: 1,
     spawnIdentity: { emoji: '', color: '#FF5C00', archetype: '' },
     selectedPreset: '',
@@ -395,6 +396,13 @@ function agentsPage() {
     },
 
     // ── Multi-step wizard navigation ──
+    async loadSpawnProviders() {
+      try {
+        var data = await OpenFangAPI.get('/api/providers');
+        this.spawnProviders = (data.providers || []);
+      } catch(e) { this.spawnProviders = []; }
+    },
+
     async openSpawnWizard() {
       this.showSpawnModal = true;
       this.spawnStep = 1;
@@ -407,6 +415,7 @@ function agentsPage() {
       this.spawnForm.model = 'llama-3.3-70b-versatile';
       this.spawnForm.systemPrompt = 'You are a helpful assistant.';
       this.spawnForm.profile = 'full';
+      await this.loadSpawnProviders();
       try {
         var res = await fetch('/api/status');
         if (res.ok) {


### PR DESCRIPTION
## Summary

This changes the provider field in the agent spawn form from a hardcoded list to a dynamically loaded list from /api/providers, so the UI always reflects the currently available providers.

## Changes

Before:

<img width="765" height="751" alt="screenshot-20260317-175657" src="https://github.com/user-attachments/assets/42c0d00a-fae4-4642-973b-a16c7d389c97" />

After:

<img width="770" height="1012" alt="screenshot-20260317-173515" src="https://github.com/user-attachments/assets/cf4e1f2c-5e8a-4e1f-a13e-359cd16f779d" />

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [ ] No new unsafe code
- [ ] No secrets or API keys in diff
- [ ] User input validated at boundaries
