### PR TITLE
fix: replace bool comparison with negation to satisfy clippy

### DIFF
--- a/crates/openfang-runtime/src/web_fetch.rs
+++ b/crates/openfang-runtime/src/web_fetch.rs
@@ -514,7 +514,7 @@ mod tests {
         let allow = vec!["*.example.com".to_string()];
         assert!(check_ssrf("http://api.example.com", &allow).is_ok());
         // Non-matching domain should still go through normal checks
-        assert!(is_host_allowed("other.net", &allow) == false);
+        assert!(!is_host_allowed("other.net", &allow));
     }
 
     #[test]


### PR DESCRIPTION
`assert!(expr == false)` triggers `clippy::bool_comparison`; use `assert!(!expr)` instead.

## Summary

Fixes #939 

## Changes

Changed `== false` to `!`

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes - not in isolation, needs fix for #926 first
- [ ] `cargo test --workspace` passes -- as above
- [n/a] Live integration tested (if applicable)

## Security

- [X] No new unsafe code
- [X] No secrets or API keys in diff
- [X] User input validated at boundaries
