### PR TITLE
fix: stamp release version from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,27 +56,7 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           VERSION="${VERSION#v}"
-          node - <<'JS'
-          const fs = require('fs');
-          const version = process.env.VERSION;
-          if (!version) throw new Error('VERSION is required');
-
-          const cargoPath = 'Cargo.toml';
-          const cargo = fs.readFileSync(cargoPath, 'utf8');
-          const updatedCargo = cargo.replace(
-            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
-            `$1${version}$2`,
-          );
-          if (updatedCargo === cargo) {
-            throw new Error('failed to stamp workspace.package version in Cargo.toml');
-          }
-          fs.writeFileSync(cargoPath, updatedCargo);
-
-          const tauriPath = 'crates/openfang-desktop/tauri.conf.json';
-          const tauri = JSON.parse(fs.readFileSync(tauriPath, 'utf8'));
-          tauri.version = version;
-          fs.writeFileSync(tauriPath, `${JSON.stringify(tauri, null, 2)}\n`);
-          JS
+          node scripts/stamp-release-version.mjs
 
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
@@ -196,22 +176,7 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           VERSION="${VERSION#v}"
-          node - <<'JS'
-          const fs = require('fs');
-          const version = process.env.VERSION;
-          if (!version) throw new Error('VERSION is required');
-
-          const cargoPath = 'Cargo.toml';
-          const cargo = fs.readFileSync(cargoPath, 'utf8');
-          const updatedCargo = cargo.replace(
-            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
-            `$1${version}$2`,
-          );
-          if (updatedCargo === cargo) {
-            throw new Error('failed to stamp workspace.package version in Cargo.toml');
-          }
-          fs.writeFileSync(cargoPath, updatedCargo);
-          JS
+          node scripts/stamp-release-version.mjs
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -268,22 +233,7 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           VERSION="${VERSION#v}"
-          node - <<'JS'
-          const fs = require('fs');
-          const version = process.env.VERSION;
-          if (!version) throw new Error('VERSION is required');
-
-          const cargoPath = 'Cargo.toml';
-          const cargo = fs.readFileSync(cargoPath, 'utf8');
-          const updatedCargo = cargo.replace(
-            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
-            `$1${version}$2`,
-          );
-          if (updatedCargo === cargo) {
-            throw new Error('failed to stamp workspace.package version in Cargo.toml');
-          }
-          fs.writeFileSync(cargoPath, updatedCargo);
-          JS
+          node scripts/stamp-release-version.mjs
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,33 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Stamp release version from tag
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          node - <<'JS'
+          const fs = require('fs');
+          const version = process.env.VERSION;
+          if (!version) throw new Error('VERSION is required');
+
+          const cargoPath = 'Cargo.toml';
+          const cargo = fs.readFileSync(cargoPath, 'utf8');
+          const updatedCargo = cargo.replace(
+            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
+            `$1${version}$2`,
+          );
+          if (updatedCargo === cargo) {
+            throw new Error('failed to stamp workspace.package version in Cargo.toml');
+          }
+          fs.writeFileSync(cargoPath, updatedCargo);
+
+          const tauriPath = 'crates/openfang-desktop/tauri.conf.json';
+          const tauri = JSON.parse(fs.readFileSync(tauriPath, 'utf8'));
+          tauri.version = version;
+          fs.writeFileSync(tauriPath, `${JSON.stringify(tauri, null, 2)}\n`);
+          JS
 
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
@@ -163,6 +190,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Stamp release version from tag
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          node - <<'JS'
+          const fs = require('fs');
+          const version = process.env.VERSION;
+          if (!version) throw new Error('VERSION is required');
+
+          const cargoPath = 'Cargo.toml';
+          const cargo = fs.readFileSync(cargoPath, 'utf8');
+          const updatedCargo = cargo.replace(
+            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
+            `$1${version}$2`,
+          );
+          if (updatedCargo === cargo) {
+            throw new Error('failed to stamp workspace.package version in Cargo.toml');
+          }
+          fs.writeFileSync(cargoPath, updatedCargo);
+          JS
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -213,6 +262,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Stamp release version from tag
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          node - <<'JS'
+          const fs = require('fs');
+          const version = process.env.VERSION;
+          if (!version) throw new Error('VERSION is required');
+
+          const cargoPath = 'Cargo.toml';
+          const cargo = fs.readFileSync(cargoPath, 'utf8');
+          const updatedCargo = cargo.replace(
+            /(\[workspace\.package\][\s\S]*?^version\s*=\s*")[^"]+("\s*$)/m,
+            `$1${version}$2`,
+          );
+          if (updatedCargo === cargo) {
+            throw new Error('failed to stamp workspace.package version in Cargo.toml');
+          }
+          fs.writeFileSync(cargoPath, updatedCargo);
+          JS
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:

--- a/scripts/stamp-release-version.mjs
+++ b/scripts/stamp-release-version.mjs
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+
+const version = process.env.VERSION;
+if (!version) throw new Error('VERSION is required');
+
+function replaceWorkspacePackageVersion(content) {
+  const lines = content.split('\n');
+  let inWorkspacePackage = false;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+
+    if (/^\s*\[workspace\.package\]\s*$/.test(line)) {
+      inWorkspacePackage = true;
+      continue;
+    }
+
+    if (inWorkspacePackage && /^\s*\[.*\]\s*$/.test(line)) {
+      break;
+    }
+
+    if (inWorkspacePackage && /^\s*version\s*=\s*"[^"]+"\s*$/.test(line)) {
+      lines[i] = `version = "${version}"`;
+      return lines.join('\n');
+    }
+  }
+
+  throw new Error('failed to stamp workspace.package version in Cargo.toml');
+}
+
+const cargoPath = 'Cargo.toml';
+const cargo = fs.readFileSync(cargoPath, 'utf8');
+fs.writeFileSync(cargoPath, replaceWorkspacePackageVersion(cargo));
+
+const tauriPath = 'crates/openfang-desktop/tauri.conf.json';
+if (fs.existsSync(tauriPath)) {
+  const tauri = JSON.parse(fs.readFileSync(tauriPath, 'utf8'));
+  tauri.version = version;
+  fs.writeFileSync(tauriPath, `${JSON.stringify(tauri, null, 2)}\n`);
+}


### PR DESCRIPTION
## Summary
- stamp the release tag version into `Cargo.toml` before desktop, CLI, and Docker release builds
- sync `crates/openfang-desktop/tauri.conf.json` to the same tag version for desktop releases

## Problem
The `v0.5.5` release artifacts can report stale versions because the repo metadata checked out by the release workflow still declares older values:
- workspace Cargo version stayed at `0.5.1`
- desktop Tauri config stayed at `0.1.0`

That lets packaged binaries drift from the actual release tag.

## Fix
For tag-triggered release jobs, derive the version from `github.ref_name`, strip the leading `v`, and stamp it into the workspace Cargo metadata before building.

For the desktop release job, also update the Tauri config version before packaging.

## Validation
- replayed the stamping logic locally against `v0.5.5`
- confirmed it rewrites both the Cargo workspace version and desktop Tauri version to `0.5.5`

Closes #884
