### PR TITLE
fix(mcp): handle Streamable HTTP MCP responses with SSE framing

### DIFF
--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -365,7 +365,21 @@ impl McpConnection {
                     .await
                     .map_err(|e| format!("Failed to read SSE response: {e}"))?;
 
-                let rpc_response: JsonRpcResponse = serde_json::from_str(&body)
+                // Handle Streamable HTTP MCP responses that use SSE framing
+                // (e.g. "event: message\ndata: {...}\n\n"). Extract the JSON
+                // from the last `data:` line if the body looks like SSE.
+                let json_body = if body.trim_start().starts_with("event:") || body.trim_start().starts_with("data:") {
+                    body.lines()
+                        .filter_map(|line| line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:")))
+                        .filter(|s| !s.is_empty())
+                        .last()
+                        .unwrap_or(&body)
+                        .to_string()
+                } else {
+                    body
+                };
+
+                let rpc_response: JsonRpcResponse = serde_json::from_str(&json_body)
                     .map_err(|e| format!("Invalid MCP SSE JSON-RPC response: {e}"))?;
 
                 if let Some(err) = rpc_response.error {


### PR DESCRIPTION
## Problem

MCP servers using Streamable HTTP transport (e.g., [Hindsight](https://github.com/vectorize-io/hindsight)) wrap JSON-RPC responses in SSE framing:

```
event: message
data: {"jsonrpc":"2.0","id":1,"result":{...}}
```

The SSE transport handler expected raw JSON bodies, causing `Invalid MCP SSE JSON-RPC response: expected value at line 1 column 1` errors when connecting to these servers.

## Fix

Extract the JSON payload from `data:` lines before deserializing. Falls back to raw body parsing for servers that return plain JSON, so existing SSE servers are unaffected.

## Testing

- Tested against Hindsight MCP server (v0.4.19) — 26 tools discovered and operational
- Existing plain-JSON SSE servers continue to work (no behavioral change for non-SSE-framed responses)

## Context

Streamable HTTP is the newer MCP transport defined in the [MCP spec (2025-03-26)](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). This change adds forward-compatible support without requiring a new transport type.