### PR TITLE
Set GHCR package visibility to public on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,5 +235,17 @@ jobs:
           tags: |
             ghcr.io/rightnow-ai/openfang:latest
             ghcr.io/rightnow-ai/openfang:${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/RightNow-AI/openfang
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.description=OpenFang Agent OS — single-binary Rust agent framework
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Set GHCR package visibility to public
+        run: |
+          curl -fsSL -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/orgs/RightNow-AI/packages/container/openfang \
+            -d '{"visibility":"public"}'


### PR DESCRIPTION
## What

Fixes #961.

`docker pull ghcr.io/rightnow-ai/openfang:<tag>` returned 401 for unauthenticated users because GHCR defaults new packages to **private**, even when the repository is public. The release workflow was pushing the image but never setting visibility.

## How

Two additions to the `docker` job in `release.yml`:

**1. OCI labels on the build** — links the package to the repository so GHCR associates them correctly. Standard practice for container images, and a prerequisite for the visibility API call to work reliably.

**2. Post-push visibility step** — calls the GitHub Packages API after each push to explicitly set the package public. The workflow already declares `packages: write`, which is the required scope. Running on every release tag means visibility cannot silently regress.

## CI note

This PR touches only `release.yml` — no Rust code changes. The cargo check/test/clippy/fmt jobs will run but any failures are due to the pre-existing `mcp.rs` build blocker (tracked in #926, fix open in #927), not this PR.

## Note on existing packages

This fix takes effect on the next release. The existing v0.5.6/v0.5.7 packages need a one-time manual change: **GitHub → Packages → openfang → Package settings → Change visibility → Public**. After that, this workflow step keeps them public automatically.

## Verification

After the next release tag is pushed:
```bash
docker pull ghcr.io/rightnow-ai/openfang:latest  # succeeds without auth
```