### PR TITLE
fix: apply cargo fmt --all formatting fixes

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -881,12 +881,12 @@ impl OpenFangKernel {
                 // Auto-detect embedding provider by checking API key env vars in
                 // priority order.  First match wins.
                 const API_KEY_PROVIDERS: &[(&str, &str)] = &[
-                    ("OPENAI_API_KEY",    "openai"),
-                    ("GROQ_API_KEY",      "groq"),
-                    ("MISTRAL_API_KEY",   "mistral"),
-                    ("TOGETHER_API_KEY",  "together"),
+                    ("OPENAI_API_KEY", "openai"),
+                    ("GROQ_API_KEY", "groq"),
+                    ("MISTRAL_API_KEY", "mistral"),
+                    ("TOGETHER_API_KEY", "together"),
                     ("FIREWORKS_API_KEY", "fireworks"),
-                    ("COHERE_API_KEY",    "cohere"),
+                    ("COHERE_API_KEY", "cohere"),
                 ];
 
                 let detected_from_key = API_KEY_PROVIDERS
@@ -1127,8 +1127,7 @@ impl OpenFangKernel {
                                                 != entry.manifest.tool_allowlist
                                             || disk_manifest.tool_blocklist
                                                 != entry.manifest.tool_blocklist
-                                            || disk_manifest.skills
-                                                != entry.manifest.skills
+                                            || disk_manifest.skills != entry.manifest.skills
                                             || disk_manifest.mcp_servers
                                                 != entry.manifest.mcp_servers;
                                         if changed {

--- a/crates/openfang-runtime/src/web_fetch.rs
+++ b/crates/openfang-runtime/src/web_fetch.rs
@@ -506,7 +506,11 @@ mod tests {
         assert!(check_ssrf("http://169.254.169.254/latest/meta-data/", &allow).is_err());
         // Also verify hostname-based metadata blocks
         let allow2 = vec!["metadata.google.internal".to_string()];
-        assert!(check_ssrf("http://metadata.google.internal/computeMetadata/v1/", &allow2).is_err());
+        assert!(check_ssrf(
+            "http://metadata.google.internal/computeMetadata/v1/",
+            &allow2
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/openfang-runtime/src/web_search.rs
+++ b/crates/openfang-runtime/src/web_search.rs
@@ -358,7 +358,10 @@ impl WebSearchEngine {
 
         let resp = self
             .client
-            .get(format!("{}/search", self.config.searxng.url.trim_end_matches('/')))
+            .get(format!(
+                "{}/search",
+                self.config.searxng.url.trim_end_matches('/')
+            ))
             .query(&[
                 ("q", query),
                 ("format", "json"),
@@ -451,7 +454,10 @@ impl WebSearchEngine {
 
         let resp = self
             .client
-            .get(format!("{}/config", self.config.searxng.url.trim_end_matches('/')))
+            .get(format!(
+                "{}/config",
+                self.config.searxng.url.trim_end_matches('/')
+            ))
             .header("User-Agent", "Mozilla/5.0 (compatible; OpenFangAgent/0.1)")
             .send()
             .await


### PR DESCRIPTION
Fixes formatting issues detected by `cargo fmt --all` in 3 files:

- `crates/openfang-kernel/src/kernel.rs` — removed extra whitespace alignment in tuple definitions
- `crates/openfang-runtime/src/web_fetch.rs` — fixed line wrapping
- `crates/openfang-runtime/src/web_search.rs` — fixed line wrapping (2 locations)

Purely cosmetic changes, no logic modifications.