### PR TITLE
fix(matrix): make auto_accept_invites configurable, default to false

### DIFF
--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -1218,6 +1218,7 @@ pub async fn start_channel_bridge_with_config(
                 mx_config.user_id.clone(),
                 token,
                 mx_config.allowed_rooms.clone(),
+                mx_config.auto_accept_invites,
             ));
             adapters.push((adapter, mx_config.default_agent.clone()));
         }

--- a/crates/openfang-channels/src/matrix.rs
+++ b/crates/openfang-channels/src/matrix.rs
@@ -46,6 +46,7 @@ impl MatrixAdapter {
         user_id: String,
         access_token: String,
         allowed_rooms: Vec<String>,
+        auto_accept_invites: bool,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
@@ -57,7 +58,7 @@ impl MatrixAdapter {
             shutdown_tx: Arc::new(shutdown_tx),
             shutdown_rx,
             since_token: Arc::new(RwLock::new(None)),
-            auto_accept_invites: true,
+            auto_accept_invites,
         }
     }
 
@@ -461,6 +462,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "access_token".to_string(),
             vec![],
+            false,
         );
         assert_eq!(adapter.name(), "matrix");
     }
@@ -472,6 +474,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "token".to_string(),
             vec!["!room1:matrix.org".to_string()],
+            false,
         );
         assert!(adapter.is_allowed_room("!room1:matrix.org"));
         assert!(!adapter.is_allowed_room("!room2:matrix.org"));
@@ -481,6 +484,7 @@ mod tests {
             "@bot:matrix.org".to_string(),
             "token".to_string(),
             vec![],
+            false,
         );
         assert!(open.is_allowed_room("!any:matrix.org"));
     }

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -1861,6 +1861,9 @@ pub struct MatrixConfig {
     pub allowed_rooms: Vec<String>,
     /// Default agent name to route messages to.
     pub default_agent: Option<String>,
+    /// Whether to auto-accept room invites (default: false).
+    #[serde(default)]
+    pub auto_accept_invites: bool,
     /// Per-channel behavior overrides.
     #[serde(default)]
     pub overrides: ChannelOverrides,
@@ -1874,6 +1877,7 @@ impl Default for MatrixConfig {
             access_token_env: "MATRIX_ACCESS_TOKEN".to_string(),
             allowed_rooms: vec![],
             default_agent: None,
+            auto_accept_invites: false,
             overrides: ChannelOverrides::default(),
         }
     }


### PR DESCRIPTION
## Summary

- `MatrixAdapter` hardcoded `auto_accept_invites: true`, meaning any Matrix-connected instance would blindly join every room it was invited to
- This is a security concern for public-facing homeservers — a malicious user could invite the bot into an arbitrary room and interact with the agent without the operator's consent
- The field was not exposed in `MatrixConfig`, so operators had no way to disable it

## Changes

- Add `auto_accept_invites: bool` to `MatrixConfig` (`openfang-types`), with `#[serde(default)]` defaulting to `false`
- Thread the field through `MatrixAdapter::new()` instead of hardcoding `true`
- Wire it in `channel_bridge.rs` from `mx_config.auto_accept_invites`
- Update unit tests to pass the new parameter

### Migration

**Breaking change in default behavior**: existing setups that relied on auto-accept will need to explicitly opt in:

```toml
[channels.matrix]
auto_accept_invites = true
```

## Test plan

- [ ] `cargo build --workspace --lib` compiles
- [ ] `cargo test --workspace` passes (3 updated test call sites in `matrix.rs`)
- [ ] Start daemon with `auto_accept_invites = false` (default) — invite the bot to a room, verify it does **not** join
- [ ] Set `auto_accept_invites = true` — invite again, verify auto-join works
- [ ] Verify `allowed_rooms` filtering still applies when auto-accept is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)