### PR TITLE
fix(ui): use dynamic provider options in spawn wizard (#816)

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -1155,29 +1155,19 @@
                     <div class="form-group">
                       <label>Provider</label>
                       <select class="form-select" x-model="spawnForm.provider">
-                        <optgroup label="Cloud">
-                          <option value="anthropic">Anthropic</option>
-                          <option value="openai">OpenAI</option>
-                          <option value="gemini">Google Gemini</option>
-                          <option value="groq">Groq</option>
-                          <option value="deepseek">DeepSeek</option>
-                          <option value="openrouter">OpenRouter</option>
-                          <option value="mistral">Mistral</option>
-                          <option value="xai">xAI</option>
-                          <option value="together">Together</option>
-                          <option value="fireworks">Fireworks</option>
-                          <option value="cerebras">Cerebras</option>
-                          <option value="sambanova">SambaNova</option>
-                          <option value="azure">Azure OpenAI</option>
-                          <option value="nvidia">NVIDIA NIM</option>
-                        </optgroup>
-                        <optgroup label="Local">
-                          <option value="ollama">Ollama</option>
-                          <option value="lmstudio">LM Studio</option>
-                          <option value="vllm">vLLM</option>
-                          <option value="lemonade">Lemonade</option>
-                        </optgroup>
+                        <template x-for="group in spawnProviderGroups" :key="group.label">
+                          <optgroup :label="group.label">
+                            <template x-for="provider in group.providers" :key="provider.id">
+                              <option :value="provider.id" x-text="provider.display_name || provider.id"></option>
+                            </template>
+                          </optgroup>
+                        </template>
+                        <template x-if="spawnForm.provider && !hasSpawnProvider(spawnForm.provider)">
+                          <option :value="spawnForm.provider" x-text="spawnForm.provider"></option>
+                        </template>
                       </select>
+                      <p class="text-xs text-dim" x-show="spawnProvidersLoading">Loading provider catalog...</p>
+                      <p class="text-xs text-dim" x-show="spawnProvidersError" x-text="spawnProvidersError"></p>
                     </div>
                     <div class="form-group">
                       <label>Model</label>

--- a/crates/openfang-api/static/js/pages/agents.js
+++ b/crates/openfang-api/static/js/pages/agents.js
@@ -89,6 +89,8 @@ function agentsPage() {
     tplProviders: [],
     tplLoading: false,
     tplLoadError: '',
+    spawnProvidersLoading: false,
+    spawnProvidersError: '',
     selectedCategory: 'All',
     searchQuery: '',
 
@@ -268,6 +270,23 @@ function agentsPage() {
       });
     },
 
+    get spawnProviderGroups() {
+      var providers = (this.tplProviders || []).slice().sort(function(a, b) {
+        return (a.display_name || a.id).localeCompare(b.display_name || b.id);
+      });
+      var cloudProviders = providers.filter(function(p) { return !p.is_local; });
+      var localProviders = providers.filter(function(p) { return !!p.is_local; });
+      var groups = [];
+      if (cloudProviders.length) groups.push({ label: 'Cloud', providers: cloudProviders });
+      if (localProviders.length) groups.push({ label: 'Local', providers: localProviders });
+      return groups;
+    },
+
+    hasSpawnProvider(providerId) {
+      if (!providerId) return false;
+      return this.tplProviders.some(function(p) { return p.id === providerId; });
+    },
+
     isProviderConfigured(providerName) {
       if (!providerName) return false;
       var p = this.tplProviders.find(function(pr) { return pr.id === providerName; });
@@ -324,6 +343,20 @@ function agentsPage() {
         this.tplLoadError = e.message || 'Could not load templates.';
       }
       this.tplLoading = false;
+    },
+
+    async loadSpawnProviders(force) {
+      if (this.spawnProvidersLoading) return;
+      if (!force && this.tplProviders.length) return;
+      this.spawnProvidersLoading = true;
+      this.spawnProvidersError = '';
+      try {
+        var result = await OpenFangAPI.get('/api/providers');
+        this.tplProviders = result.providers || [];
+      } catch(e) {
+        this.spawnProvidersError = e.message || 'Could not load providers.';
+      }
+      this.spawnProvidersLoading = false;
     },
 
     chatWithAgent(agent) {
@@ -407,6 +440,7 @@ function agentsPage() {
       this.spawnForm.model = 'llama-3.3-70b-versatile';
       this.spawnForm.systemPrompt = 'You are a helpful assistant.';
       this.spawnForm.profile = 'full';
+      this.loadSpawnProviders();
       try {
         var res = await fetch('/api/status');
         if (res.ok) {


### PR DESCRIPTION
## Summary

Fixes #816 by replacing the spawn wizard's hardcoded provider dropdown with options loaded from /api/providers.

## Changes

- load provider options when opening the spawn wizard
- render cloud/local provider groups dynamically from backend data
- keep the currently selected provider visible as a fallback if the catalog has not loaded yet

## Testing

- 
ode --check crates/openfang-api/static/js/pages/agents.js
- verified the spawn wizard template now renders spawnProviderGroups instead of hardcoded provider <option> entries
- Docker sandbox validation could not be run on this machine because the Docker daemon was not running

## Impact

- provider options in the spawn wizard now stay aligned with the backend model catalog
- newly added providers no longer require manual frontend updates to appear in the UI