### PR TITLE
fix: install perl and make in Docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM rust:1-slim-bookworm AS builder
 WORKDIR /build
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y pkg-config libssl-dev perl make && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask


### PR DESCRIPTION
## Summary
- install `perl` and `make` in the Docker builder image
- keep the change limited to the builder stage so `openssl-sys` can compile successfully on `rust:1-slim-bookworm`

## Testing
- attempted `docker build -t openfang-issue-983-test .` locally
- local Docker build stalled while resolving the Dockerfile frontend image on this host, so I could not complete an end-to-end container build here
