### PR TITLE
Fix Gemini driver crash on content entries without parts

### DIFF
--- a/crates/openfang-runtime/src/drivers/gemini.rs
+++ b/crates/openfang-runtime/src/drivers/gemini.rs
@@ -60,6 +60,7 @@ struct GeminiRequest {
 struct GeminiContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     role: Option<String>,
+    #[serde(default)]
     parts: Vec<GeminiPart>,
 }
 


### PR DESCRIPTION
## Summary
Add `#[serde(default)]` to `GeminiContent.parts` to prevent deserialization crash.

## Problem
When Gemini returns a content entry with only a `role` and no `parts` array (observed with large tool counts, 100+), the response parser fails with `missing field 'parts'`, crashing the agent loop.

## Fix
One-line change: `#[serde(default)]` on the `parts` field defaults to an empty `Vec` instead of failing.

## Test plan
- [x] `cargo check` passes
- [x] Existing Gemini driver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)