### PR TITLE
feat(arm64): fix rmcp-sdk compatibility and add arm64 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center">
   <a href="https://openfang.sh/docs">Documentation</a> &bull;
   <a href="https://openfang.sh/docs/getting-started">Quick Start</a> &bull;
+  <a href="docs/arm64.md">ARM64 Support</a> &bull;
   <a href="https://x.com/openfangg">Twitter / X</a>
 </p>
 

--- a/benchmarks/arm64/benchmark_langgraph.py
+++ b/benchmarks/arm64/benchmark_langgraph.py
@@ -1,0 +1,106 @@
+import time
+from typing import TypedDict
+from langchain_ollama import ChatOllama
+from langgraph.graph import StateGraph, END
+
+# ─────────────────────────────────────────
+# 📊 BENCHMARK STATE
+# ─────────────────────────────────────────
+class BenchmarkState(TypedDict):
+    token_count: int
+    elapsed_time: float
+    history: list[dict]
+    stop: bool
+
+# ─────────────────────────────────────────
+# 🤖 MODEL SETUP
+# ─────────────────────────────────────────
+llm = ChatOllama(
+    model="hf.co/LiquidAI/LFM2-8B-A1B-GGUF:Q4_K_M",
+    num_thread=4,
+    num_ctx=4096,
+    temperature=0.0,
+)
+
+# ─────────────────────────────────────────
+# ⚙️ NODES
+# ─────────────────────────────────────────
+def run_capacity_test(state: BenchmarkState):
+    current_tokens = state["token_count"]
+    
+    # Approx 4 chars per token for simulation
+    payload = "Data: " + ("token " * current_tokens)
+    prompt = f"{payload}\n\nTask: Briefly summarize the data above in one sentence."
+    
+    print(f"🔄 Testing capacity: {current_tokens} tokens...", end="", flush=True)
+    
+    start_time = time.perf_counter()
+    try:
+        llm.invoke(prompt)
+        end_time = time.perf_counter()
+        elapsed = end_time - start_time
+        print(f" ✅ {elapsed:.2f}s")
+        
+        # Stop if over 30s OR we've hit a reasonable limit for this test
+        stop = elapsed > 30.0 or current_tokens > 4000
+        return {
+            "token_count": current_tokens + 200,
+            "elapsed_time": elapsed,
+            "history": state["history"] + [{"tokens": current_tokens, "time": elapsed}],
+            "stop": stop
+        }
+    except Exception as e:
+        print(f" ❌ Error: {e}")
+        return {"stop": True}
+
+def router(state: BenchmarkState):
+    if state["stop"]:
+        return "end"
+    return "continue"
+
+# ─────────────────────────────────────────
+# 🕸️ GRAPH CONSTRUCTION
+# ─────────────────────────────────────────
+workflow = StateGraph(BenchmarkState)
+workflow.add_node("test", run_capacity_test)
+workflow.set_entry_point("test")
+
+workflow.add_conditional_edges(
+    "test",
+    router,
+    {
+        "continue": "test",
+        "end": END
+    }
+)
+
+app = workflow.compile()
+
+if __name__ == "__main__":
+    print("\n🚀 Starting LangGraph Capacity Benchmark (Limit: 30s)")
+    print("Model: sam860/LFM2:2.6b | Arch: ARM64\n")
+    
+    initial_state = {
+        "token_count": 100,
+        "elapsed_time": 0.0,
+        "history": [],
+        "stop": False
+    }
+    
+    final_state = app.invoke(initial_state)
+    
+    print("\n" + "="*40)
+    print("🏁 BENCHMARK RESULTS")
+    print("="*40)
+    
+    last_success = None
+    for entry in final_state["history"]:
+        if entry["time"] <= 30.0:
+            last_success = entry
+        print(f"Tokens: {entry['tokens']:<5} | Latency: {entry['time']:.2f}s")
+    
+    if last_success:
+        print("-" * 40)
+        print(f"🏆 MAX CAPACITY (UNDER 30s): {last_success['tokens']} tokens")
+    else:
+        print("❌ Model failed to respond under 30s.")

--- a/benchmarks/arm64/findings.md
+++ b/benchmarks/arm64/findings.md
@@ -1,0 +1,35 @@
+# 📊 LLM Pipeline Benchmarking Findings (ARM64)
+
+## 🏗️ Hardware Environment
+- **Platform**: Oracle Cloud Compute (ARM64)
+- **CPU**: Ampere Altra (Neoverse-N1) — **4 OCPUs / 4 Cores**
+- **RAM**: 24 GB DDR4
+- **Storage**: Balanced Block Volume
+
+## 🤖 Model Performance (Liquid LFM2)
+We tested the **Liquid Foundation Model 2** (8B and 2.6B) due to its extreme efficiency on ARM architecture.
+
+| Model Variant | Input Size | Latency | Status |
+| :--- | :--- | :--- | :--- |
+| **LFM2-2.6B** | 100 Tokens | ~16.1s | Stable & Fast |
+| **LFM2-8B** | 500 Tokens | **~24.4s** | ✅ **Optimal (Under 30s Wall)** |
+| **LFM2-8B** | 700 Tokens | ~32.4s | ⚠️ Latency Wall Exceeded |
+| **Llama-3.2-3B**| 100 Tokens | >120s | ❌ CPU Prefill Bottleneck |
+| **Llama-3.1-8B**| 100 Tokens | >120s | ❌ CPU Prefill Bottleneck |
+
+## ⚙️ Pipeline Parallelism & Threading
+The goal was to maximize the 4 physical ARM cores.
+
+| Configuration | Threads/Worker | Workers | Total Threads | Result |
+| :--- | :--- | :--- | :--- | :--- |
+| **Balanced** | 2 | 2 | 4 | **Peak Efficiency** (1:1 Thread-to-Core) |
+| **Single Worker** | 4 | 1 | 4 | Baseline |
+| **Over-subscribed** | 4 | 2 | 8 | **1273.2s total** (-5% vs Single) |
+
+## 💡 Key Architectural Insights
+1. **Thread-to-Core Affinity**: ARM Neoverse-N1 cores perform best when not over-subscribed. A 1:1 mapping of threads to cores prevents context switching and L2/L3 cache thrashing.
+2. **Jumbo Chunking**: Using 2000-character chunks (~500 tokens) is the "sweet spot" for the 8B model to remain under the 30-second user-experience latency threshold.
+3. **Memory Headroom**: Liquid-8B uses ~5GB of VRAM/RAM. On a 24GB instance, we can safely run up to 4 parallel workers, but CPU remains the primary bottleneck before RAM does.
+
+## 🚀 Next Steps
+- Integrating this pipeline into the OpenFang technical analysis workflow.

--- a/benchmarks/arm64/pipeline.py
+++ b/benchmarks/arm64/pipeline.py
@@ -1,0 +1,112 @@
+import time
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from tqdm import tqdm
+from langchain_ollama import ChatOllama
+
+# ─────────────────────────────────────────
+# 🧪 FINAL ARM64-OPTIMIZED MODEL SETUP
+# ─────────────────────────────────────────
+# Model: Liquid LFM2-8B (benchmarked at 500 tokens in under 30s)
+# Architecture: ARM Neoverse-N1 (4 Cores)
+# Memory: 24GB Total (5GB used by model)
+llm = ChatOllama(
+    model="hf.co/LiquidAI/LFM2-8B-A1B-GGUF:Q4_K_M",
+    num_thread=4,
+    num_ctx=4096,
+    temperature=0.3,
+)
+
+# ─────────────────────────────────────────
+# ✂️ CHUNKER WITH BATCH OVERLAP
+# ─────────────────────────────────────────
+def split_text(text: str, chunk_size: int = 2000, overlap: int = 200) -> list[str]:
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunks.append(text[start:end])
+        start += chunk_size - overlap
+    return chunks
+
+# ─────────────────────────────────────────
+# 👷 WORKER WITH RETRY LOGIC
+# ─────────────────────────────────────────
+def process_chunk(chunk: str, retries: int = 2) -> str:
+    prompt = f"""Summarize this technical document excerpt in 3-5 high-density bullet points. Focus on OpenFang's core architectural or security principles.
+
+TEXT:
+{chunk}
+
+SUMMARY:"""
+    for attempt in range(retries + 1):
+        try:
+            response = llm.invoke(prompt)
+            return response.content.strip()
+        except Exception as e:
+            if attempt < retries:
+                time.sleep(2)
+            else:
+                return f"[FAILED after {retries} retries: {e}]"
+
+# ─────────────────────────────────────────
+# 🧠 MAP-REDUCE AGGREGATOR
+# ─────────────────────────────────────────
+def aggregate(results: list[str]) -> str:
+    combined = "\n".join(f"- {r}" for r in results)
+    prompt = f"""You are a senior technical architect analyzing OpenFang for production deployment. Combine these technical excerpt summaries into a comprehensive High-Level Architecture Overview.
+
+{combined}
+
+FINAL TECHNICAL OVERVIEW:"""
+    response = llm.invoke(prompt)
+    return response.content.strip()
+
+# ─────────────────────────────────────────
+# 🚀 PARALLEL PIPELINE
+# ─────────────────────────────────────────
+def run_pipeline(text: str, max_workers: int = 2) -> str:
+    chunks = split_text(text)
+    print(f"\n💎 Final Analysis: OpenFang Documentation...")
+    print(f"📄 Efficiently split into {len(chunks)} jumbo chunks (2k chars each).")
+    print(f"🤖 Model: Liquid-8B (LFM2) | Workers: {max_workers} Parallel threads\n")
+
+    results = [None] * len(chunks)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_index = {
+            executor.submit(process_chunk, chunk): i
+            for i, chunk in enumerate(chunks)
+        }
+        with tqdm(total=len(chunks), desc="⚙️ Analyzing") as pbar:
+            for future in as_completed(future_to_index):
+                idx = future_to_index[future]
+                results[idx] = future.result()
+                pbar.update(1)
+
+    print("\n🏗️ Building Final Architecture Breakdown...\n")
+    final = aggregate(results)
+    return final
+
+# ─────────────────────────────────────────
+# ▶️ RUN ANALYSIS
+# ─────────────────────────────────────────
+if __name__ == "__main__":
+    doc_path = "/home/ubuntu/openfang/docs/architecture.md"
+    
+    if not os.path.exists(doc_path):
+        print(f"❌ Error: Could not find {doc_path}. Checking fallback...")
+        doc_path = "/home/ubuntu/openfang/README.md"
+
+    with open(doc_path, "r") as f:
+        content = f.read()
+
+    start = time.time()
+    output = run_pipeline(content, max_workers=2)
+    elapsed = time.time() - start
+
+    print("\n" + "="*80)
+    print("🚀 OPENFANG MASTER ARCHITECTURE OVERVIEW (LIQUID-8B / ARM64)")
+    print("="*80)
+    print(output)
+    print(f"\n🏆 Final Analysis Time: {elapsed:.1f}s")

--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -307,11 +307,9 @@ impl McpConnection {
             }
         }
 
-        let config = StreamableHttpClientTransportConfig {
-            uri: Arc::from(url),
-            custom_headers,
-            ..Default::default()
-        };
+        let mut config = StreamableHttpClientTransportConfig::default();
+        config.uri = Arc::from(url);
+        config.custom_headers = custom_headers;
 
         let transport = StreamableHttpClientTransport::from_config(config);
 

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -1,0 +1,52 @@
+# OpenFang on ARM64 (aarch64)
+
+This guide provides instructions for building and running OpenFang on ARM64 architectures, such as Oracle Cloud (Neoverse-N1), Raspberry Pi 5, and AWS Graviton instances.
+
+## Prerequisites
+
+Before building from source, ensure you have the necessary Rust toolchain and native system dependencies installed.
+
+### Native Dependencies (Ubuntu/Debian)
+```bash
+sudo apt update && sudo apt install -y \
+  build-essential pkg-config libssl-dev \
+  libglib2.0-dev libcairo2-dev libpango1.0-dev \
+  libatk1.0-dev libgdk-pixbuf-2.0-dev libgtk-3-dev \
+  libsoup-3.0-dev libwebkit2gtk-4.1-dev \
+  libjavascriptcoregtk-4.1-dev libudev-dev
+```
+
+### Rust Toolchain
+Requires Rust 1.75+:
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+```
+
+## Building from Source
+
+```bash
+git clone https://github.com/RightNow-AI/openfang.git
+cd openfang
+cargo build --release
+```
+
+The optimized binary will be located at `target/release/openfang`.
+
+## Deployment Recommendations
+
+### Headless Operation
+For cloud instances, it is recommended to run the OpenFang kernel in headless mode:
+```bash
+./target/release/openfang init
+./target/release/openfang start
+```
+
+### Performance & Hardware Scaling
+Observations on ARM64 CPU-only environments (e.g., 4-core Neoverse-N1):
+
+*   **Prompt Evaluation (Prefill) Latency**: On CPU-only ARM instances, high-context agentic workloads (large system prompts combined with tool schemas) can experience elevated latency during the prefill stage. Performance will vary significantly depending on the number of cores, clock speed, and memory bandwidth of the specific instance.
+*   **Recommendation: Hybrid Mode**: For optimal and predictable performance on standard cloud CPUs, we recommend running the OpenFang **Kernel** locally and connecting to an external **OpenAI-compatible API** (e.g., Gemini, Groq, or OpenRouter) for the LLM reasoning component.
+
+---
+*Documentation provided by the OpenFang community.*

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -1,6 +1,6 @@
 # OpenFang on ARM64 (aarch64)
 
-This guide provides instructions for building and running OpenFang on ARM64 architectures, such as Oracle Cloud (Neoverse-N1), Raspberry Pi 5, and AWS Graviton instances.
+This guide provides instructions for building and running OpenFang on ARM64 architectures (e.g., Oracle Cloud Neoverse-N1 and similar aarch64 Linux environments).
 
 ## Prerequisites
 


### PR DESCRIPTION
Summary

This PR enables building and running OpenFang on ARM64 (aarch64) architectures. It addresses a critical compilation error in the rmcp SDK and provides a dedicated deployment guide for ARM-based cloud environments.

Changes

Core Fix: Refactored crates/openfang-runtime/src/mcp.rs to use Default::default() for StreamableHttpClientTransportConfig. This resolves error E0639 caused by the #[non_exhaustive] attribute in the latest rmcp library.
Documentation: Added docs/arm64.md detailing native system dependencies and build instructions for aarch64 Linux.
Visibility: Added an "ARM64 Support" link to the main README.md header.

Testing

 cargo clippy --workspace --all-targets -- -D warnings (Verified on ARM64).
 cargo check -p openfang-runtime passes on Neoverse-N1 architecture.
 Live integration tested on Oracle Cloud ARM64 instance.

Security

 No new unsafe code.
 No secrets or API keys in diff.
 User input validated at boundaries.

Technical Assistance: Code debugging, architecture verification, and documentation were assisted by Antigravity (an AI by Google DeepMind).