### PR TITLE
Fix Notion MCP server env var name (NOTION_API_KEY → NOTION_TOKEN)

### DIFF
--- a/crates/openfang-extensions/integrations/notion.toml
+++ b/crates/openfang-extensions/integrations/notion.toml
@@ -11,7 +11,7 @@ command = "npx"
 args = ["-y", "@notionhq/notion-mcp-server"]
 
 [[required_env]]
-name = "NOTION_API_KEY"
+name = "NOTION_TOKEN"
 label = "Notion Integration Token"
 help = "An internal integration token created in your Notion workspace settings"
 is_secret = true
@@ -24,5 +24,5 @@ unhealthy_threshold = 3
 setup_instructions = """
 1. Go to https://www.notion.so/my-integrations and click 'New integration'.
 2. Give it a name, select your workspace, and grant the required capabilities (Read/Update/Insert content).
-3. Copy the Internal Integration Token and paste it into the NOTION_API_KEY field above. Then share relevant pages with the integration in Notion.
+3. Copy the Internal Integration Token and paste it into the NOTION_TOKEN field above. Then share relevant pages with the integration in Notion.
 """

--- a/crates/openfang-extensions/src/installer.rs
+++ b/crates/openfang-extensions/src/installer.rs
@@ -327,7 +327,7 @@ mod tests {
 
         // Provide key directly
         let mut keys = HashMap::new();
-        keys.insert("NOTION_API_KEY".to_string(), "ntn_test_key_123".to_string());
+        keys.insert("NOTION_TOKEN".to_string(), "ntn_test_key_123".to_string());
 
         let result = install_integration(&mut registry, &mut resolver, "notion", &keys).unwrap();
         assert_eq!(result.id, "notion");


### PR DESCRIPTION
## Summary

Fixes #660 — The Notion MCP server (`@notionhq/notion-mcp-server`) expects the env var `NOTION_TOKEN`, but OpenFang's integration template was using `NOTION_API_KEY`, causing the server to fail on startup.

## Changes

- Renamed `NOTION_API_KEY` → `NOTION_TOKEN` in `crates/openfang-extensions/integrations/notion.toml`
- Updated setup instructions to reference the correct env var name
- Updated the installer test in `crates/openfang-extensions/src/installer.rs` to match

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (pre-existing `const_is_empty` warnings on `main` unrelated to this change)
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries