### PR TITLE
fix: use builder API for StreamableHttpClientTransportConfig (rmcp 1.3.0 compat)

### DIFF
--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -14,7 +14,6 @@ use rmcp::service::RunningService;
 use rmcp::{RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::{debug, info};
 
 // ---------------------------------------------------------------------------
@@ -307,11 +306,8 @@ impl McpConnection {
             }
         }
 
-        let config = StreamableHttpClientTransportConfig {
-            uri: Arc::from(url),
-            custom_headers,
-            ..Default::default()
-        };
+        let config = StreamableHttpClientTransportConfig::with_uri(url)
+            .custom_headers(custom_headers);
 
         let transport = StreamableHttpClientTransport::from_config(config);
 


### PR DESCRIPTION
## 问题

`rmcp` 1.3.0 将 `StreamableHttpClientTransportConfig` 标记为 `#[non_exhaustive]`，导致在定义 crate 外部无法使用结构体字面量构造（包括 `..Default::default()` 填充语法），编译报错：

```
error[E0639]: cannot create non-exhaustive struct using struct expression
```

## 修复

将结构体字面量替换为官方提供的 builder API：

```rust
// 修复前（编译失败）
StreamableHttpClientTransportConfig {
    uri: url.to_string(),
    headers: HeaderMap::new(),
    ..Default::default()
}

// 修复后
StreamableHttpClientTransportConfig::with_uri(url)
    .custom_headers(headers)
```

同时移除了不再使用的 `use std::sync::Arc` 导入。

## 测试

- `cargo build --workspace --lib` ✅ 编译通过
- `cargo test --workspace` ✅ 所有测试通过（1744+）
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ 零 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)