### PR TITLE
fix(claude-code): fix empty responses from claude -p driver (issue #295)

### DIFF
--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -524,11 +524,30 @@ impl LlmDriver for ClaudeCodeDriver {
                     Ok(event) => {
                         match event.r#type.as_str() {
                             "content" | "text" | "assistant" | "content_block_delta" => {
-                                if let Some(ref content) = event.content {
-                                    full_text.push_str(content);
+                                // Older CLI: flat `content` string.
+                                // CLI ≥2.x (type=assistant): text is nested in
+                                // `message.content[].text`; the flat `content`
+                                // field is absent or null.
+                                let chunk = event.content.clone().unwrap_or_default();
+                                let nested: String = event
+                                    .message
+                                    .as_ref()
+                                    .map(|msg| {
+                                        msg.content
+                                            .iter()
+                                            .filter(|b| b.block_type == "text")
+                                            .map(|b| b.text.as_str())
+                                            .collect::<Vec<_>>()
+                                            .join("")
+                                    })
+                                    .unwrap_or_default();
+                                let text_chunk =
+                                    if !chunk.is_empty() { chunk } else { nested };
+                                if !text_chunk.is_empty() {
+                                    full_text.push_str(&text_chunk);
                                     let _ = tx
                                         .send(StreamEvent::TextDelta {
-                                            text: content.clone(),
+                                            text: text_chunk,
                                         })
                                         .await;
                                 }


### PR DESCRIPTION
## Summary

Fixes **#295** — the `claude-code` driver always returns empty responses when using `claude -p`.

Five root causes were identified and each fixed in a separate commit:

### Fix 1 — `#[serde(default)]` on `ClaudeJsonOutput.result`
`serde_json` fails to deserialize the CLI's JSON output if the `result` field is absent (e.g. when the response is in `content` or `text` instead). Adding `#[serde(default)]` makes the field optional and prevents silent deserialization failure that swallows the response.

### Fix 2 — New structs for nested assistant message content
CLI ≥2.x emits `type=assistant` stream-json events where the text is nested in `message.content[{"type":"text","text":"..."}]`. `ClaudeStreamEvent` had no `message` field, so these events were always skipped. Added `ClaudeMessageBlock`, `ClaudeAssistantMessage`, and a `message: Option<ClaudeAssistantMessage>` field.

### Fix 3 — Concurrent pipe drain in `complete()` to prevent deadlock
`complete()` called `child.wait()` before reading stdout/stderr. For responses larger than the OS pipe buffer (~64 KB), the subprocess blocks on `write()`, `wait()` never returns, the timeout fires, and stdout is empty. Fixed by spawning two `tokio::spawn` tasks to drain pipes concurrently with `child.wait()`.

Also injects `HOME` from `home_dir()` so the CLI can find `~/.claude/credentials` when OpenFang runs as a service, and sets `stdin` to `null` to prevent the CLI from blocking on interactive input.

### Fix 4 — Inject HOME and null stdin in `stream()`
Same environment hygiene as Fix 3, applied to the streaming path.

### Fix 5 — Extract text from `message.content[].text` in `stream()` handler
The `type=assistant` match arm only checked `event.content` (flat string). For CLI ≥2.x this field is null, so every streamed token was dropped and the method returned an empty string. The handler now checks `event.content` first (backward-compatible with older CLI), then falls back to joining all `text`-type blocks from `message.content[]`.

## Test plan

- [x] `cargo test -p openfang-runtime --lib` — **826 passed, 0 failed**
- [x] Verified `claude -p "Say hello" --output-format json` returns non-empty `result` on CLI ≥2.x
- [x] Verified `claude -p "Say hello" --output-format stream-json --verbose` emits `type=assistant` events with nested content on CLI ≥2.x
- [x] Each fix is in its own commit for reviewability

🤖 Generated with [Claude Code](https://claude.com/claude-code)