### PR TITLE
Expose Telegram slash commands via setMyCommands

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -6,6 +6,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use dashmap::DashMap;
+use openfang_channels::bridge::channel_command_specs;
 use openfang_kernel::triggers::{TriggerId, TriggerPattern};
 use openfang_kernel::workflow::{
     ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowStep,
@@ -10471,21 +10472,24 @@ pub async fn pairing_notify(
 
 /// GET /api/commands — List available chat commands (for dynamic slash menu).
 pub async fn list_commands(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let mut commands = vec![
-        serde_json::json!({"cmd": "/help", "desc": "Show available commands"}),
-        serde_json::json!({"cmd": "/new", "desc": "Reset session (clear history)"}),
-        serde_json::json!({"cmd": "/compact", "desc": "Trigger LLM session compaction"}),
-        serde_json::json!({"cmd": "/model", "desc": "Show or switch model (/model [name])"}),
-        serde_json::json!({"cmd": "/stop", "desc": "Cancel current agent run"}),
-        serde_json::json!({"cmd": "/usage", "desc": "Show session token usage & cost"}),
-        serde_json::json!({"cmd": "/think", "desc": "Toggle extended thinking (/think [on|off|stream])"}),
+    let mut commands: Vec<serde_json::Value> = channel_command_specs()
+        .iter()
+        .map(|spec| {
+            serde_json::json!({
+                "cmd": format!("/{}", spec.name),
+                "desc": spec.desc,
+                "source": "channel",
+            })
+        })
+        .collect();
+
+    commands.extend([
         serde_json::json!({"cmd": "/context", "desc": "Show context window usage & pressure"}),
         serde_json::json!({"cmd": "/verbose", "desc": "Cycle tool detail level (/verbose [off|on|full])"}),
         serde_json::json!({"cmd": "/queue", "desc": "Check if agent is processing"}),
-        serde_json::json!({"cmd": "/status", "desc": "Show system status"}),
         serde_json::json!({"cmd": "/clear", "desc": "Clear chat display"}),
         serde_json::json!({"cmd": "/exit", "desc": "Disconnect from agent"}),
-    ];
+    ]);
 
     // Add skill-registered tool names as potential commands
     if let Ok(registry) = state.kernel.skill_registry.read() {

--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -13,12 +13,84 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::StreamExt;
 use openfang_types::agent::AgentId;
+use openfang_types::approval::ApprovalRequest;
 use openfang_types::config::{ChannelOverrides, DmPolicy, GroupPolicy, OutputFormat};
 use openfang_types::message::ContentBlock;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChatCommandSpec {
+    pub name: &'static str,
+    pub desc: &'static str,
+    pub help: &'static str,
+    pub section: &'static str,
+}
+
+const CHANNEL_COMMAND_SPECS: &[ChatCommandSpec] = &[
+    ChatCommandSpec { name: "start", desc: "Show welcome message", help: "/start - show welcome message", section: "General" },
+    ChatCommandSpec { name: "help", desc: "Show available commands", help: "/help - show this help", section: "General" },
+    ChatCommandSpec { name: "agents", desc: "List running agents", help: "/agents - list running agents", section: "Session" },
+    ChatCommandSpec { name: "agent", desc: "Select agent (/agent <name>)", help: "/agent <name> - select which agent to talk to", section: "Session" },
+    ChatCommandSpec { name: "new", desc: "Reset session (clear history)", help: "/new - reset session (clear messages)", section: "Session" },
+    ChatCommandSpec { name: "compact", desc: "Trigger LLM session compaction", help: "/compact - trigger LLM session compaction", section: "Session" },
+    ChatCommandSpec { name: "model", desc: "Show or switch model", help: "/model [name] - show or switch agent model", section: "Session" },
+    ChatCommandSpec { name: "stop", desc: "Cancel current agent run", help: "/stop - cancel current agent run", section: "Session" },
+    ChatCommandSpec { name: "usage", desc: "Show session usage and cost", help: "/usage - show session token usage and cost", section: "Session" },
+    ChatCommandSpec { name: "think", desc: "Toggle extended thinking", help: "/think [on|off] - toggle extended thinking", section: "Session" },
+    ChatCommandSpec { name: "status", desc: "Show system status", help: "/status - show system status", section: "Info" },
+    ChatCommandSpec { name: "models", desc: "List available AI models", help: "/models - list available AI models", section: "Info" },
+    ChatCommandSpec { name: "providers", desc: "Show configured providers", help: "/providers - show configured providers", section: "Info" },
+    ChatCommandSpec { name: "skills", desc: "List installed skills", help: "/skills - list installed skills", section: "Info" },
+    ChatCommandSpec { name: "hands", desc: "List available and active hands", help: "/hands - list available and active hands", section: "Info" },
+    ChatCommandSpec { name: "workflows", desc: "List workflows", help: "/workflows - list workflows", section: "Automation" },
+    ChatCommandSpec { name: "workflow", desc: "Run workflow (/workflow run <name> [input])", help: "/workflow run <name> [input] - run a workflow", section: "Automation" },
+    ChatCommandSpec { name: "triggers", desc: "List event triggers", help: "/triggers - list event triggers", section: "Automation" },
+    ChatCommandSpec { name: "trigger", desc: "Manage triggers", help: "/trigger add <agent> <pattern> <prompt> | /trigger del <id>", section: "Automation" },
+    ChatCommandSpec { name: "schedules", desc: "List cron jobs", help: "/schedules - list cron jobs", section: "Automation" },
+    ChatCommandSpec { name: "schedule", desc: "Manage schedules", help: "/schedule add <agent> <cron-5-fields> <message> | /schedule del <id> | /schedule run <id>", section: "Automation" },
+    ChatCommandSpec { name: "approvals", desc: "List pending approvals", help: "/approvals - list pending approvals", section: "Automation" },
+    ChatCommandSpec { name: "approve", desc: "Approve request", help: "/approve <id> - approve a request", section: "Automation" },
+    ChatCommandSpec { name: "reject", desc: "Reject request", help: "/reject <id> - reject a request", section: "Automation" },
+    ChatCommandSpec { name: "budget", desc: "Show spending limits and costs", help: "/budget - show spending limits and current costs", section: "Monitoring" },
+    ChatCommandSpec { name: "peers", desc: "Show OFP peer network status", help: "/peers - show OFP peer network status", section: "Monitoring" },
+    ChatCommandSpec { name: "a2a", desc: "List discovered external A2A agents", help: "/a2a - list discovered external A2A agents", section: "Monitoring" },
+];
+
+pub fn channel_command_specs() -> &'static [ChatCommandSpec] {
+    CHANNEL_COMMAND_SPECS
+}
+
+fn is_channel_command(name: &str) -> bool {
+    channel_command_specs().iter().any(|spec| spec.name == name)
+}
+
+fn format_channel_help() -> String {
+    let sections = ["General", "Session", "Info", "Automation", "Monitoring"];
+    let mut msg = String::from("OpenFang Bot Commands:");
+
+    for section in sections {
+        let commands: Vec<&ChatCommandSpec> = channel_command_specs()
+            .iter()
+            .filter(|spec| spec.section == section)
+            .collect();
+        if commands.is_empty() {
+            continue;
+        }
+        msg.push_str("\n\n");
+        msg.push_str(section);
+        msg.push_str(":\n");
+        for spec in commands {
+            msg.push_str(spec.help);
+            msg.push('\n');
+        }
+        msg.pop();
+    }
+
+    msg
+}
 
 /// Kernel operations needed by channel adapters.
 ///
@@ -57,6 +129,20 @@ pub trait ChannelBridgeHandle: Send + Sync {
 
     /// Spawn an agent by manifest name, returning its ID.
     async fn spawn_agent_by_name(&self, manifest_name: &str) -> Result<AgentId, String>;
+
+    /// Transcribe raw audio bytes to text.
+    async fn transcribe_audio(
+        &self,
+        _audio_bytes: Vec<u8>,
+        _mime_type: &str,
+    ) -> Result<String, String> {
+        Err("Audio transcription not available.".to_string())
+    }
+
+    /// List pending approval requests for a specific agent.
+    async fn pending_approvals_for_agent(&self, _agent_id: AgentId) -> Vec<ApprovalRequest> {
+        Vec::new()
+    }
 
     /// Return uptime info string (e.g., "2h 15m, 5 agents").
     async fn uptime_info(&self) -> String {
@@ -693,36 +779,7 @@ async fn dispatch_message(
             vec![]
         };
 
-        if matches!(
-            cmd,
-            "start"
-                | "help"
-                | "agents"
-                | "agent"
-                | "status"
-                | "models"
-                | "providers"
-                | "new"
-                | "compact"
-                | "model"
-                | "stop"
-                | "usage"
-                | "think"
-                | "skills"
-                | "hands"
-                | "workflows"
-                | "workflow"
-                | "triggers"
-                | "trigger"
-                | "schedules"
-                | "schedule"
-                | "approvals"
-                | "approve"
-                | "reject"
-                | "budget"
-                | "peers"
-                | "a2a"
-        ) {
+        if is_channel_command(cmd) {
             let result = handle_command(cmd, &args, handle, router, &message.sender).await;
             send_response(adapter, &message.sender, result, thread_id, output_format).await;
             return;
@@ -1429,47 +1486,7 @@ async fn handle_command(
             msg.push_str("\nCommands:\n/agents - list agents\n/agent <name> - select an agent\n/help - show this help");
             msg
         }
-        "help" => "OpenFang Bot Commands:\n\
-             \n\
-             Session:\n\
-             /agents - list running agents\n\
-             /agent <name> - select which agent to talk to\n\
-             /new - reset session (clear messages)\n\
-             /compact - trigger LLM session compaction\n\
-             /model [name] - show or switch agent model\n\
-             /stop - cancel current agent run\n\
-             /usage - show session token usage and cost\n\
-             /think [on|off] - toggle extended thinking\n\
-             \n\
-             Info:\n\
-             /models - list available AI models\n\
-             /providers - show configured providers\n\
-             /skills - list installed skills\n\
-             /hands - list available and active hands\n\
-             /status - show system status\n\
-             \n\
-             Automation:\n\
-             /workflows - list workflows\n\
-             /workflow run <name> [input] - run a workflow\n\
-             /triggers - list event triggers\n\
-             /trigger add <agent> <pattern> <prompt> - create trigger\n\
-             /trigger del <id> - remove trigger\n\
-             /schedules - list cron jobs\n\
-             /schedule add <agent> <cron-5-fields> <message> - create job\n\
-             /schedule del <id> - remove job\n\
-             /schedule run <id> - run job now\n\
-             /approvals - list pending approvals\n\
-             /approve <id> - approve a request\n\
-             /reject <id> - reject a request\n\
-             \n\
-             Monitoring:\n\
-             /budget - show spending limits and current costs\n\
-             /peers - show OFP peer network status\n\
-             /a2a - list discovered external A2A agents\n\
-             \n\
-             /start - show welcome message\n\
-             /help - show this help"
-            .to_string(),
+        "help" => format_channel_help(),
         "status" => handle.uptime_info().await,
         "agents" => {
             let agents = handle.list_agents().await.unwrap_or_default();
@@ -1485,7 +1502,15 @@ async fn handle_command(
         }
         "agent" => {
             if args.is_empty() {
-                return "Usage: /agent <name>".to_string();
+                let agents = handle.list_agents().await.unwrap_or_default();
+                if agents.is_empty() {
+                    return "No agents running. Usage: /agent <name>".to_string();
+                }
+                let mut msg = "Usage: /agent <name>\n\nAvailable agents:\n".to_string();
+                for (_, name) in &agents {
+                    msg.push_str(&format!("  - {name}\n"));
+                }
+                return msg.trim_end().to_string();
             }
             let agent_name = &args[0];
             match handle.find_agent_by_name(agent_name).await {
@@ -1786,6 +1811,32 @@ mod tests {
         // Verify router was updated
         let resolved = router.resolve(&ChannelType::Telegram, "user1", None);
         assert_eq!(resolved, Some(agent_id));
+    }
+
+    #[tokio::test]
+    async fn test_handle_command_agent_without_args_lists_agents() {
+        let agent_id = AgentId::new();
+        let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(MockHandle {
+            agents: Mutex::new(vec![(agent_id, "coder".to_string())]),
+        });
+        let router = Arc::new(AgentRouter::new());
+        let sender = ChannelUser {
+            platform_id: "user1".to_string(),
+            display_name: "Test".to_string(),
+            openfang_user: None,
+        };
+
+        let result = handle_command("agent", &[], &handle, &router, &sender).await;
+        assert!(result.contains("Usage: /agent <name>"));
+        assert!(result.contains("coder"));
+    }
+
+    #[test]
+    fn test_channel_command_specs_include_agent_and_help() {
+        let specs = channel_command_specs();
+        assert!(specs.iter().any(|spec| spec.name == "help"));
+        assert!(specs.iter().any(|spec| spec.name == "agent"));
+        assert!(specs.iter().any(|spec| spec.name == "agents"));
     }
 
     #[test]

--- a/crates/openfang-channels/src/telegram.rs
+++ b/crates/openfang-channels/src/telegram.rs
@@ -3,12 +3,14 @@
 //! Uses long-polling via `getUpdates` with exponential backoff on failures.
 //! No external Telegram crate — just `reqwest` for full control over error handling.
 
+use crate::bridge::channel_command_specs;
 use crate::types::{
     split_message, ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
     LifecycleReaction,
 };
 use async_trait::async_trait;
 use futures::Stream;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -26,6 +28,12 @@ const LONG_POLL_TIMEOUT: u64 = 30;
 
 /// Default Telegram Bot API base URL.
 const DEFAULT_API_URL: &str = "https://api.telegram.org";
+
+#[derive(Serialize)]
+struct TelegramBotCommand<'a> {
+    command: &'a str,
+    description: &'a str,
+}
 
 /// Telegram Bot API adapter using long-polling.
 pub struct TelegramAdapter {
@@ -94,6 +102,36 @@ impl TelegramAdapter {
             .unwrap_or("unknown")
             .to_string();
         Ok(bot_name)
+    }
+
+    async fn register_bot_commands(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/bot{}/setMyCommands",
+            self.api_base_url,
+            self.token.as_str()
+        );
+        let commands: Vec<TelegramBotCommand<'_>> = channel_command_specs()
+            .iter()
+            .map(|spec| TelegramBotCommand {
+                command: spec.name,
+                description: spec.desc,
+            })
+            .collect();
+        let resp: serde_json::Value = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({ "commands": commands }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if resp["ok"].as_bool() != Some(true) {
+            let desc = resp["description"].as_str().unwrap_or("unknown error");
+            return Err(format!("Telegram setMyCommands failed: {desc}").into());
+        }
+
+        Ok(())
     }
 
     /// Call `sendMessage` on the Telegram API.
@@ -436,6 +474,14 @@ impl ChannelAdapter for TelegramAdapter {
                 Ok(_) => info!("Telegram: cleared webhook, polling mode active"),
                 Err(e) => tracing::warn!("Telegram: deleteWebhook failed (non-fatal): {e}"),
             }
+        }
+
+        match self.register_bot_commands().await {
+            Ok(()) => info!(
+                "Telegram: registered {} bot commands",
+                channel_command_specs().len()
+            ),
+            Err(e) => warn!("Telegram: setMyCommands failed (non-fatal): {e}"),
         }
 
         let (tx, rx) = mpsc::channel::<ChannelMessage>(256);


### PR DESCRIPTION
## Summary

Expose the existing Telegram bot commands through Telegram's native slash-command menu and unify command definitions across Telegram, `/help`, and `/api/commands`.

Fixes #700

## Changes

- register Telegram bot commands with `setMyCommands` when the Telegram adapter starts
- add a shared channel command catalog and reuse it for Telegram command registration, `/help`, and `/api/commands`
- include `/agents` and `/agent` in the shared command list
- update `/agent` so calling it without an argument returns usage guidance plus the live list of available agents from the server
- add default `ChannelBridgeHandle` methods for pending approvals and audio transcription so the current branch compiles with the existing bridge wiring

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

Additional verification:
- `cargo check --workspace`
- `cargo audit`
- `cargo test -p openfang-channels test_handle_command_ -- --nocapture`
- `cargo build -p openfang-api --lib`
- `cargo build -p openfang-cli --bin openfang`
- verified live daemon startup with real Telegram config
- verified `GET /api/health`
- verified `GET /api/commands` returns the unified command list, including `/agents` and `/agent`
- verified Telegram bot startup logs show webhook cleanup, polling mode activation, and bot command registration
- verified `getMyCommands` returns the registered Telegram command list

Note: `cargo fmt --check` currently fails on unrelated pre-existing formatting drift elsewhere in this checkout, outside this PR diff.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries

Telegram Bot API supports native command menus, but it does not support dynamic server-driven autocomplete for command arguments after `/agent `. This change uses the best available fallback by returning the live agent list when `/agent` is sent without an argument.
