### PR TITLE
fix: discord gateway protocol requires a heartbeat

### DIFF
--- a/crates/openfang-channels/src/discord.rs
+++ b/crates/openfang-channels/src/discord.rs
@@ -192,7 +192,8 @@ impl ChannelAdapter for DiscordAdapter {
                 info!("Discord gateway connected");
 
                 let (mut ws_tx, mut ws_rx) = ws_stream.split();
-                let mut _heartbeat_interval: Option<u64> = None;
+                let mut heartbeat_tick = tokio::time::interval(Duration::from_millis(45_000));
+                heartbeat_tick.reset();
 
                 // Inner message loop — returns true if we should reconnect
                 let should_reconnect = 'inner: loop {
@@ -204,6 +205,21 @@ impl ChannelAdapter for DiscordAdapter {
                                 let _ = ws_tx.close().await;
                                 return;
                             }
+                            continue;
+                        }
+                        _ = heartbeat_tick.tick() => {
+                            let seq = *sequence.read().await;
+                            let hb = serde_json::json!({ "op": opcode::HEARTBEAT, "d": seq });
+                            if let Err(e) = ws_tx
+                                .send(tokio_tungstenite::tungstenite::Message::Text(
+                                    serde_json::to_string(&hb).unwrap(),
+                                ))
+                                .await
+                            {
+                                error!("Discord: failed to send heartbeat: {e}");
+                                break 'inner true;
+                            }
+                            debug!("Discord heartbeat sent");
                             continue;
                         }
                     };
@@ -248,7 +264,9 @@ impl ChannelAdapter for DiscordAdapter {
                         opcode::HELLO => {
                             let interval =
                                 payload["d"]["heartbeat_interval"].as_u64().unwrap_or(45000);
-                            _heartbeat_interval = Some(interval);
+                            heartbeat_tick =
+                                tokio::time::interval(Duration::from_millis(interval));
+                            heartbeat_tick.reset();
                             debug!("Discord HELLO: heartbeat_interval={interval}ms");
 
                             // Try RESUME if we have a session, otherwise IDENTIFY


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link related issues with "Fixes #123". -->

Fixes #937

Implements a heartbeat for Discord

## Changes

<!-- Brief list of what changed. -->

Adds a `tokio::time::interval` tick to the main `select!` loop that sends a heartbeat with the current sequence number. The interval starts at a 45 second default and gets re-calibrated to the server-specified `heartbeat_interval` once the HELLO payload arrives.

## Testing

- [X] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [X] `cargo test --workspace` passes
- [X] Live integration tested (if applicable)

## Security

- [X] No new unsafe code
- [X] No secrets or API keys in diff
- [X] User input validated at boundaries
