### PR TITLE
fix(comms): align task and send modals to center

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -4538,7 +4538,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
           </div>
 
           <!-- Send Message Modal -->
-          <div x-show="showSendModal" style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);backdrop-filter:blur(4px)" @click.self="showSendModal=false" x-transition>
+          <div style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);backdrop-filter:blur(4px)" @click.self="showSendModal=false" :style="{ display: showSendModal ? 'flex' : 'none' }" x-transition>
             <div class="card" style="width:420px;max-width:90vw" @click.stop>
               <div class="card-header">Send Agent Message</div>
               <div style="display:flex;flex-direction:column;gap:12px;margin-top:12px">
@@ -4576,7 +4576,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]</pre>
           </div>
 
           <!-- Post Task Modal -->
-          <div x-show="showTaskModal" style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);backdrop-filter:blur(4px)" @click.self="showTaskModal=false" x-transition>
+          <div style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);backdrop-filter:blur(4px)" :style="{ display: showTaskModal ? 'flex' : 'none' }" @click.self="showTaskModal=false" x-transition>
             <div class="card" style="width:420px;max-width:90vw" @click.stop>
               <div class="card-header">Post Task</div>
               <div style="display:flex;flex-direction:column;gap:12px;margin-top:12px">


### PR DESCRIPTION
## Summary

Fixed the issue where the modal was not centered. The problem occurred because the `display` property was not set to `flex` when the modal was displayed. Replaced `x-show` with a dynamic `:style` binding to explicitly set `display: flex` when the modal is shown.

## Changes

<table>
<thead>
<tr>
<td>Before</td>
<td>After</td>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="885" height="566" alt="screenshot-20260410-153520" src="https://github.com/user-attachments/assets/55ca0a0d-9fd3-4a44-87d9-5991369773ec" />
</td>
<td>
<img width="893" height="661" alt="screenshot-20260410-153427" src="https://github.com/user-attachments/assets/aa136602-ca0c-4ce4-a2e6-db2d7f279616" /></td>
</tr>
<tr>
<td>
<img width="926" height="549" alt="screenshot-20260410-153241" src="https://github.com/user-attachments/assets/66f365be-e619-4701-a765-b5073c40798d" />
</td>
<td>
<img width="1054" height="807" alt="screenshot-20260410-153345" src="https://github.com/user-attachments/assets/16b62b6b-de7f-4377-9c03-e60cb4eef6cb" />
</td>
</tr>
</today>
</table>


## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
