### PR TITLE
fix: stamp last_active before LLM call to prevent mid-iteration heartbeat timeouts

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5715,6 +5715,12 @@ impl KernelHandle for OpenFangKernel {
             .collect()
     }
 
+    fn touch_agent(&self, agent_id: &str) {
+        if let Ok(id) = agent_id.parse::<AgentId>() {
+            self.registry.touch(id);
+        }
+    }
+
     fn kill_agent(&self, agent_id: &str) -> Result<(), String> {
         let id: AgentId = agent_id
             .parse()

--- a/crates/openfang-kernel/src/registry.rs
+++ b/crates/openfang-kernel/src/registry.rs
@@ -235,6 +235,14 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Touch an agent — refresh last_active without changing any other state.
+    /// Used by the agent loop to prevent heartbeat false-positives during long LLM calls.
+    pub fn touch(&self, id: AgentId) {
+        if let Some(mut entry) = self.agents.get_mut(&id) {
+            entry.last_active = chrono::Utc::now();
+        }
+    }
+
     /// Update an agent's system prompt (hot-swap, takes effect on next message).
     pub fn update_system_prompt(&self, id: AgentId, new_prompt: String) -> OpenFangResult<()> {
         let mut entry = self

--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -348,6 +348,12 @@ pub async fn run_agent_loop(
             cb(LoopPhase::Thinking);
         }
 
+        // Stamp last_active before the (potentially long) LLM call so the
+        // heartbeat monitor doesn't flag us as unresponsive mid-iteration.
+        if let Some(k) = &kernel {
+            k.touch_agent(&agent_id_str);
+        }
+
         // Call LLM with retry, error classification, and circuit breaker
         let provider_name = manifest.model.provider.as_str();
         let mut response = call_with_retry(&*driver, request, Some(provider_name), None).await?;

--- a/crates/openfang-runtime/src/kernel_handle.rs
+++ b/crates/openfang-runtime/src/kernel_handle.rs
@@ -238,6 +238,12 @@ pub trait KernelHandle: Send + Sync {
         Err("Channel file data send not available".to_string())
     }
 
+    /// Refresh an agent's last_active timestamp without changing any other state.
+    /// Called by the agent loop before long LLM calls to prevent heartbeat false-positives.
+    fn touch_agent(&self, agent_id: &str) {
+        let _ = agent_id;
+    }
+
     /// Spawn an agent with capability inheritance enforcement.
     /// `parent_caps` are the parent's granted capabilities. The kernel MUST verify
     /// that every capability in the child manifest is covered by `parent_caps`.


### PR DESCRIPTION
## Problem

Agents running slow local models (e.g. 27B quantised MLX models running on-device) can take 3–4+ minutes per loop iteration. The heartbeat monitor's default `inactive_secs` timeout is 180s. Because `last_active` was only stamped at the **end** of an iteration — after the LLM call returns — the heartbeat would fire mid-call and flag the agent as unresponsive, triggering crash/recovery while the loop was still running correctly.

## Root Cause

`last_active` updates happen as a side-effect of state/data mutations in `AgentRegistry` (e.g. `set_state`, `update_model`). There was no mechanism for the agent loop to signal liveness during a long-running LLM call — the only updates were at iteration boundaries, not within one.

## Fix

Add a lightweight `touch_agent` callback through the existing `KernelHandle` trait so the agent loop can refresh `last_active` without mutating any real state:

1. **`AgentRegistry::touch(id)`** — updates `last_active` only, no other side-effects. Silently ignores unknown IDs (non-blocking).
2. **`KernelHandle::touch_agent(&str)`** — new trait method with a default no-op, so all existing mock/test implementations require zero changes.
3. **`OpenFangKernel::touch_agent`** — parses the UUID string and delegates to `registry.touch()`.
4. **`agent_loop`** — calls `kernel.touch_agent(agent_id)` at the top of each iteration, immediately before `call_with_retry`, resetting the inactivity clock at the start of every LLM call rather than only at completion.

## Impact

- Remote API providers (OpenAI, Anthropic, Groq) are rarely affected since calls complete in seconds; this is a no-op overhead for them.
- Local model users (mlx-lm, llama.cpp via OpenAI-compat, Ollama) benefit directly: a 4-minute 27B model call no longer triggers false crash detection.
- The `KernelHandle` default no-op means downstream forks/embedders that implement the trait don't need any changes.

## Testing

Verified on a local 27B 4-bit MLX model. Before the fix, agents were killed and restarted mid-loop. After the fix, `inactive_secs` resets to ~0 at the start of each iteration and the loop completes without interruption.

- [x] `cargo build --workspace --lib` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes
- [x] Live integration tested with slow local LLM (27B MLX model, ~3–4 min/iteration)
