### PR TITLE
fix: Empty string IDs are overwritten, leading to inconsistencies in …

### DIFF
--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -1173,7 +1173,10 @@ impl LlmDriver for OpenAIDriver {
 
                                 // ID (sent in first chunk for this tool)
                                 if let Some(id) = call["id"].as_str() {
-                                    tool_accum[idx].0 = id.to_string();
+                                    // Fix: Empty string IDs are overwritten, leading to inconsistencies in certain models.
+                                    if !id.is_empty() {
+                                        tool_accum[idx].0 = id.to_string();
+                                    }
                                 }
 
                                 if let Some(func) = call.get("function") {


### PR DESCRIPTION
…certain models.

## Summary
Empty string IDs are overwritten, leading to inconsistencies in certain models.

If the ID is an empty string, it gets overwritten, causing anomalies in models like `qwen3.5-plus` and `minimax-2.5` during multi-turn tool calls.
<!-- What does this PR do? Link related issues with "Fixes #123". -->

## Changes

<!-- Brief list of what changed. -->

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
