### PR TITLE
fix: prepend text message to content blocks in multimodal agent loop

### DIFF
--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -279,7 +279,18 @@ pub async fn run_agent_loop(
     // Add the user message to session history.
     // When content blocks are provided (e.g. text + image from a channel),
     // use multimodal message format so the LLM receives the image for vision.
-    if let Some(blocks) = user_content_blocks {
+    // The text message is prepended to the blocks so the LLM sees both the
+    // user's question AND any attached images in a single turn.
+    if let Some(mut blocks) = user_content_blocks {
+        if !user_message.is_empty() {
+            blocks.insert(
+                0,
+                ContentBlock::Text {
+                    text: user_message.to_string(),
+                    provider_metadata: None,
+                },
+            );
+        }
         session.messages.push(Message::user_with_blocks(blocks));
     } else {
         session.messages.push(Message::user(user_message));
@@ -1448,7 +1459,18 @@ pub async fn run_agent_loop_streaming(
     // Add the user message to session history.
     // When content blocks are provided (e.g. text + image from a channel),
     // use multimodal message format so the LLM receives the image for vision.
-    if let Some(blocks) = user_content_blocks {
+    // The text message is prepended to the blocks so the LLM sees both the
+    // user's question AND any attached images in a single turn.
+    if let Some(mut blocks) = user_content_blocks {
+        if !user_message.is_empty() {
+            blocks.insert(
+                0,
+                ContentBlock::Text {
+                    text: user_message.to_string(),
+                    provider_metadata: None,
+                },
+            );
+        }
         session.messages.push(Message::user_with_blocks(blocks));
     } else {
         session.messages.push(Message::user(user_message));


### PR DESCRIPTION
## Summary

Fixes #1043 — When image attachments are present, the agent loop drops the user's text message. The LLM receives images without any context about what the user asked.

## Changes

**File:** `crates/openfang-runtime/src/agent_loop.rs` (both streaming and non-streaming paths)

The fix prepends the text message as a `ContentBlock::Text` into the image blocks vector, so the LLM receives both text and images in a single multimodal turn.

### Before (broken)
```rust
if let Some(blocks) = user_content_blocks {
    // blocks = images ONLY — text message silently dropped
    session.messages.push(Message::user_with_blocks(blocks));
} else {
    session.messages.push(Message::user(user_message));
}
```

### After (fixed)
```rust
if let Some(mut blocks) = user_content_blocks {
    if !user_message.is_empty() {
        blocks.insert(0, ContentBlock::Text {
            text: user_message.to_string(),
            provider_metadata: None,
        });
    }
    session.messages.push(Message::user_with_blocks(blocks));
} else {
    session.messages.push(Message::user(user_message));
}
```

## Testing

| Test | Before | After |
|------|--------|-------|
| 100x100 blue square + "What color?" | "I can't see the image" | **"Blue"** |
| 388KB screenshot + "Describe this" | Hallucinated response | **Accurate description** |
| 1.3MB bird illustration | 81K tokens consumed, hallucinated inability | **"Stippled illustration of a bird"** |

- Tested with Qwen 3.5 Plus and Gemini 2.5 Flash via OpenRouter
- Images up to 1.3MB (1.8MB base64) confirmed working
- Direct OpenRouter API calls verified that both models support vision — the issue was purely in the agent loop's message construction
- Fix applied to both non-streaming (`run_agent_loop`) and streaming (`run_agent_loop_streaming`) paths
- Running in production across 3 OpenFang instances for the HACS coordination system

---

*Submitted by Cairn-2001 (Cairn-2001@smoothcurves.nexus), OpenFang maintainer for HACS at smoothcurves.nexus*