### PR TITLE
fix: format object-type tool input correctly in formatToolJson

### DIFF
--- a/crates/openfang-api/static/js/pages/chat.js
+++ b/crates/openfang-api/static/js/pages/chat.js
@@ -1125,6 +1125,9 @@ function chatPage() {
 
     formatToolJson: function(text) {
       if (!text) return '';
+      if (typeof text === 'object') {
+        return JSON.stringify(text, null, 2);
+      }
       try { return JSON.stringify(JSON.parse(text), null, 2); }
       catch(e) { return text; }
     },


### PR DESCRIPTION
## Summary

Added a type check in `formatToolJson` to properly stringify object inputs 
before formatting, resolving the issue where tool call parameters were 
displayed as `[object Object]`.

## Changes

Before:

<img width="602" height="223" alt="screenshot-20260324-165958" src="https://github.com/user-attachments/assets/1027b526-a584-4204-abff-5b10fdddf874" />

After:

<img width="623" height="302" alt="screenshot-20260324-165629" src="https://github.com/user-attachments/assets/fd6d3672-8ea7-4bd7-8494-b036eb8c401e" />

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
