### PR TITLE
fix: avoid Alpine SVG template rendering errors in cost charts

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -4045,20 +4045,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
                 <div x-show="costByProvider().length > 0" class="donut-chart-wrap">
                   <div class="donut-chart">
                     <svg viewBox="0 0 160 160" width="160" height="160">
-                      <template x-for="(seg, idx) in donutSegments()" :key="seg.provider">
-                        <circle
-                          cx="80" cy="80" r="60"
-                          fill="none"
-                          :stroke="seg.color"
-                          stroke-width="24"
-                          :stroke-dasharray="seg.dasharray"
-                          :stroke-dashoffset="seg.dashoffset"
-                          transform="rotate(-90 80 80)"
-                          class="donut-segment"
-                        >
-                          <title x-text="seg.provider + ': ' + seg.percent + '% (' + formatCost(seg.cost) + ')'"></title>
-                        </circle>
-                      </template>
+                      <g x-html="donutSegmentsSvg()"></g>
                       <!-- Center text -->
                       <text x="80" y="76" text-anchor="middle" fill="var(--text)" style="font-size:14px;font-weight:700;font-family:var(--font-mono)" x-text="formatCost(summary.total_cost_usd)"></text>
                       <text x="80" y="92" text-anchor="middle" fill="var(--text-muted)" style="font-size:9px;font-family:var(--font-mono)">TOTAL</text>
@@ -4085,41 +4072,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
                   <svg :viewBox="'0 0 ' + (barChartData().length * 50 + 20) + ' 180'" :width="barChartData().length * 50 + 20" height="180">
                     <!-- Baseline -->
                     <line x1="10" :x2="barChartData().length * 50 + 10" y1="150" y2="150" stroke="var(--border)" stroke-width="1"/>
-                    <template x-for="(bar, idx) in barChartData()" :key="bar.date">
-                      <g>
-                        <!-- Bar rect -->
-                        <rect
-                          :x="idx * 50 + 18"
-                          :y="150 - bar.barHeight"
-                          width="24"
-                          :height="bar.barHeight"
-                          rx="3"
-                          fill="var(--accent)"
-                          class="cost-bar"
-                          style="opacity:0.85"
-                        >
-                          <title x-text="bar.date + ': ' + formatCost(bar.cost) + ' (' + bar.calls + ' calls)'"></title>
-                        </rect>
-                        <!-- Day label -->
-                        <text
-                          :x="idx * 50 + 30"
-                          y="166"
-                          text-anchor="middle"
-                          fill="var(--text-muted)"
-                          style="font-size:9px;font-family:var(--font-mono)"
-                          x-text="bar.dayName"
-                        ></text>
-                        <!-- Cost label on top -->
-                        <text
-                          :x="idx * 50 + 30"
-                          :y="150 - bar.barHeight - 4"
-                          text-anchor="middle"
-                          fill="var(--text-dim)"
-                          style="font-size:8px;font-family:var(--font-mono)"
-                          x-text="formatCost(bar.cost)"
-                        ></text>
-                      </g>
-                    </template>
+                    <g x-html="barChartSvg()"></g>
                   </svg>
                 </div>
               </div>

--- a/crates/openfang-api/static/js/pages/usage.js
+++ b/crates/openfang-api/static/js/pages/usage.js
@@ -191,6 +191,33 @@ function analyticsPage() {
       return segments;
     },
 
+    donutSegmentsSvg() {
+      var segments = this.donutSegments();
+      if (!segments.length) return '';
+
+      function escapeXml(value) {
+        return String(value)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&apos;');
+      }
+
+      var out = [];
+      for (var i = 0; i < segments.length; i++) {
+        var seg = segments[i];
+        var title = seg.provider + ': ' + seg.percent + '% (' + this.formatCost(seg.cost) + ')';
+        out.push(
+          '<circle cx="80" cy="80" r="60" fill="none" stroke="' + escapeXml(seg.color) + '" stroke-width="24" stroke-dasharray="' + escapeXml(seg.dasharray) + '" stroke-dashoffset="' + escapeXml(seg.dashoffset) + '" transform="rotate(-90 80 80)" class="donut-segment">' +
+          '<title>' + escapeXml(title) + '</title>' +
+          '</circle>'
+        );
+      }
+
+      return out.join('');
+    },
+
     // ── Bar chart (last 7 days) ──
 
     barChartData() {
@@ -216,6 +243,42 @@ function analyticsPage() {
         });
       }
       return result;
+    },
+
+    barChartSvg() {
+      var bars = this.barChartData();
+      if (!bars.length) return '';
+
+      function escapeXml(value) {
+        return String(value)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&apos;');
+      }
+
+      var out = [];
+      for (var i = 0; i < bars.length; i++) {
+        var bar = bars[i];
+        var x = i * 50 + 18;
+        var labelX = i * 50 + 30;
+        var y = 150 - bar.barHeight;
+        var costLabelY = y - 4;
+        var title = bar.date + ': ' + this.formatCost(bar.cost) + ' (' + bar.calls + ' calls)';
+
+        out.push(
+          '<g>' +
+          '<rect x="' + x + '" y="' + y + '" width="24" height="' + bar.barHeight + '" rx="3" fill="var(--accent)" class="cost-bar" style="opacity:0.85">' +
+          '<title>' + escapeXml(title) + '</title>' +
+          '</rect>' +
+          '<text x="' + labelX + '" y="166" text-anchor="middle" fill="var(--text-muted)" style="font-size:9px;font-family:var(--font-mono)">' + escapeXml(bar.dayName) + '</text>' +
+          '<text x="' + labelX + '" y="' + costLabelY + '" text-anchor="middle" fill="var(--text-dim)" style="font-size:8px;font-family:var(--font-mono)">' + escapeXml(this.formatCost(bar.cost)) + '</text>' +
+          '</g>'
+        );
+      }
+
+      return out.join('');
     },
 
     // ── Cost by model table (sorted by cost descending) ──


### PR DESCRIPTION
## Summary

This PR fixes chart rendering issues caused by Alpine directives inside SVG templates. In the analytics cost dashboard, SVG-based donut and bar charts could fail to render correctly (including runtime expression/import errors), which resulted in broken or incomplete chart visuals.

<img width="960" height="95" alt="screenshot-20260407-160312" src="https://github.com/user-attachments/assets/91d1e016-fccc-4506-8100-92f089eb8493" />
<img width="811" height="302" alt="screenshot-20260407-160302" src="https://github.com/user-attachments/assets/3a07d79d-f957-4b73-b614-0487fc5bd1f3" />
<img width="930" height="135" alt="screenshot-20260407-160239" src="https://github.com/user-attachments/assets/d493506f-c2ab-44e3-9128-3dae97f6961f" />
<img width="1002" height="328" alt="screenshot-20260407-160225" src="https://github.com/user-attachments/assets/49b1cf3b-abc3-4e8e-96f0-12e74e2369f7" />


## Changes

- Replaced SVG `<template x-for>` loops with `x-html`-based rendering for chart segments/bars.  
- Added JS helper functions to generate SVG markup for donut and daily bar charts.  
- Preserved existing chart behavior and data sources (colors, labels, tooltips, percentages, totals).  
- Added XML escaping for generated SVG text/attributes to improve rendering safety and stability.  

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
