### PR TITLE
fix(kernel): resolve "default" provider in fallback_models before driver init

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -4685,26 +4685,44 @@ impl OpenFangKernel {
                 String,
             )> = vec![(primary.clone(), String::new())];
             for fb in &manifest.fallback_models {
+                // Resolve "default" provider/model to the kernel's configured defaults,
+                // mirroring the overlay logic for the primary model.
+                let dm = &self.config.default_model;
+                let fb_provider = if fb.provider.is_empty() || fb.provider == "default" {
+                    dm.provider.clone()
+                } else {
+                    fb.provider.clone()
+                };
+                let fb_model_name = if fb.model.is_empty() || fb.model == "default" {
+                    dm.model.clone()
+                } else {
+                    fb.model.clone()
+                };
+                let _ = &fb_model_name; // used below in strip_provider_prefix
+
                 let fb_api_key = if let Some(env) = &fb.api_key_env {
                     std::env::var(env).ok()
+                } else if fb_provider == dm.provider && !dm.api_key_env.is_empty() {
+                    std::env::var(&dm.api_key_env).ok()
                 } else {
                     // Resolve using provider_api_keys / convention for custom providers
-                    let env_var = self.config.resolve_api_key_env(&fb.provider);
+                    let env_var = self.config.resolve_api_key_env(&fb_provider);
                     std::env::var(&env_var).ok()
                 };
                 let config = DriverConfig {
-                    provider: fb.provider.clone(),
+                    provider: fb_provider.clone(),
                     api_key: fb_api_key,
                     base_url: fb
                         .base_url
                         .clone()
-                        .or_else(|| self.lookup_provider_url(&fb.provider)),
+                        .or_else(|| dm.base_url.clone())
+                        .or_else(|| self.lookup_provider_url(&fb_provider)),
                     skip_permissions: true,
                 };
                 match drivers::create_driver(&config) {
-                    Ok(d) => chain.push((d, strip_provider_prefix(&fb.model, &fb.provider))),
+                    Ok(d) => chain.push((d, strip_provider_prefix(&fb_model_name, &fb_provider))),
                     Err(e) => {
-                        warn!("Fallback driver '{}' failed to init: {e}", fb.provider);
+                        warn!("Fallback driver '{}' failed to init: {e}", fb_provider);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Fallback model entries with `provider = "default"` were passed verbatim to `create_driver()`, which only recognises real provider names (`ollama`, `openai`, `anthropic`, …)
- The primary model already resolves `"default"` → kernel config at `spawn_agent()`, but the fallback loop was missing the same resolution — causing every bundled agent with a `"default"` fallback to silently lose all fallback drivers:
  ```
  WARN Fallback driver 'default' failed to init: Unknown provider 'default'
  ```
- This is particularly visible for users whose `config.toml` sets a non-standard default provider (e.g. `ollama` pointing at a local proxy), where the fallback is the only recovery path

## Changes

- Mirror the primary-model overlay logic for fallback entries: resolve `provider`, `model`, `api_key_env`, and `base_url` from `config.default_model` when the fallback specifies `"default"` or empty string
- Inherit `base_url` from `default_model` before falling back to `lookup_provider_url()`, so custom endpoints propagate correctly
- Use resolved values in `strip_provider_prefix()` and warn messages

## Test plan

- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` — existing tests pass (no signature changes to public API)
- [ ] Start daemon with `[default_model] provider = "ollama"` and an agent with `[[fallback_models]] provider = "default"` — verify the `Unknown provider 'default'` warning is gone
- [ ] Kill the primary LLM endpoint mid-request — verify the fallback driver activates using the resolved provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)