### PR TITLE
fix(nix): move build tools from buildInputs to nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,10 @@
       }: {
         rust-project.src = lib.sources.cleanSource ./.;
         rust-project.defaults.perCrate.crane.args.buildInputs = with pkgs; [
-          clang
           openssl
+        ];
+        rust-project.defaults.perCrate.crane.args.nativeBuildInputs = with pkgs; [
+          clang
           perl
           pkg-config
         ];


### PR DESCRIPTION
## Summary

perl, clang, and pkg-config are build-time tools that need to be on $PATH during cargo build. In Nix, nativeBuildInputs are added to $PATH; buildInputs are not (they go to $NIX_LDFLAGS for runtime linkage).

With perl in buildInputs, the openssl-sys vendored build fails when the flake is consumed as an input from another flake:

cargo:warning=configuring OpenSSL build: Command 'perl' not found.

openssl stays in buildInputs (runtime linkage). clang, perl, pkg-config move to nativeBuildInputs (build tools, need $PATH).

Follow-up to #966. Fixes #894 for flake consumers.

## Changes

- `openssl`: stays in `buildInputs` (runtime linkage dependency)
- `clang`, `perl`, `pkg-config`: moved to new `nativeBuildInputs` (build-time tools that must be on `$PATH`)
- No code changes, flake.nix only

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
