### PR TITLE
fix: exempt non-autonomous agents from heartbeat inactivity timeout

### DIFF
--- a/crates/openfang-kernel/src/heartbeat.rs
+++ b/crates/openfang-kernel/src/heartbeat.rs
@@ -130,7 +130,7 @@ impl Default for RecoveryTracker {
 ///
 /// This is a pure function — it doesn't start a background task.
 /// The caller (kernel) can run this periodically or in a background task.
-pub fn check_agents(registry: &AgentRegistry, config: &HeartbeatConfig) -> Vec<HeartbeatStatus> {
+pub fn check_agents(registry: &AgentRegistry, _config: &HeartbeatConfig) -> Vec<HeartbeatStatus> {
     let now = Utc::now();
     let mut statuses = Vec::new();
 
@@ -143,16 +143,19 @@ pub fn check_agents(registry: &AgentRegistry, config: &HeartbeatConfig) -> Vec<H
 
         let inactive_secs = (now - entry_ref.last_active).num_seconds();
 
-        // Determine timeout: use agent's autonomous config if set, else default
-        let timeout_secs = entry_ref
+        // Non-autonomous (reactive) agents have no inactivity timeout: they wait
+        // indefinitely for incoming messages and are never unresponsive due to
+        // idleness. Only autonomous agents need the inactivity check.
+        let timeout_secs: Option<i64> = entry_ref
             .manifest
             .autonomous
             .as_ref()
-            .map(|a| a.heartbeat_interval_secs * UNRESPONSIVE_MULTIPLIER)
-            .unwrap_or(config.default_timeout_secs) as i64;
+            .map(|a| (a.heartbeat_interval_secs * UNRESPONSIVE_MULTIPLIER) as i64);
 
-        // Crashed agents are always considered unresponsive
-        let unresponsive = entry_ref.state == AgentState::Crashed || inactive_secs > timeout_secs;
+        let unresponsive = match timeout_secs {
+            Some(t) => entry_ref.state == AgentState::Crashed || inactive_secs > t,
+            None => entry_ref.state == AgentState::Crashed,
+        };
 
         if unresponsive && entry_ref.state == AgentState::Running {
             warn!(


### PR DESCRIPTION
## Problem

Non-autonomous (reactive) agents were being flagged as unresponsive and crash-recovered after sitting idle for `default_timeout_secs` (180s), even though idle is their normal state. They wait for incoming messages and have no expected self-trigger schedule.

This caused unnecessary crash/recovery cycles for healthy agents that simply hadn't received a message in the last 3 minutes.

## Root Cause

`check_agents` in `heartbeat.rs` applied the same inactivity timeout to all Running agents regardless of type. For agents without an `autonomous` config block, it fell back to `config.default_timeout_secs` (180s). A reactive agent idle for 3+ minutes would be indistinguishable from an autonomous agent that had stalled.

## Fix

Make the inactivity check conditional on agent type:

- **Autonomous agents** retain the `heartbeat_interval_secs × 2` inactivity check — meaningful because they are expected to fire periodically.
- **Non-autonomous agents** are only flagged when their state is `Crashed`; idle time is no longer checked at all.

```rust
// Before
let timeout_secs = entry_ref.manifest.autonomous.as_ref()
    .map(|a| a.heartbeat_interval_secs * UNRESPONSIVE_MULTIPLIER)
    .unwrap_or(config.default_timeout_secs) as i64;
let unresponsive = entry_ref.state == AgentState::Crashed || inactive_secs > timeout_secs;

// After
let timeout_secs: Option<i64> = entry_ref.manifest.autonomous.as_ref()
    .map(|a| (a.heartbeat_interval_secs * UNRESPONSIVE_MULTIPLIER) as i64);
let unresponsive = match timeout_secs {
    Some(t) => entry_ref.state == AgentState::Crashed || inactive_secs > t,
    None    => entry_ref.state == AgentState::Crashed,
};
```

## Testing

Verified with a 5-agent setup (mix of autonomous and reactive). Before the fix, idle reactive agents were logged as unresponsive at `inactive_secs=210`. After the fix, they show `heartbeat OK` at 210s, 240s, and beyond with no crash/recovery cycles.

- [x] `cargo build --workspace --lib` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes
- [x] Live integration tested
