### PR TITLE
fix: replace bool comparison with negation to fix clippy lint error

### DIFF
--- a/crates/openfang-runtime/src/web_fetch.rs
+++ b/crates/openfang-runtime/src/web_fetch.rs
@@ -514,7 +514,7 @@ mod tests {
         let allow = vec!["*.example.com".to_string()];
         assert!(check_ssrf("http://api.example.com", &allow).is_ok());
         // Non-matching domain should still go through normal checks
-        assert!(is_host_allowed("other.net", &allow) == false);
+        assert!(!is_host_allowed("other.net", &allow));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the clippy lint error reported in #939.

`cargo clippy --workspace --all-targets -- -D warnings` fails with:

```
error: equality checks against false can be replaced by a negation
   --> crates/openfang-runtime/src/web_fetch.rs:517:17
    |
517 |         assert!(is_host_allowed("other.net", &allow) == false);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `!is_host_allowed("other.net", &allow)`
    |
    = note: `-D clippy::bool-comparison` implied by `-D warnings`
```

## Change

Replace `assert!(expr == false)` with the idiomatic `assert!(!expr)` in the `test_ssrf_allowlist_wildcard_domain` test.

Closes #939