### PR TITLE
fix(nix): add perl to buildInputs for openssl-sys vendored build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         rust-project.defaults.perCrate.crane.args.buildInputs = with pkgs; [
           clang
           openssl
+          perl
           pkg-config
         ];
         rust-project.crates.openfang-desktop.crane.args.buildInputs = with pkgs; [


### PR DESCRIPTION
## Summary

Since v0.5.4, native-tls uses features = ["vendored"], which compiles OpenSSL from source via openssl-sys. This requires perl for the OpenSSL Configure script, but perl was missing from the flake's buildInputs.

Mirrors the Dockerfile fix in #952. Fixes #894.

## Changes

- Added perl to rust-project.defaults.perCrate.crane.args.buildInputs in flake.nix

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
