### PR TITLE
feat: add statically compiled native-tls to binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ zip = { version = "4", default-features = false, features = ["deflate"] }
 # Email (SMTP + IMAP)
 lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 imap = "2"
-native-tls = "0.2"
+native-tls = { version = "0.2", features = ["vendored"] }
 mailparse = "0.16"
 
 # OpenSSL (vendored = statically compiled, no runtime libssl dependency on Linux)


### PR DESCRIPTION
## Summary

Originally `native-tls` pulls in `openssl` as a transitive dependency for IMAP support, and `native-tls` doesn't use the vendored feature by default. It links against the system's libssl, which on Debian Trixie is OpenSSL 3.x (libssl3), not libssl.so.1.0.0. As a result, running `openfang` on Debian trixie will results in 
```
openfang: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
```
This PR add `features = ["vendored"]` into native-tls. Which causes it (and the imap crate's transitive OpenSSL dependency) to statically compile OpenSSL rather than link against the system's libssl at runtime. The binary will no longer depend on libssl.so.1.0.0 being present on the target system.

Previously, commit 135c37f adds `features = ["vendored"]` to `openssl`, however it does not fully resolve the linking issue.
## Changes

- Cargo.toml: add `features = ["vendored"]` to `native-tls`

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes: [Proof](https://github.com/b4iterdev/openfang/actions/runs/23426300916/job/68141815520)
- [X] `cargo test --workspace` passes: [Proof](https://github.com/b4iterdev/openfang/actions/runs/23426300916/)
- [X] Live integration tested (if applicable): Installed binary with existing Github Action workflow on Debian trixie and the problem no longer exists
## Security

- [X] No new unsafe code
- [X] No secrets or API keys in diff: N/A
- [X] User input validated at boundaries: N/A
