### PR TITLE
fix(analytics): correct bar style attribute binding

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -3994,7 +3994,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
                       <td x-text="formatTokens(m.total_input_tokens)"></td>
                       <td x-text="formatTokens(m.total_output_tokens)"></td>
                       <td x-text="formatCost(m.total_cost_usd)"></td>
-                      <td><div style="background:var(--surface2);border-radius:4px;height:16px;overflow:hidden"><div style="height:100%;border-radius:4px;background:var(--accent);transition:width 0.3s" :style="'width:' + barWidth(m)"></div></div></td>
+                      <td><div style="background:var(--surface2);border-radius:4px;height:16px;overflow:hidden"><div style="height:100%;border-radius:4px;background:var(--accent);transition:width 0.3s" :style="{ width: barWidth(m) }"></div></div></td>
                     </tr>
                   </template>
                 </tbody>
@@ -4166,7 +4166,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
                         <td class="font-bold" x-text="formatCost(m.total_cost_usd)"></td>
                         <td>
                           <div style="background:var(--surface2);border-radius:4px;height:16px;overflow:hidden">
-                            <div style="height:100%;border-radius:4px;background:var(--accent);transition:width 0.3s" :style="'width:' + costBarWidth(m)"></div>
+                            <div style="height:100%;border-radius:4px;background:var(--accent);transition:width 0.3s" :style="{ width: costBarWidth(m) }"></div>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION

## Summary

Fixed an issue in the **analysis** page where `:style` binding with a string value would overwrite the initial `style` attribute instead of merging with it. By switching to an object-based binding (e.g., `:style="{ width: barWidth(m) }" `), the styles are now correctly applied and merged as expected.

## Changes

Before:

<img width="844" height="104" alt="screenshot-20260409-191624" src="https://github.com/user-attachments/assets/197ab599-17d6-4359-b7b9-dade390794b5" />

After:

<img width="1225" height="109" alt="screenshot-20260409-191059" src="https://github.com/user-attachments/assets/09c184a5-f87c-45fd-ba3b-7eaba3268cd0" />


## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
