### PR TITLE
Fix: Safe char boundary handling for UTF-8 string slicing

### DIFF
--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -435,11 +435,10 @@ async fn summarize_messages(
         let safe_start = if conversation_text.is_char_boundary(start) {
             start
         } else {
-            conversation_text[start..]
-                .char_indices()
-                .next()
-                .map(|(i, _)| start + i)
-                .unwrap_or(conversation_text.len())
+            // Find the nearest valid character boundary moving upward   
+	        (start..conversation_text.len())
+	            .find(|&i| conversation_text.is_char_boundary(i))
+	            .unwrap_or(conversation_text.len())
         };
         conversation_text = conversation_text[safe_start..].to_string();
     }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link related issues with "Fixes #123". -->
Fixed a panic when slicing UTF-8 strings at invalid char boundaries.
Added safe boundary detection to find the nearest valid char boundary before slicing the conversation text, preventing out-of-chars bounds errors.
e.g. 
thread 'tokio-rt-worker' (156147) panicked at crates/openfang-runtime/src/compactor.rs:438:30:

byte index 7160 is not a char boundary; it is inside '议' (bytes 7158..7161) of `[Used tool 'web_fetch' with params: {"body":"{\n \"param\": \"SELECT region, quantity FROM sdp_unpaid_receipt_distribution WHERE biz_month = '2026-04' ORDER BY quantity DESC\"\n}","headers":{"Content-Type":"application/json"},"method":...]

[Tool result (`[...] 
## Changes

<!-- Brief list of what changed. -->
    // Find the nearest valid character boundary moving upward   
	(start..conversation_text.len())
	.find(|&i| conversation_text.is_char_boundary(i))
	.unwrap_or(conversation_text.len())
## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [ ] No new unsafe code
- [ ] No secrets or API keys in diff
- [ ] User input validated at boundaries
