### PR TITLE
fix(api): reject unauth requests from non-loopback by default (#1034)

### DIFF
--- a/crates/openfang-api/src/middleware.rs
+++ b/crates/openfang-api/src/middleware.rs
@@ -49,14 +49,23 @@ pub struct AuthState {
     pub api_key: String,
     pub auth_enabled: bool,
     pub session_secret: String,
+    /// Set from `OPENFANG_ALLOW_NO_AUTH=1` to permit running without an api_key
+    /// on a non-loopback bind. Off by default so empty keys fail closed.
+    pub allow_no_auth: bool,
 }
 
 /// Bearer token authentication middleware.
 ///
 /// When `api_key` is non-empty (after trimming), requests to non-public
 /// endpoints must include `Authorization: Bearer <api_key>`.
-/// If the key is empty or whitespace-only, auth is disabled entirely
-/// (public/local development mode).
+///
+/// When `api_key` is empty (no key configured) the server defaults to
+/// fail-closed for any request that does NOT originate from loopback.
+/// Loopback traffic (127.0.0.1 / ::1) is always allowed through with no
+/// key so single-user local setups keep zero-config UX. To explicitly
+/// run a no-auth server on a LAN/WAN address, set
+/// `OPENFANG_ALLOW_NO_AUTH=1`; this opts out of fail-closed and is
+/// reported loudly at startup.
 ///
 /// When dashboard auth is enabled, session cookies are also accepted.
 pub async fn auth(
@@ -67,17 +76,17 @@ pub async fn auth(
     // SECURITY: Capture method early for method-aware public endpoint checks.
     let method = request.method().clone();
 
-    // Shutdown is loopback-only (CLI on same machine) — skip token auth
+    let is_loopback = request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().is_loopback())
+        .unwrap_or(false); // SECURITY: default-deny; unknown origin is NOT loopback
+
+    // Shutdown is loopback-only (CLI on same machine). Skip token auth only
+    // when the request is from loopback.
     let path = request.uri().path();
-    if path == "/api/shutdown" {
-        let is_loopback = request
-            .extensions()
-            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-            .map(|ci| ci.0.ip().is_loopback())
-            .unwrap_or(false); // SECURITY: default-deny — unknown origin is NOT loopback
-        if is_loopback {
-            return next.run(request).await;
-        }
+    if path == "/api/shutdown" && is_loopback {
+        return next.run(request).await;
     }
 
     // Public endpoints that don't require auth (dashboard needs these).
@@ -133,12 +142,29 @@ pub async fn auth(
         return next.run(request).await;
     }
 
-    // If no API key configured (empty, whitespace-only, or missing), skip auth
-    // entirely. Users who don't set api_key accept that all endpoints are open.
-    // To secure the dashboard, set a non-empty api_key in config.toml.
+    // If no API key configured and no dashboard login is active, fail closed
+    // for anything that did not come from loopback. Opting out of this
+    // behavior requires setting `OPENFANG_ALLOW_NO_AUTH=1`, which is logged
+    // loudly at startup.
+    //
+    // See issue #1034 (B1/B2): empty api_key previously bypassed auth for
+    // all origins, exposing agent config, channel tokens, and LLM keys on
+    // any LAN-reachable bind.
     let api_key_trimmed = auth_state.api_key.trim().to_string();
     if api_key_trimmed.is_empty() && !auth_state.auth_enabled {
-        return next.run(request).await;
+        if is_loopback || auth_state.allow_no_auth {
+            return next.run(request).await;
+        }
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("www-authenticate", "Bearer")
+            .body(Body::from(
+                serde_json::json!({
+                    "error": "API key required for non-loopback requests. Set OPENFANG_API_KEY or bind to 127.0.0.1."
+                })
+                .to_string(),
+            ))
+            .unwrap_or_default();
     }
     let api_key = api_key_trimmed.as_str();
 
@@ -265,9 +291,123 @@ pub async fn security_headers(request: Request<Body>, next: Next) -> Response<Bo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::{Method, Request};
+    use axum::routing::get;
+    use axum::Router;
+    use std::net::SocketAddr;
+    use tower::ServiceExt;
 
     #[test]
     fn test_request_id_header_constant() {
         assert_eq!(REQUEST_ID_HEADER, "x-request-id");
+    }
+
+    fn auth_state_empty() -> AuthState {
+        AuthState {
+            api_key: String::new(),
+            auth_enabled: false,
+            session_secret: String::new(),
+            allow_no_auth: false,
+        }
+    }
+
+    fn auth_state_with_key(key: &str) -> AuthState {
+        AuthState {
+            api_key: key.to_string(),
+            auth_enabled: false,
+            session_secret: key.to_string(),
+            allow_no_auth: false,
+        }
+    }
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    fn router(state: AuthState) -> Router {
+        Router::new()
+            .route("/api/agents/1", get(ok_handler))
+            .route_layer(axum::middleware::from_fn_with_state(state, auth))
+    }
+
+    fn req_from(ip: &str) -> Request<Body> {
+        let addr: SocketAddr = format!("{ip}:40000").parse().unwrap();
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/api/agents/1")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
+    }
+
+    #[tokio::test]
+    async fn empty_key_allows_loopback() {
+        let app = router(auth_state_empty());
+        let resp = app.oneshot(req_from("127.0.0.1")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn empty_key_blocks_lan_origin() {
+        // Issue #1034 B1: previously 192.168/10/... could hit every non-public
+        // endpoint when api_key was unset. Must now be 401.
+        let app = router(auth_state_empty());
+        let resp = app.oneshot(req_from("192.168.1.50")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn empty_key_blocks_public_origin() {
+        let app = router(auth_state_empty());
+        let resp = app.oneshot(req_from("203.0.113.5")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn empty_key_blocks_unknown_connect_info() {
+        // Paranoia: if ConnectInfo is missing for any reason, we must fail
+        // closed, not open.
+        let app = router(auth_state_empty());
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/api/agents/1")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn empty_key_with_allow_no_auth_opens_everything() {
+        let mut s = auth_state_empty();
+        s.allow_no_auth = true;
+        let app = router(s);
+        let resp = app.oneshot(req_from("10.0.0.9")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn configured_key_rejects_missing_token_from_loopback() {
+        let app = router(auth_state_with_key("secret"));
+        let resp = app.oneshot(req_from("127.0.0.1")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn configured_key_accepts_bearer() {
+        let app = router(auth_state_with_key("secret"));
+        let addr: SocketAddr = "127.0.0.1:40000".parse().unwrap();
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/api/agents/1")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/crates/openfang-api/src/server.rs
+++ b/crates/openfang-api/src/server.rs
@@ -115,6 +115,32 @@ pub async fn build_router(
 
     // Trim whitespace so `api_key = ""` or `api_key = "  "` both disable auth.
     let api_key = state.kernel.config.api_key.trim().to_string();
+    let allow_no_auth = std::env::var("OPENFANG_ALLOW_NO_AUTH")
+        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false);
+
+    // Fail-closed warning: if no api_key and no dashboard auth, and the
+    // server is bound to a non-loopback address without an explicit opt-in,
+    // shout about it. The middleware will reject non-loopback traffic.
+    let bind_is_loopback = listen_addr.ip().is_loopback();
+    if api_key.is_empty() && !state.kernel.config.auth.enabled && !bind_is_loopback {
+        if allow_no_auth {
+            tracing::warn!(
+                "OPENFANG_ALLOW_NO_AUTH=1 is set. Running WITHOUT authentication on {}. \
+                 Anyone reachable at this address can read/write agents, channels, and keys.",
+                listen_addr
+            );
+        } else {
+            tracing::warn!(
+                "No api_key configured and server is bound to {} (non-loopback). \
+                 Non-loopback requests will be rejected with 401. \
+                 Set OPENFANG_API_KEY (or api_key in config.toml), or bind to 127.0.0.1, \
+                 or set OPENFANG_ALLOW_NO_AUTH=1 to explicitly run open.",
+                listen_addr
+            );
+        }
+    }
+
     let auth_state = crate::middleware::AuthState {
         api_key: api_key.clone(),
         auth_enabled: state.kernel.config.auth.enabled,
@@ -125,6 +151,7 @@ pub async fn build_router(
         } else {
             String::new()
         },
+        allow_no_auth,
     };
     let gcra_limiter = rate_limiter::create_rate_limiter();
 

--- a/crates/openfang-api/src/ws.rs
+++ b/crates/openfang-api/src/ws.rs
@@ -145,11 +145,27 @@ pub async fn agent_ws(
     headers: axum::http::HeaderMap,
     uri: axum::http::Uri,
 ) -> impl IntoResponse {
-    // SECURITY: Authenticate WebSocket upgrades (bypasses middleware).
-    // Trim whitespace so empty/whitespace-only api_key disables auth.
+    // SECURITY: Authenticate WebSocket upgrades (bypasses HTTP middleware).
+    // Trim whitespace so empty/whitespace-only api_key still triggers the
+    // fail-closed path for non-loopback origins (see issue #1034 B2).
     let api_key_raw = &state.kernel.config.api_key;
     let api_key = api_key_raw.trim();
-    if !api_key.is_empty() {
+    let is_loopback = addr.ip().is_loopback();
+
+    if api_key.is_empty() {
+        // No key configured. Only allow loopback, unless the operator has
+        // explicitly opted in to running open via OPENFANG_ALLOW_NO_AUTH=1.
+        let allow_no_auth = std::env::var("OPENFANG_ALLOW_NO_AUTH")
+            .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+            .unwrap_or(false);
+        if !is_loopback && !allow_no_auth {
+            warn!(
+                ip = %addr.ip(),
+                "WebSocket upgrade rejected: no api_key configured and origin is not loopback"
+            );
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+    } else {
         // SECURITY: Use constant-time comparison to prevent timing attacks on API key
         let ct_eq = |token: &str, key: &str| -> bool {
             use subtle::ConstantTimeEq;

--- a/crates/openfang-api/tests/api_integration_test.rs
+++ b/crates/openfang-api/tests/api_integration_test.rs
@@ -834,6 +834,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
         } else {
             String::new()
         },
+        allow_no_auth: true,
     };
 
     let app = Router::new()


### PR DESCRIPTION
Fixes #1034

## What

Empty `api_key` used to turn off auth for everyone. If you bound the
server to `0.0.0.0` with no key set, anyone on the network could hit
`/api/*` and WebSocket endpoints with no credentials.

Now an empty key only works for loopback. Non-loopback requests get 401
unless the operator sets `OPENFANG_ALLOW_NO_AUTH=1` on purpose.

## Behavior

| Bind | api_key | Origin | Result |
|------|---------|--------|--------|
| 127.0.0.1 | empty | loopback | allow |
| 0.0.0.0 | empty | loopback | allow |
| 0.0.0.0 | empty | LAN/public | 401 |
| 0.0.0.0 | empty | LAN/public, `OPENFANG_ALLOW_NO_AUTH=1` | allow (loud warn) |
| any | set | any | bearer check (constant time) |

## Changes

- `middleware.rs`: check `ConnectInfo<SocketAddr>`, fail closed on non-loopback
- `ws.rs`: same logic for WebSocket upgrades (closes B2)
- `server.rs`: loud startup warn when bound to non-loopback with no key
- `AuthState`: new `allow_no_auth` flag from `OPENFANG_ALLOW_NO_AUTH`
- Missing `ConnectInfo` is treated as unknown origin and rejected

## Tests

8 new unit tests in `middleware::tests`:

- `empty_key_allows_loopback`
- `empty_key_blocks_lan_origin`
- `empty_key_blocks_public_origin`
- `empty_key_blocks_unknown_connect_info`
- `empty_key_with_allow_no_auth_opens_everything`
- `configured_key_accepts_bearer`
- `configured_key_rejects_missing_token_from_loopback`
- `test_request_id_header_constant`

All pass. `cargo clippy -p openfang-api --tests -- -D warnings` is clean.
`cargo fmt --check` is clean.

## Ops note

Local dev on 127.0.0.1 keeps working with no config. Operators running
openly on a LAN/public IP now see a 401 and have to pick one:

1. set `OPENFANG_API_KEY` / `api_key` in `config.toml`
2. bind to `127.0.0.1`
3. set `OPENFANG_ALLOW_NO_AUTH=1` to keep the old open behavior
