### PR TITLE
feat(channels): notify originating chat room on approval requests

### DIFF
--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -1727,7 +1727,7 @@ pub async fn start_channel_bridge_with_config(
         started_at: Instant::now(),
     });
     let router = Arc::new(router);
-    let mut manager = BridgeManager::new(bridge_handle, router);
+    let mut manager = BridgeManager::new(bridge_handle, router.clone());
 
     let mut started_names = Vec::new();
     for (adapter, _) in adapters {
@@ -1747,6 +1747,67 @@ pub async fn start_channel_bridge_with_config(
                 error!("Failed to start {name} bridge: {e}");
             }
         }
+    }
+
+    // Spawn a task that listens for approval requests and notifies
+    // the originating channel room so users can /approve or /deny from chat.
+    if !started_names.is_empty() {
+        let mut approval_rx = kernel.approval_manager.subscribe();
+        let adapters_map = kernel.channel_adapters.clone();
+        let approval_router = router.clone();
+        tokio::spawn(async move {
+            while let Ok(req) = approval_rx.recv().await {
+                let id_str = req.id.to_string();
+                let id_short = &id_str[..8];
+                let msg = format!(
+                    "Approval required\n  Tool: {}\n  Risk: {:?}\n  Agent: {}\n  {}\n\nReply /approve {} or /reject {}",
+                    req.tool_name,
+                    req.risk_level,
+                    req.agent_id,
+                    req.action_summary,
+                    id_short,
+                    id_short,
+                );
+
+                // Try to send only to the room that originated the request
+                // by reverse-looking up which rooms route to this agent.
+                let target_rooms: Vec<String> = req
+                    .agent_id
+                    .parse::<openfang_types::agent::AgentId>()
+                    .ok()
+                    .map(|aid| approval_router.rooms_for_agent(aid))
+                    .unwrap_or_default();
+
+                let adapters: Vec<_> = adapters_map
+                    .iter()
+                    .map(|entry| entry.value().clone())
+                    .collect();
+
+                if target_rooms.is_empty() {
+                    // Fallback: broadcast to all rooms if no route found
+                    for adapter in &adapters {
+                        let _ = adapter.broadcast(&msg).await;
+                    }
+                } else {
+                    // Send only to the originating room(s)
+                    for adapter in &adapters {
+                        for room_id in &target_rooms {
+                            let user = openfang_channels::types::ChannelUser {
+                                platform_id: room_id.clone(),
+                                display_name: "system".to_string(),
+                                openfang_user: None,
+                            };
+                            let _ = adapter
+                                .send(
+                                    &user,
+                                    openfang_channels::types::ChannelContent::Text(msg.clone()),
+                                )
+                                .await;
+                        }
+                    }
+                }
+            }
+        });
     }
 
     if started_names.is_empty() {

--- a/crates/openfang-channels/src/matrix.rs
+++ b/crates/openfang-channels/src/matrix.rs
@@ -422,6 +422,36 @@ impl ChannelAdapter for MatrixAdapter {
         Ok(())
     }
 
+    async fn broadcast(&self, message: &str) -> Result<(), Box<dyn std::error::Error>> {
+        // Get all joined rooms and send the message to each
+        let url = format!(
+            "{}/_matrix/client/v3/joined_rooms",
+            self.homeserver_url
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&*self.access_token)
+            .send()
+            .await?;
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp.json().await?;
+            if let Some(rooms) = body["joined_rooms"].as_array() {
+                for room in rooms {
+                    if let Some(room_id) = room.as_str() {
+                        if !self.allowed_rooms.is_empty()
+                            && !self.allowed_rooms.iter().any(|r| r == room_id)
+                        {
+                            continue;
+                        }
+                        let _ = self.api_send_message(room_id, message).await;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn send_typing(&self, user: &ChannelUser) -> Result<(), Box<dyn std::error::Error>> {
         let url = format!(
             "{}/_matrix/client/v3/rooms/{}/typing/{}",

--- a/crates/openfang-channels/src/router.rs
+++ b/crates/openfang-channels/src/router.rs
@@ -94,6 +94,15 @@ impl AgentRouter {
             .insert(channel_key.to_string(), new_agent_id);
     }
 
+    /// Find platform_ids (room IDs) that are currently routed to the given agent.
+    pub fn rooms_for_agent(&self, agent_id: AgentId) -> Vec<String> {
+        self.user_defaults
+            .iter()
+            .filter(|entry| *entry.value() == agent_id)
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     /// Set a user's default agent.
     pub fn set_user_default(&self, user_key: String, agent_id: AgentId) {
         self.user_defaults.insert(user_key, agent_id);

--- a/crates/openfang-channels/src/types.rs
+++ b/crates/openfang-channels/src/types.rs
@@ -259,6 +259,13 @@ pub trait ChannelAdapter: Send + Sync {
         ChannelStatus::default()
     }
 
+    /// Broadcast a system message to all connected rooms/conversations.
+    /// Used for approval notifications and other system-wide alerts.
+    /// Default: no-op (adapters that support it should override).
+    async fn broadcast(&self, _message: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
     /// Send a response as a thread reply (optional — default falls back to `send()`).
     async fn send_in_thread(
         &self,

--- a/crates/openfang-kernel/src/approval.rs
+++ b/crates/openfang-kernel/src/approval.rs
@@ -15,6 +15,9 @@ const MAX_PENDING_PER_AGENT: usize = 5;
 pub struct ApprovalManager {
     pending: DashMap<Uuid, PendingRequest>,
     policy: std::sync::RwLock<ApprovalPolicy>,
+    /// Broadcast channel for notifying external systems (channel bridge, websockets)
+    /// about new approval requests. Receivers can display the request in chat.
+    notify_tx: tokio::sync::broadcast::Sender<ApprovalRequest>,
 }
 
 struct PendingRequest {
@@ -24,10 +27,18 @@ struct PendingRequest {
 
 impl ApprovalManager {
     pub fn new(policy: ApprovalPolicy) -> Self {
+        let (notify_tx, _) = tokio::sync::broadcast::channel(16);
         Self {
             pending: DashMap::new(),
             policy: std::sync::RwLock::new(policy),
+            notify_tx,
         }
+    }
+
+    /// Subscribe to approval request notifications.
+    /// Returns a receiver that gets a copy of each new `ApprovalRequest`.
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<ApprovalRequest> {
+        self.notify_tx.subscribe()
     }
 
     /// Check if a tool requires approval based on current policy.
@@ -62,6 +73,11 @@ impl ApprovalManager {
         );
 
         info!(request_id = %id, "Approval request submitted, waiting for resolution");
+
+        // Notify subscribers (channel bridge, etc.) — best-effort, ignore if no receivers
+        if let Some(entry) = self.pending.get(&id) {
+            let _ = self.notify_tx.send(entry.request.clone());
+        }
 
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(decision)) => {


### PR DESCRIPTION
## Summary

When an agent invokes a tool that requires approval (e.g. `shell_exec`), the request was only visible in the web dashboard. Users interacting via Matrix or other channel adapters had no way to know an approval was pending, causing silent timeouts and confusing "denied" responses.

This PR adds proactive approval notifications to chat channels:

```
Approval required
  Tool: shell_exec
  Risk: Critical
  Agent: bd2faf58-038b-4fdb-8eb4-780abffe0506
  shell_exec: {"command":"gcc -o hello hello.c && ./hello"}

Reply /approve 24dc494b or /reject 24dc494b
```

## Changes

- **`openfang-kernel/approval.rs`**: Add `tokio::sync::broadcast` channel to `ApprovalManager` that fires on every new request, with `subscribe()` for consumers
- **`openfang-channels/types.rs`**: Add `broadcast(&str)` default method to `ChannelAdapter` trait for system-wide messages
- **`openfang-channels/matrix.rs`**: Implement `broadcast()` by querying `/joined_rooms` and sending to each (respecting `allowed_rooms`)
- **`openfang-channels/router.rs`**: Add `rooms_for_agent(AgentId)` reverse-lookup to find which room(s) route to a given agent
- **`openfang-api/channel_bridge.rs`**: Spawn listener task that subscribes to approval notifications, resolves the originating room via router, and sends formatted message with `/approve` and `/reject` instructions. Falls back to broadcast only if no route found.

The existing `/approve` and `/reject` slash commands were already fully implemented — this PR adds the missing notification trigger so users actually see the request in chat.

## Test plan

- [ ] `cargo build --workspace --lib`
- [ ] `cargo test --workspace`
- [ ] Configure `[approval] require_approval = ["shell_exec"]` and a Matrix channel
- [ ] Send a message that triggers `shell_exec` (e.g. "compile and run hello.c")
- [ ] Verify notification appears **only** in the originating room, not all rooms
- [ ] Reply `/approve <id>` — verify tool executes and agent responds with result
- [ ] Reply `/reject <id>` — verify agent gets denial
- [ ] Let timeout expire — verify agent gets timeout denial
- [ ] Test with no channel configured — verify no panics (broadcast has no receivers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)