### PR TITLE
Fix WebSocket auth rejecting API keys with URL-special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/openfang-api/Cargo.toml
+++ b/crates/openfang-api/Cargo.toml
@@ -32,6 +32,7 @@ futures = { workspace = true }
 governor = { workspace = true }
 tokio-stream = { workspace = true }
 subtle = { workspace = true }
+url = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 hmac = { workspace = true }

--- a/crates/openfang-api/src/ws.rs
+++ b/crates/openfang-api/src/ws.rs
@@ -168,8 +168,16 @@ pub async fn agent_ws(
 
         let query_auth = uri
             .query()
-            .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
-            .map(|token| ct_eq(token, api_key))
+            .and_then(|q| {
+                url::form_urlencoded::parse(q.as_bytes()).find_map(|(k, v)| {
+                    if k == "token" {
+                        Some(v.into_owned())
+                    } else {
+                        None
+                    }
+                })
+            })
+            .map(|token| ct_eq(&token, api_key))
             .unwrap_or(false);
 
         if !header_auth && !query_auth {


### PR DESCRIPTION
## What

Fixes #962.

The WebSocket upgrade handler authenticates browser clients via a `?token=` query parameter (browsers cannot set custom headers on WebSocket connections). The handler was extracting the token with `split('&')` / `strip_prefix("token=")` and comparing it directly against the configured API key using constant-time comparison.

**The problem**: browsers call `encodeURIComponent()` on the token before appending it to the WebSocket URL (`api.js:226`). Characters common in base64-derived keys — `+`, `/`, `=` — are percent-encoded to `%2B`, `%2F`, `%3D`. The server received the encoded string and compared it character-for-character against the raw key. They never match, so every WebSocket upgrade returned 401.

The result: the fallback in `chat.js` silently switched to HTTP polling mode. Users with base64-derived API keys (e.g. generated with `openssl rand -base64 32`) could never get streaming — without any clear error pointing to the root cause.

## How

Switch to `url::form_urlencoded::parse()` to decode the query string before comparison. This is an existing workspace dependency (`url = "2"` in root `Cargo.toml`) — no new transitive dependencies are added.

**Before** (`ws.rs`):
```rust
let query_auth = uri
    .query()
    .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
    .map(|token| ct_eq(token, api_key))
    .unwrap_or(false);
```

**After**:
```rust
let query_auth = uri
    .query()
    .and_then(|q| {
        url::form_urlencoded::parse(q.as_bytes()).find_map(|(k, v)| {
            if k == "token" {
                Some(v.into_owned())
            } else {
                None
            }
        })
    })
    .map(|token| ct_eq(&token, api_key))
    .unwrap_or(false);
```

## Verification

- `cargo clippy -p openfang-api --all-targets -- -D warnings`: zero warnings
- `cargo test -p openfang-api`: 7/7 tests pass
- Full workspace build is currently blocked by the pre-existing mcp.rs build failure (tracked in #926, fix open in #927)

## Workaround (until merged)

Generate an API key using only URL-safe characters:
```bash
openssl rand -hex 32
```