### PR TITLE
fix(wizard): prevent provider reset to first item during API_KEY test

### DIFF
--- a/crates/openfang-api/static/js/pages/wizard.js
+++ b/crates/openfang-api/static/js/pages/wizard.js
@@ -254,6 +254,15 @@ function wizardPage() {
       this.error = '';
       try {
         await this.loadProviders();
+        // Pre-select first unconfigured provider, or first one
+        var unconfigured = this.providers.filter(function(p) {
+          return p.auth_status !== 'configured' && p.api_key_env;
+        });
+        if (unconfigured.length > 0) {
+          this.selectedProvider = unconfigured[0].id;
+        } else if (this.providers.length > 0) {
+          this.selectedProvider = this.providers[0].id;
+        }
       } catch(e) {
         this.error = e.message || 'Could not load setup data.';
       }
@@ -313,15 +322,6 @@ function wizardPage() {
       try {
         var data = await OpenFangAPI.get('/api/providers');
         this.providers = data.providers || [];
-        // Pre-select first unconfigured provider, or first one
-        var unconfigured = this.providers.filter(function(p) {
-          return p.auth_status !== 'configured' && p.api_key_env;
-        });
-        if (unconfigured.length > 0) {
-          this.selectedProvider = unconfigured[0].id;
-        } else if (this.providers.length > 0) {
-          this.selectedProvider = this.providers[0].id;
-        }
       } catch(e) { this.providers = []; }
     },
 


### PR DESCRIPTION
## Summary

Fix the provider selection reset issue in the `saveKey()` function. After saving an API Key, this function calls `loadProviders()`, which resets `selectedProvider` to the first unconfigured provider. This causes `testKey()` to use the wrong provider object for testing.

## Changes

- Move the `selectedProvider` initialization logic from `loadProviders()` to `loadData()`
- Ensure `selectedProvider` is only set when initially entering the page, preventing it from being unexpectedly reset after saving a Key

<table>
<thead>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
</thead>
<tbody>
<tr>
<td>
Reset to OpenAI when testing Anthropic

![openfang-test-provider-1](https://github.com/user-attachments/assets/f9d75c1c-5983-4871-8261-9ec3e1257122)

</td>
<td>
Will not reset

![openfang-test-provider-2](https://github.com/user-attachments/assets/8a2c515a-1b7d-4e5d-ab50-784d8c354da6)

</td>
</tr>
</tbody>
</table>

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
