### PR TITLE
runtime: preserve screenshot tool results as multimodal input

### DIFF
--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -81,6 +81,59 @@ fn append_tool_error_guidance(tool_result_blocks: &mut Vec<ContentBlock>) {
     }
 }
 
+fn parse_inline_image_data_url(data_url: &str) -> Option<(String, String)> {
+    let rest = data_url.strip_prefix("data:")?;
+    let (metadata, payload) = rest.split_once(',')?;
+    let (media_type, encoding) = metadata.split_once(';')?;
+    if !encoding.eq_ignore_ascii_case("base64") || !media_type.starts_with("image/") {
+        return None;
+    }
+    openfang_types::message::validate_image(media_type, payload).ok()?;
+    Some((media_type.to_string(), payload.to_string()))
+}
+
+fn augment_tool_result_for_vision(tool_name: &str, content: &str) -> (String, Vec<ContentBlock>) {
+    let mut value = match serde_json::from_str::<serde_json::Value>(content) {
+        Ok(value) => value,
+        Err(_) => return (content.to_string(), Vec::new()),
+    };
+    let Some(object) = value.as_object_mut() else {
+        return (content.to_string(), Vec::new());
+    };
+
+    let image = object
+        .remove("dataUrl")
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .and_then(|data_url| parse_inline_image_data_url(&data_url));
+
+    let Some((media_type, data)) = image else {
+        return (content.to_string(), Vec::new());
+    };
+
+    object.insert("imageAttached".to_string(), serde_json::json!(true));
+    object.insert(
+        "imageMediaType".to_string(),
+        serde_json::json!(media_type.clone()),
+    );
+    object.insert(
+        "visionHint".to_string(),
+        serde_json::json!("Use the attached screenshot as visual evidence for the current page state."),
+    );
+
+    let sanitized_content = serde_json::to_string_pretty(&value)
+        .unwrap_or_else(|_| format!("Tool '{tool_name}' returned a screenshot. Image attached."));
+    let live_blocks = vec![
+        ContentBlock::Text {
+            text: format!(
+                "[Screenshot attached from tool '{tool_name}'. Use it as visual evidence for the visible page state.]"
+            ),
+            provider_metadata: None,
+        },
+        ContentBlock::Image { media_type, data },
+    ];
+
+    (sanitized_content, live_blocks)
+}
 /// Strip a provider prefix from a model ID before sending to the API.
 ///
 /// Many models are stored as `provider/org/model` (e.g. `openrouter/google/gemini-2.5-flash`)
@@ -173,7 +226,6 @@ pub async fn run_agent_loop(
         .get("hand_allowed_env")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default();
-
     // Recall relevant memories — prefer vector similarity search when embedding driver is available
     let memories = if let Some(emb) = embedding_driver {
         match emb.embed_one(user_message).await {
@@ -557,15 +609,15 @@ pub async fn run_agent_loop(
                         }
                     }
                 } else {
-                    let _ = memory
-                        .remember(
-                            session.agent_id,
-                            &interaction_text,
-                            MemorySource::Conversation,
-                            "episodic",
-                            HashMap::new(),
-                        )
-                        .await;
+                        let _ = memory
+                            .remember(
+                                session.agent_id,
+                                &interaction_text,
+                                MemorySource::Conversation,
+                                "episodic",
+                                HashMap::new(),
+                            )
+                            .await;
                 }
 
                 // Notify phase: Done
@@ -752,6 +804,9 @@ pub async fn run_agent_loop(
                         }
                     };
 
+                    let (vision_ready_content, vision_blocks) =
+                        augment_tool_result_for_vision(&tool_call.name, &result.content);
+
                     // Fire AfterToolCall hook
                     if let Some(hook_reg) = hooks {
                         let ctx = crate::hooks::HookContext {
@@ -760,7 +815,7 @@ pub async fn run_agent_loop(
                             event: openfang_types::agent::HookEvent::AfterToolCall,
                             data: serde_json::json!({
                                 "tool_name": &tool_call.name,
-                                "result": &result.content,
+                                "result": &vision_ready_content,
                                 "is_error": result.is_error,
                             }),
                         };
@@ -768,7 +823,8 @@ pub async fn run_agent_loop(
                     }
 
                     // Dynamic truncation based on context budget (replaces flat MAX_TOOL_RESULT_CHARS)
-                    let content = truncate_tool_result_dynamic(&result.content, &context_budget);
+                    let content =
+                        truncate_tool_result_dynamic(&vision_ready_content, &context_budget);
 
                     // Append warning if verdict was Warn
                     let final_content = if let LoopGuardVerdict::Warn(ref warn_msg) = verdict {
@@ -783,6 +839,7 @@ pub async fn run_agent_loop(
                         content: final_content,
                         is_error: result.is_error,
                     });
+                    tool_result_blocks.extend(vision_blocks.iter().cloned());
                 }
 
                 append_tool_error_guidance(&mut tool_result_blocks);
@@ -1180,7 +1237,6 @@ pub async fn run_agent_loop_streaming(
         .get("hand_allowed_env")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default();
-
     // Recall relevant memories — prefer vector similarity search when embedding driver is available
     let memories = if let Some(emb) = embedding_driver {
         match emb.embed_one(user_message).await {
@@ -1560,15 +1616,15 @@ pub async fn run_agent_loop_streaming(
                         }
                     }
                 } else {
-                    let _ = memory
-                        .remember(
-                            session.agent_id,
-                            &interaction_text,
-                            MemorySource::Conversation,
-                            "episodic",
-                            HashMap::new(),
-                        )
-                        .await;
+                        let _ = memory
+                            .remember(
+                                session.agent_id,
+                                &interaction_text,
+                                MemorySource::Conversation,
+                                "episodic",
+                                HashMap::new(),
+                            )
+                            .await;
                 }
 
                 // Notify phase: Done
@@ -1751,6 +1807,9 @@ pub async fn run_agent_loop_streaming(
                         }
                     };
 
+                    let (vision_ready_content, vision_blocks) =
+                        augment_tool_result_for_vision(&tool_call.name, &result.content);
+
                     // Fire AfterToolCall hook
                     if let Some(hook_reg) = hooks {
                         let ctx = crate::hooks::HookContext {
@@ -1759,7 +1818,7 @@ pub async fn run_agent_loop_streaming(
                             event: openfang_types::agent::HookEvent::AfterToolCall,
                             data: serde_json::json!({
                                 "tool_name": &tool_call.name,
-                                "result": &result.content,
+                                "result": &vision_ready_content,
                                 "is_error": result.is_error,
                             }),
                         };
@@ -1767,7 +1826,8 @@ pub async fn run_agent_loop_streaming(
                     }
 
                     // Dynamic truncation based on context budget (replaces flat MAX_TOOL_RESULT_CHARS)
-                    let content = truncate_tool_result_dynamic(&result.content, &context_budget);
+                    let content =
+                        truncate_tool_result_dynamic(&vision_ready_content, &context_budget);
 
                     // Append warning if verdict was Warn
                     let final_content = if let LoopGuardVerdict::Warn(ref warn_msg) = verdict {
@@ -1796,6 +1856,7 @@ pub async fn run_agent_loop_streaming(
                         content: final_content,
                         is_error: result.is_error,
                     });
+                    tool_result_blocks.extend(vision_blocks.iter().cloned());
                 }
 
                 append_tool_error_guidance(&mut tool_result_blocks);
@@ -2737,6 +2798,7 @@ mod tests {
     use super::*;
     use crate::llm_driver::{CompletionResponse, LlmError};
     use async_trait::async_trait;
+    use openfang_types::message::ContentBlock;
     use openfang_types::tool::ToolCall;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -2798,6 +2860,27 @@ mod tests {
     #[test]
     fn test_max_history_messages() {
         assert_eq!(MAX_HISTORY_MESSAGES, 20);
+    }
+
+    #[test]
+    fn test_augment_tool_result_for_vision_extracts_inline_screenshot() {
+        let payload = serde_json::json!({
+            "tabId": 7,
+            "dataUrl": "data:image/png;base64,iVBORw0KGgo=",
+        })
+        .to_string();
+
+        let (sanitized, blocks) = augment_tool_result_for_vision("mcp_firefox_tab_capture_visible", &payload);
+
+        assert!(sanitized.contains("\"imageAttached\": true"));
+        assert!(!sanitized.contains("data:image/png;base64"));
+        assert_eq!(blocks.len(), 2);
+        assert!(matches!(&blocks[0], ContentBlock::Text { .. }));
+        assert!(matches!(
+            &blocks[1],
+            ContentBlock::Image { media_type, data }
+            if media_type == "image/png" && data == "iVBORw0KGgo="
+        ));
     }
 
     // --- Integration tests for empty response guards ---

--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -236,6 +236,53 @@ struct OaiToolDef {
     parameters: serde_json::Value,
 }
 
+fn push_openai_user_blocks(oai_messages: &mut Vec<OaiMessage>, blocks: &[ContentBlock]) {
+    let mut parts: Vec<OaiContentPart> = Vec::new();
+
+    for block in blocks {
+        match block {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => {
+                oai_messages.push(OaiMessage {
+                    role: "tool".to_string(),
+                    content: Some(OaiMessageContent::Text(if content.is_empty() {
+                        "(empty)".to_string()
+                    } else {
+                        content.clone()
+                    })),
+                    tool_calls: None,
+                    tool_call_id: Some(tool_use_id.clone()),
+                    reasoning_content: None,
+                });
+            }
+            ContentBlock::Text { text, .. } => {
+                parts.push(OaiContentPart::Text { text: text.clone() });
+            }
+            ContentBlock::Image { media_type, data } => {
+                parts.push(OaiContentPart::ImageUrl {
+                    image_url: OaiImageUrl {
+                        url: format!("data:{media_type};base64,{data}"),
+                    },
+                });
+            }
+            ContentBlock::Thinking { .. } | ContentBlock::Unknown | ContentBlock::ToolUse { .. } => {}
+        }
+    }
+
+    if !parts.is_empty() {
+        oai_messages.push(OaiMessage {
+            role: "user".to_string(),
+            content: Some(OaiMessageContent::Parts(parts)),
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+        });
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct OaiResponse {
     choices: Vec<OaiChoice>,
@@ -312,52 +359,7 @@ impl LlmDriver for OpenAIDriver {
                     });
                 }
                 (Role::User, MessageContent::Blocks(blocks)) => {
-                    // Handle tool results and images in user messages
-                    let mut parts: Vec<OaiContentPart> = Vec::new();
-                    let mut has_tool_results = false;
-                    for block in blocks {
-                        match block {
-                            ContentBlock::ToolResult {
-                                tool_use_id,
-                                content,
-                                ..
-                            } => {
-                                has_tool_results = true;
-                                oai_messages.push(OaiMessage {
-                                    role: "tool".to_string(),
-                                    content: Some(OaiMessageContent::Text(if content.is_empty() {
-                                        "(empty)".to_string()
-                                    } else {
-                                        content.clone()
-                                    })),
-                                    tool_calls: None,
-                                    tool_call_id: Some(tool_use_id.clone()),
-                                    reasoning_content: None,
-                                });
-                            }
-                            ContentBlock::Text { text, .. } => {
-                                parts.push(OaiContentPart::Text { text: text.clone() });
-                            }
-                            ContentBlock::Image { media_type, data } => {
-                                parts.push(OaiContentPart::ImageUrl {
-                                    image_url: OaiImageUrl {
-                                        url: format!("data:{media_type};base64,{data}"),
-                                    },
-                                });
-                            }
-                            ContentBlock::Thinking { .. } => {}
-                            _ => {}
-                        }
-                    }
-                    if !parts.is_empty() && !has_tool_results {
-                        oai_messages.push(OaiMessage {
-                            role: "user".to_string(),
-                            content: Some(OaiMessageContent::Parts(parts)),
-                            tool_calls: None,
-                            tool_call_id: None,
-                            reasoning_content: None,
-                        });
-                    }
+                    push_openai_user_blocks(&mut oai_messages, blocks);
                 }
                 (Role::Assistant, MessageContent::Blocks(blocks)) => {
                     let mut text_parts = Vec::new();
@@ -794,26 +796,7 @@ impl LlmDriver for OpenAIDriver {
                     });
                 }
                 (Role::User, MessageContent::Blocks(blocks)) => {
-                    for block in blocks {
-                        if let ContentBlock::ToolResult {
-                            tool_use_id,
-                            content,
-                            ..
-                        } = block
-                        {
-                            oai_messages.push(OaiMessage {
-                                role: "tool".to_string(),
-                                content: Some(OaiMessageContent::Text(if content.is_empty() {
-                                    "(empty)".to_string()
-                                } else {
-                                    content.clone()
-                                })),
-                                tool_calls: None,
-                                tool_call_id: Some(tool_use_id.clone()),
-                                reasoning_content: None,
-                            });
-                        }
-                    }
+                    push_openai_user_blocks(&mut oai_messages, blocks);
                 }
                 (Role::Assistant, MessageContent::Blocks(blocks)) => {
                     let mut text_parts = Vec::new();
@@ -1680,6 +1663,45 @@ mod tests {
     #[test]
     fn test_extract_max_tokens_limit_no_match() {
         assert_eq!(extract_max_tokens_limit("some random error"), None);
+    }
+
+    #[test]
+    fn test_push_openai_user_blocks_keeps_image_after_tool_result() {
+        let mut messages = Vec::new();
+        let blocks = vec![
+            ContentBlock::ToolResult {
+                tool_use_id: "tool_1".to_string(),
+                tool_name: "mcp_firefox_tab_capture_visible".to_string(),
+                content: "{\"imageAttached\":true}".to_string(),
+                is_error: false,
+            },
+            ContentBlock::Text {
+                text: "Screenshot attached.".to_string(),
+                provider_metadata: None,
+            },
+            ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: "iVBORw0KGgo=".to_string(),
+            },
+        ];
+
+        push_openai_user_blocks(&mut messages, &blocks);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, "tool");
+        assert_eq!(messages[0].tool_call_id.as_deref(), Some("tool_1"));
+        match &messages[1].content {
+            Some(OaiMessageContent::Parts(parts)) => {
+                assert_eq!(parts.len(), 2);
+                assert!(matches!(&parts[0], OaiContentPart::Text { text } if text == "Screenshot attached."));
+                assert!(matches!(
+                    &parts[1],
+                    OaiContentPart::ImageUrl { image_url }
+                    if image_url.url == "data:image/png;base64,iVBORw0KGgo="
+                ));
+            }
+            other => panic!("expected user parts, got {other:?}"),
+        }
     }
 
     // ----- extract_think_tags tests -----


### PR DESCRIPTION
Problem

When a tool returns a ToolResult plus an attached screenshot, the OpenAI-compatible driver currently serializes the tool result but drops the accompanying image/text blocks on the next model turn. In practice, that means agents can capture screenshots but cannot actually reason over them as visual context.

Root cause

In crates/openfang-runtime/src/drivers/openai.rs, Role::User messages containing ToolResult blocks were converted into tool messages, but any sibling image/text content in the same turn was not preserved for the next model request.

What this changes

- In crates/openfang-runtime/src/agent_loop.rs, screenshot-bearing tool results are normalized into a sanitized ToolResult plus companion live image/text blocks.
- In crates/openfang-runtime/src/drivers/openai.rs, the OpenAI-compatible driver now preserves both the tool message and the follow-up multimodal user parts.
- Adds regression coverage for inline screenshot extraction and mixed tool+image serialization.

Why this is useful upstream

- It is not Firefox-specific.
- It improves any tool workflow that returns visual evidence.
- It fixes a real multimodal runtime gap without changing text-only or tool-only flows.

Validation

- cargo test -p openfang-runtime -j 1
