### PR TITLE
fix: use builder API for StreamableHttpClientTransportConfig

### DIFF
--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -14,7 +14,6 @@ use rmcp::service::RunningService;
 use rmcp::{RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::{debug, info};
 
 // ---------------------------------------------------------------------------
@@ -307,11 +306,8 @@ impl McpConnection {
             }
         }
 
-        let config = StreamableHttpClientTransportConfig {
-            uri: Arc::from(url),
-            custom_headers,
-            ..Default::default()
-        };
+        let config = StreamableHttpClientTransportConfig::with_uri(url)
+            .custom_headers(custom_headers);
 
         let transport = StreamableHttpClientTransport::from_config(config);
 

--- a/crates/openfang-runtime/src/web_fetch.rs
+++ b/crates/openfang-runtime/src/web_fetch.rs
@@ -514,7 +514,7 @@ mod tests {
         let allow = vec!["*.example.com".to_string()];
         assert!(check_ssrf("http://api.example.com", &allow).is_ok());
         // Non-matching domain should still go through normal checks
-        assert!(is_host_allowed("other.net", &allow) == false);
+        assert!(!is_host_allowed("other.net", &allow));
     }
 
     #[test]


### PR DESCRIPTION
`StreamableHttpClientTransportConfig` is `#[non_exhaustive]`, so it cannot be constructed via a struct literal. Replace with the builder pattern using `with_uri()` and `custom_headers()`, and drop the now- unused `std::sync::Arc` import.

Fixes `cargo install --path crates/openfang-cli` compile error E0639.

## Summary

<!-- What does this PR do? Link related issues with "Fixes #123". -->

## Changes

<!-- Brief list of what changed. -->

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
