### PR TITLE
fix(kernel): preserve cron jobs across hand reactivation

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -3490,6 +3490,15 @@ impl OpenFangKernel {
         let saved_triggers = old_agent_id
             .map(|id| self.triggers.take_agent_triggers(id))
             .unwrap_or_default();
+        // Snapshot cron jobs before kill_agent destroys them. kill_agent calls
+        // remove_agent_jobs() which deletes the jobs from memory and persists
+        // an empty cron_jobs.json to disk. The reassign_agent_jobs() call below
+        // would always be a no-op without this snapshot — same pattern as
+        // saved_triggers above. Fixes the silent loss of cron jobs across
+        // every daemon restart for hand-style agents.
+        let saved_crons: Vec<openfang_types::scheduler::CronJob> = old_agent_id
+            .map(|id| self.cron_scheduler.list_jobs(id))
+            .unwrap_or_default();
         if let Some(old) = existing {
             info!(agent = %old.name, id = %old.id, "Removing existing hand agent for reactivation");
             let _ = self.kill_agent(old.id);
@@ -3520,9 +3529,38 @@ impl OpenFangKernel {
             }
         }
 
-        // Migrate cron jobs from old agent to new agent so they survive restarts.
-        // Without this, persisted cron jobs would reference the stale old UUID
-        // and fail silently (issue #461).
+        // Restore cron jobs that were snapshotted before kill_agent. They're
+        // re-added under the new agent_id (which equals old.id when fixed_id is
+        // derived from hand_id, but be explicit). Runtime state is reset so
+        // jobs get a fresh start.
+        if !saved_crons.is_empty() {
+            let mut restored = 0usize;
+            for mut job in saved_crons {
+                job.agent_id = agent_id;
+                job.next_run = None;
+                job.last_run = None;
+                if self.cron_scheduler.add_job(job, false).is_ok() {
+                    restored += 1;
+                }
+            }
+            if restored > 0 {
+                info!(
+                    agent = %agent_id,
+                    restored,
+                    "Restored cron jobs after hand reactivation"
+                );
+                if let Err(e) = self.cron_scheduler.persist() {
+                    warn!("Failed to persist cron jobs after restoration: {e}");
+                }
+            }
+        }
+
+        // Belt-and-braces: also reassign any jobs that somehow still reference
+        // the old UUID (shouldn't happen after the snapshot/restore above, but
+        // kept as a safety net for edge cases like out-of-band cron creation
+        // between kill and respawn). Removed reassign as primary path because
+        // kill_agent's remove_agent_jobs always wipes saved_crons before this
+        // could fire — see issue with #461's original fix.
         if let Some(old_id) = old_agent_id {
             let migrated = self.cron_scheduler.reassign_agent_jobs(old_id, agent_id);
             if migrated > 0 {


### PR DESCRIPTION
## Summary                    
                                                                                                                
  Cron jobs are silently destroyed across daemon restarts for hand-style agents. Root cause: in `activate_hand()`, `kill_agent(old.id)` runs **before** the new agent is spawned. `kill_agent`  
  calls `cron_scheduler.remove_agent_jobs()` which deletes the agent's jobs from memory and persists `[]` to `cron_jobs.json` on disk. The `reassign_agent_jobs()` call further down (added by  
  #461 to fix exactly this class of bug) is therefore **always a no-op** — by the time it runs, the jobs are already gone.                                                                      
                                                                                                                                                                                                
  Symptom: every daemon restart wipes `cron_jobs.json` for hand-managed agents. `/api/cron/jobs` returns empty. No error logged. Users report "my crons disappeared" with no explanation.       
   
  This PR fixes it by snapshotting the cron jobs into a local `Vec<CronJob>` **before** `kill_agent`, then re-adding them under the new agent ID **after** `spawn_agent_with_parent` — the exact
   same pattern already used for `saved_triggers` immediately above (which fixed the analogous bug for triggers in #519).
                                                                                                                                                                                                
  Fixes the "cron jobs lost on restart" regression that #461's original fix attempted but did not actually resolve due to the operation ordering.                                               
   
  ## Changes                                                                                                                                                                                    
                                                                  
  - `crates/openfang-kernel/src/kernel.rs` — in `activate_hand()`:                                                                                                                              
    - Snapshot `saved_crons: Vec<CronJob>` from `cron_scheduler.list_jobs(old_id)` before `kill_agent` (mirrors the existing `saved_triggers` snapshot 3 lines above)
    - After `spawn_agent_with_parent`, re-add each saved cron under the new `agent_id`, resetting `next_run` and `last_run` so jobs get a fresh schedule                                        
    - Persist once after the bulk re-add                                                                                                                                                        
    - Existing `reassign_agent_jobs()` block kept as a defensive safety net (it's now redundant in the common path but harmless)                                                                
  - 41 insertions, 3 deletions, 1 file                                                                                                                                                          
                                                                                                                                                                                                
## Testing                                                                                                                                                                                    
                                                                                                                                                                                                
  - [x] `cargo check -p openfang-kernel --lib` passes clean against `upstream/main` (v0.5.7) — no warnings beyond the pre-existing `imap-proto` future-incompat note                            
  - [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes — *could not run locally (workspace requires `gdk-3.0` system lib for an unrelated GUI crate); kernel crate alone is 
  clean. CI will exercise the full workspace.*                                                                                                                                                  
  - [ ] `cargo test --workspace` passes — *same gdk-3.0 limitation; kernel-level unit tests for `cron_scheduler.list_jobs` and `add_job` already exist and the patch only uses public APIs that 
  have those tests.*                                                                                                                                                                            
  - [x] Live integration tested manually:                         
    1. Activate a hand agent                                                                                                                                                                    
    2. `POST /api/cron/jobs` to create 3 jobs against it                                                                                                                                        
    3. Verify `/api/cron/jobs` lists them and `cron_jobs.json` contains them                                                                                                                    
    4. `docker restart` the daemon                                                                                                                                                              
    5. **Before this fix:** `/api/cron/jobs` returns empty, `cron_jobs.json` is `[]`                                                                                                            
    6. **After this fix:** all 3 jobs still present and persisted, with the new agent UUID                                                                                                      
                                                                                                                                                                                                
## Security                                                                                                                                                                                   
                                                                                                                                                                                                
  - [x] No new `unsafe` code                                                                                                                                                                    
  - [x] No secrets or API keys in diff
  - [x] User input validated at boundaries — patch only manipulates already-validated `CronJob` instances loaded from the trusted `CronScheduler`; `add_job()` re-runs its existing validation  
  (max-jobs limit, per-agent count, schedule validity) on every restored job
