### PR TITLE
fix(comms): OpenFangAPI.baseUrl is undefined

### DIFF
--- a/crates/openfang-api/static/js/pages/comms.js
+++ b/crates/openfang-api/static/js/pages/comms.js
@@ -39,7 +39,7 @@ function commsPage() {
     startSSE() {
       if (this.sseSource) this.sseSource.close();
       var self = this;
-      var url = OpenFangAPI.baseUrl + '/api/comms/events/stream';
+      var url = '/api/comms/events/stream';
       if (OpenFangAPI.apiKey) url += '?token=' + encodeURIComponent(OpenFangAPI.apiKey);
       this.sseSource = new EventSource(url);
       this.sseSource.onmessage = function(ev) {


### PR DESCRIPTION
## Summary

Fixed an issue where the `stream` API URL in the Agent Comms page contained "undefined". This was caused by the `OpenFangAPI` object missing a `baseUrl` property, resulting in malformed URLs when constructing API endpoints.

## Changes

OpenFangAPI.baseUrl deleted

Before:

<img width="874" height="99" alt="image" src="https://github.com/user-attachments/assets/dd613564-1de6-44b3-b901-8b5e1dd5bec3" />


After:

<img width="777" height="107" alt="image" src="https://github.com/user-attachments/assets/d79519b9-8260-4059-a4b6-c76f10b1185d" />


## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
