### PR TITLE
fix: resolve page-header overlap and overflow

### DIFF
--- a/crates/openfang-api/static/css/components.css
+++ b/crates/openfang-api/static/css/components.css
@@ -1274,6 +1274,7 @@ mark.search-highlight {
 /* Utility */
 .flex { display: flex; }
 .flex-col { flex-direction: column; }
+.flex-wrap { flex-wrap: wrap; }
 .items-center { align-items: center; }
 .justify-between { justify-content: space-between; }
 .gap-2 { gap: 8px; }

--- a/crates/openfang-api/static/css/layout.css
+++ b/crates/openfang-api/static/css/layout.css
@@ -243,6 +243,14 @@
   z-index: 99;
 }
 
+.mobile-menu-btn {
+  position: fixed !important;
+  top: 12px;
+  left: 16px;
+  z-index: 98;
+  padding: 6px 10px !important;
+}
+
 /* Wide desktop — larger card grids */
 @media (min-width: 1400px) {
   .card-grid { grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); }
@@ -277,6 +285,8 @@
     left: -300px;
   }
   .mobile-menu-btn { display: flex !important; }
+  /* Offset header content so it does not overlap the fixed mobile menu button. */
+  .page-header > :first-child { margin-left: 52px; }
 }
 
 @media (min-width: 769px) {
@@ -285,7 +295,14 @@
 
 /* Mobile small screen */
 @media (max-width: 480px) {
-  .page-header { flex-direction: column; gap: 8px; align-items: flex-start; padding: 12px 16px; }
+  .page-header {
+    gap: 8px;
+    padding: 12px 16px;
+    flex-wrap: wrap;
+  }
+  .page-header h2 {
+    line-height: 44px;
+  }
   .page-body { padding: 12px; }
   .stats-row { flex-wrap: wrap; }
   .stat-card { min-width: 80px; flex: 1 1 40%; }

--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -201,7 +201,7 @@
   <!-- Main Content -->
   <main class="main-content">
     <!-- Mobile menu button -->
-    <button class="mobile-menu-btn btn btn-ghost" @click="mobileMenuOpen = !mobileMenuOpen" style="position:fixed;top:8px;left:8px;z-index:98;padding:6px 10px">
+    <button class="mobile-menu-btn btn btn-ghost" @click="mobileMenuOpen = !mobileMenuOpen">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
     </button>
 
@@ -4314,7 +4314,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
       <div x-data="logsPage">
         <div class="page-header">
           <h2>Logs</h2>
-          <div class="flex gap-2 items-center" x-show="tab === 'live'">
+          <div class="flex gap-2 items-center flex-wrap" x-show="tab === 'live'">
             <!-- Connection status indicator -->
             <span class="live-indicator" :class="connectionClass">
               <span class="live-dot"></span>


### PR DESCRIPTION
## Summary

- Fixes mobile page-header title/button overlap on small screens.
- Improves page-header behavior for long content to avoid overflow.

## Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="522" height="203" alt="screenshot-20260320-154930" src="https://github.com/user-attachments/assets/57b2b218-e5b9-4edf-b561-d7e98ab293b8" /></td>
<td>
<img width="532" height="302" alt="screenshot-20260320-155605" src="https://github.com/user-attachments/assets/b2a6cdae-a20a-4ad8-8db6-f8f6975e686f" />

</td>
</tr>
<tr>
<td><img width="520" height="280" alt="screenshot-20260320-154849" src="https://github.com/user-attachments/assets/271727ea-8cae-4771-9a0f-2f188ae51057" /></td>
<td>
<img width="522" height="250" alt="screenshot-20260320-160907" src="https://github.com/user-attachments/assets/5d3598c2-9c24-4564-be9b-90538c085928" />

</td>
<tr>
<td>
<img width="525" height="207" alt="screenshot-20260320-160937" src="https://github.com/user-attachments/assets/a6c48b71-fee3-4337-9f2e-926fb18c6801" />
</td>
<td>
<img width="534" height="200" alt="screenshot-20260320-160925" src="https://github.com/user-attachments/assets/15d4b6be-c13e-40ea-bcad-f181275a5ecd" />
</td>
</tr>
</tr>
<tr>
<td><img width="525" height="212" alt="screenshot-20260320-154828" src="https://github.com/user-attachments/assets/d64b9e53-3e1a-4688-99d6-8c26a2b29ed8" /></td>
<td>
<img width="540" height="248" alt="screenshot-20260320-160513" src="https://github.com/user-attachments/assets/a7660fbf-1cf2-4b4f-9f87-b6af464b3c57" />

</td>
</tr>
</tbody>
</table>


## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
