### PR TITLE
fix(chat): prevent duplicate message keys on first chat welcome message

### DIFF
--- a/crates/openfang-api/static/js/pages/chat.js
+++ b/crates/openfang-api/static/js/pages/chat.js
@@ -488,9 +488,8 @@ function chatPage() {
       this.connectWs(agent.id);
       // Show welcome tips on first use
       if (!localStorage.getItem('of-chat-tips-seen')) {
-        var localMsgId = 0;
         this.messages.push({
-          id: ++localMsgId,
+          id: ++msgId,
           role: 'system',
           text: '**Welcome to OpenFang Chat!**\n\n' +
             '- Type `/` to see available commands\n' +


### PR DESCRIPTION
## Summary

In the first chat session, the welcome message used a local id counter, while new user messages used the global message counter.

This could generate duplicate ids and cause key collisions in message list rendering, so the chat UI did not update correctly: both the new user message and assistant reply could be missing from the visible list until a page refresh.

<img width="1248" height="335" alt="screenshot-20260407-151254" src="https://github.com/user-attachments/assets/97550764-ae3e-4620-8580-5659a74f3335" />

## Changes

Updated welcome message id generation to use the global message counter, preventing duplicate message ids.

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
