### PR TITLE
fix: add perl and make to Dockerfile builder stage for openssl-sys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM rust:1-slim-bookworm AS builder
 WORKDIR /build
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask


### PR DESCRIPTION
## Summary

Fixes #950.

The `openssl-sys` crate vendors OpenSSL and compiles it from source when a suitable system OpenSSL is not found. The vendored build requires `perl` (for OpenSSL's `Configure` script) and `make`. Neither is present in the `rust:1-slim-bookworm` base image used for the builder stage, causing builds to fail with:

```
error: failed to run custom build command for `openssl-sys v0.9.x`
...
This perl implementation doesn't work, need perl 5.10 or above.
thread 'main' panicked at 'Failed to find perl'
```

## Change

Add `perl` and `make` to the builder stage's `apt-get install` line:

```dockerfile
# Before
RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*

# After
RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make && rm -rf /var/lib/apt/lists/*
```

This unblocks anyone trying to build from source on a fresh host, which is currently the only working install path since the GHCR image is not publicly accessible (see #894).