### PR TITLE
fix: select crypto provider (#903)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,7 @@ dependencies = [
  "openfang-wire",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ clap_complete = "4"
 
 # HTTP client (for LLM drivers)
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart", "rustls-tls", "gzip", "deflate", "brotli"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 # Async trait
 async-trait = "0.1"

--- a/crates/openfang-kernel/Cargo.toml
+++ b/crates/openfang-kernel/Cargo.toml
@@ -33,6 +33,7 @@ subtle = { workspace = true }
 rand = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 cron = "0.15"
 zeroize = { workspace = true }
 

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -511,7 +511,12 @@ impl OpenFangKernel {
 
     /// Boot the kernel with an explicit configuration.
     pub fn boot_with_config(mut config: KernelConfig) -> KernelResult<Self> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        if rustls::crypto::ring::default_provider()
+            .install_default()
+            .is_err()
+        {
+            debug!("rustls crypto provider already installed, skipping");
+        }
 
         use openfang_types::config::KernelMode;
 

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -511,6 +511,8 @@ impl OpenFangKernel {
 
     /// Boot the kernel with an explicit configuration.
     pub fn boot_with_config(mut config: KernelConfig) -> KernelResult<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         use openfang_types::config::KernelMode;
 
         // Env var overrides — useful for Docker where config.toml is baked in.


### PR DESCRIPTION
  ## Summary

Install the rustls CryptoProvider (`ring`) at kernel boot to fix a panic when channel adapters (e.g. Discord) open TLS connections. Rustls 0.23+ can't auto-select a provider when both `ring` and `aws-lc-rs` are in the dependency tree. Resolves https://github.com/RightNow-AI/openfang/issues/903

> [!NOTE]
> There's also an issue with the Discord Gateway protocol. At the moment the client does not send a heartbeat. This adds that in.

## Changes

- Added `rustls` (with `ring` feature) as a workspace dependency       - Added `rustls` to `openfang-kernel` crate                           - Call `install_default()` as the first line of `boot_with_config()`, before any `reqwest::Client` construction                                                                                                    

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)                                                                                                 

## Security

- [x] No new unsafe code                                               
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
