### PR TITLE
Add runtime hand loading from $OPENFANG_HOME/hands/ directory

### DIFF
--- a/crates/openfang-hands/src/registry.rs
+++ b/crates/openfang-hands/src/registry.rs
@@ -105,6 +105,69 @@ impl HandRegistry {
             .collect()
     }
 
+    /// Load hand definitions from a directory at runtime.
+    ///
+    /// Supports two layouts:
+    /// - `hands/*.toml`      — flat TOML file per hand (no SKILL.md)
+    /// - `hands/*/HAND.toml` — subdirectory with HAND.toml and optional SKILL.md
+    ///
+    /// Returns the count of hand definitions loaded.
+    pub fn load_from_directory(&self, dir: &std::path::Path) -> usize {
+        if !dir.exists() {
+            return 0;
+        }
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(path = %dir.display(), error = %e, "Failed to read hands directory");
+                return 0;
+            }
+        };
+        let mut count = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let (toml_content, skill_content) = if path.is_file() {
+                if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+                    continue;
+                }
+                let toml = match std::fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(path = %path.display(), error = %e, "Failed to read hand TOML");
+                        continue;
+                    }
+                };
+                (toml, String::new())
+            } else if path.is_dir() {
+                let toml_path = path.join("HAND.toml");
+                if !toml_path.exists() {
+                    continue;
+                }
+                let toml = match std::fs::read_to_string(&toml_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(path = %toml_path.display(), error = %e, "Failed to read hand TOML");
+                        continue;
+                    }
+                };
+                let skill = std::fs::read_to_string(path.join("SKILL.md")).unwrap_or_default();
+                (toml, skill)
+            } else {
+                continue;
+            };
+            match self.upsert_from_content(&toml_content, &skill_content) {
+                Ok(def) => {
+                    info!(hand = %def.id, name = %def.name, "Loaded hand from directory");
+                    count += 1;
+                }
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "Failed to parse hand from directory");
+                }
+            }
+        }
+        count
+    }
+
     /// Load all bundled hand definitions. Returns count of definitions loaded.
     pub fn load_bundled(&self) -> usize {
         let bundled = bundled::bundled_hands();

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -790,6 +790,13 @@ impl OpenFangKernel {
             info!("Loaded {hand_count} bundled hand(s)");
         }
 
+        // Load user-defined hands from $OPENFANG_HOME/hands/
+        let hands_dir = config.home_dir.join("hands");
+        let custom_hand_count = hand_registry.load_from_directory(&hands_dir);
+        if custom_hand_count > 0 {
+            info!("Loaded {custom_hand_count} custom hand(s) from hands directory");
+        }
+
         // Initialize extension/integration registry
         let mut extension_registry =
             openfang_extensions::registry::IntegrationRegistry::new(&config.home_dir);


### PR DESCRIPTION
## Problem

All hand definitions must currently be compiled into the binary as bundled hands. There is no way to ship deployment-specific hands (e.g. household integrations, private API hands) without forking the source and recompiling.

## Solution

Scan `$OPENFANG_HOME/hands/` at startup and load any TOML files found there as hand definitions, alongside bundled hands.

### Two layouts supported

```
$OPENFANG_HOME/hands/
  my-hand.toml              # flat file — hand TOML, no skill content
  another-hand/
    HAND.toml               # subdirectory — hand TOML + optional SKILL.md
    SKILL.md
```

### `auto_activate` field

A new optional field `auto_activate = true` on a hand definition causes the kernel to activate it automatically on first boot (when it isn't already in `hand_state.json`). On subsequent restarts the hand is restored from `hand_state.json` like any other hand — no scripts or init containers needed.

```toml
id = "my-integration"
name = "My Integration"
auto_activate = true   # activate on first boot, persist via hand_state.json
...
```

## Changes

- **`HandDefinition`**: add `auto_activate: bool` with `#[serde(default = false)]` — fully backwards compatible, existing hands unaffected
- **`HandRegistry::load_from_directory()`**: scans a directory, upserts hand definitions from flat `.toml` files or `*/HAND.toml` subdirectories
- **Kernel boot**: calls `load_from_directory($OPENFANG_HOME/hands/)` after `load_bundled()`
- **`start_background_agents()`**: auto-activates hands with `auto_activate = true` that aren't already in persisted state

## Test plan

- [ ] Create a `hands/test-hand.toml` in `$OPENFANG_HOME/hands/`, restart — hand appears in `/api/hands`
- [ ] Add `auto_activate = true` — hand activates automatically on restart without API call
- [ ] After first activation, `hand_state.json` persists it — no double-activation on next restart
- [ ] Bundled hands unaffected (`auto_activate` defaults to `false`)
- [ ] Invalid TOML in hands dir logs a warning and continues loading others

🤖 Generated with [Claude Code](https://claude.com/claude-code)