### PR TITLE
fix(runtime): handle non-exhaustive MCP HTTP config

### DIFF
--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -307,11 +307,8 @@ impl McpConnection {
             }
         }
 
-        let config = StreamableHttpClientTransportConfig {
-            uri: Arc::from(url),
-            custom_headers,
-            ..Default::default()
-        };
+        let mut config = StreamableHttpClientTransportConfig::with_uri(Arc::from(url));
+        config.custom_headers = custom_headers;
 
         let transport = StreamableHttpClientTransport::from_config(config);
 


### PR DESCRIPTION
fix: #926 
1. Fail to compile: cannot create non-exhaustive struct using struct expression