### PR TITLE
Fix service worker cache eviction on update

### DIFF
--- a/crates/openfang-api/src/middleware.rs
+++ b/crates/openfang-api/src/middleware.rs
@@ -250,10 +250,12 @@ pub async fn security_headers(request: Request<Body>, next: Next) -> Response<Bo
         "referrer-policy",
         "strict-origin-when-cross-origin".parse().unwrap(),
     );
-    headers.insert(
-        "cache-control",
-        "no-store, no-cache, must-revalidate".parse().unwrap(),
-    );
+    if !headers.contains_key("cache-control") {
+        headers.insert(
+            "cache-control",
+            "no-store, no-cache, must-revalidate".parse().unwrap(),
+        );
+    }
     headers.insert(
         "strict-transport-security",
         "max-age=63072000; includeSubDomains".parse().unwrap(),

--- a/crates/openfang-api/static/sw.js
+++ b/crates/openfang-api/static/sw.js
@@ -1,3 +1,11 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((names) => Promise.all(names.map((n) => caches.delete(n))))
+      .then(() => self.clients.claim())
+  );
+});
 self.addEventListener('fetch', (event) => {
   event.respondWith(fetch(event.request));
 });


### PR DESCRIPTION
## Problem

When a new version of OpenFang is deployed, browsers continue serving the old UI because:

1. **`sw.js` had no lifecycle handlers** — without `skipWaiting()` and `clients.claim()`, an updated service worker waits indefinitely before taking control. Old cached resources are never evicted.

2. **Middleware overwrote `Cache-Control` unconditionally** — `sw.js` is served with `Cache-Control: no-cache` (set by the handler), but the `security_headers` middleware blindly replaced it with `no-store, no-cache, must-revalidate` on every response. While `no-store` on sw.js isn't harmful by itself, the middleware's unconditional override means handler-set values are silently discarded — a footgun for any future response that intentionally sets a different policy.

## Fix

**`static/sw.js`** — add `install`/`activate` lifecycle handlers:
- `install`: call `skipWaiting()` so the new SW activates immediately instead of waiting for all tabs to close
- `activate`: delete all caches and call `clients.claim()` so existing tabs switch to the new SW right away

**`src/middleware.rs`** — make `Cache-Control` insertion conditional:
- Apply the strict default (`no-store, no-cache, must-revalidate`) only when the handler hasn't already set a `Cache-Control` header
- Matches the existing pattern used for `Content-Security-Policy` (line 241)

## Test plan

- [ ] Deploy new build; open app in browser; it loads without needing a cache clear
- [ ] `curl -I /sw.js` → `cache-control: no-cache` (handler value preserved, not overridden)
- [ ] `curl -I /api/agents` → `cache-control: no-store, no-cache, must-revalidate` (default still applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)