### PR TITLE
fix(hands): correct trader dashboard style

### DIFF
--- a/crates/openfang-api/static/css/components.css
+++ b/crates/openfang-api/static/css/components.css
@@ -3253,7 +3253,7 @@ mark.search-highlight {
    ═══════════════════════════════════════════════════════════════════════════ */
 
 .trader-dashboard {
-  background: var(--bg-card);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
   width: 96vw;
@@ -3270,7 +3270,7 @@ mark.search-highlight {
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
-  background: var(--bg-card);
+  background: var(--surface);
   z-index: 10;
   border-radius: 12px 12px 0 0;
 }
@@ -3330,6 +3330,7 @@ mark.search-highlight {
   border-radius: 8px;
   padding: 14px 16px;
   min-width: 0;
+  position: relative;
 }
 .trader-chart-title {
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary

Fixed two styling issues in the Hands page of the trader dashboard:

- **Content overlap**: The absolutely positioned `.trader-chart-empty` element was incorrectly positioned relative to `trader-dashboard`, blocking window content and preventing scrolling.
- **Transparent background**: The window background appeared transparent due to an undefined `--bg-card` CSS variable.

## Changes

<table>
<thead>
<tr>
<td>Before</td>
<td>After</td>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1584" height="1249" alt="screenshot-20260415-165705" src="https://github.com/user-attachments/assets/7a68d4b5-6f99-4ee5-8ffd-de3fed65fc86" />
</td>
<td>
<img width="1550" height="1242" alt="screenshot-20260415-165647" src="https://github.com/user-attachments/assets/9161aadf-cce1-4e18-aaf9-dc07221a2dca" />
</td>
</tr>
</tbody>
</table>

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
