### PR TITLE
fix: reset last_active on agent restore to prevent heartbeat false-positives on startup

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -1128,9 +1128,13 @@ impl OpenFangKernel {
                         .scheduler
                         .register(agent_id, entry.manifest.resources.clone());
 
-                    // Re-register in the in-memory registry (set state back to Running)
+                    // Re-register in the in-memory registry (set state back to Running).
+                    // Reset last_active to now so the heartbeat monitor doesn't
+                    // immediately flag the agent as unresponsive due to stale
+                    // persisted timestamps from before the shutdown.
                     let mut restored_entry = entry;
                     restored_entry.state = AgentState::Running;
+                    restored_entry.last_active = chrono::Utc::now();
 
                     // Inherit kernel exec_policy for agents that lack one
                     if restored_entry.manifest.exec_policy.is_none() {


### PR DESCRIPTION
## Problem

Every daemon restart triggers a cascade of spurious crash-recovery cycles for all agents.

When agents are loaded from persistent storage, their `last_active` timestamp is restored from before the previous shutdown. If the daemon was down for longer than the heartbeat unresponsiveness threshold (default 180 s), the very first heartbeat tick — which fires ~30 s after startup — sees every restored agent as stale and immediately marks them all as `Crashed`, kicking off recovery attempts for agents that had only just been restored and hadn't had a chance to run.

Observed in logs:
```
INFO  openfang_kernel: Restored 6 agent(s) from persistent storage
...30 seconds later...
WARN  openfang_kernel::heartbeat: Agent is unresponsive agent=Athena inactive_secs=210 timeout_secs=180
WARN  openfang_kernel::heartbeat: Agent is unresponsive agent=Paige  inactive_secs=210 timeout_secs=180
WARN  openfang_kernel::heartbeat: Agent is unresponsive agent=Cortex inactive_secs=210 timeout_secs=180
WARN  openfang_kernel::kernel:    Unresponsive Running agent marked as Crashed for recovery agent=Athena
...
```

The recovery succeeds each time, but the unnecessary crash-recovery round-trip adds noise to logs, delays agent availability by 30–60 s on every restart, and burns recovery attempt budget.

## Fix

One line added to the agent restore loop in `kernel.rs`, alongside the existing `state = AgentState::Running` reset:

```rust
restored_entry.last_active = chrono::Utc::now();
```

This gives each restored agent a fresh heartbeat baseline consistent with how newly spawned agents are initialized (they also set `last_active = Utc::now()`). The heartbeat monitor then starts timing from the actual moment of restoration rather than from the pre-shutdown timestamp.

## Impact

- No behavioural change for agents that are genuinely unresponsive after restoration
- Agents that fail to start their loop after restore will still be caught by the heartbeat on the next check cycle (30 s later)
- Eliminates the false-positive crash storm on every daemon restart
