### PR TITLE
feat(cli): add hand config subcommand (#809)

### DIFF
--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -440,6 +440,27 @@ enum HandCommands {
         /// Instance ID (from `hand active`).
         id: String,
     },
+    /// Get, set, or list settings for an active hand instance.
+    ///
+    /// With no flags, prints the current settings. Use `--set KEY=VAL`
+    /// (repeatable) to update values, `--unset KEY` to remove a value,
+    /// or `--get KEY` to print a single value.
+    Config {
+        /// Hand ID (e.g. "browser", "clip").
+        id: String,
+        /// Print a single setting value.
+        #[arg(long, value_name = "KEY", conflicts_with_all = ["set", "unset", "list"])]
+        get: Option<String>,
+        /// Set a setting value. Format: `KEY=VALUE`. May be repeated.
+        #[arg(long, value_name = "KEY=VALUE")]
+        set: Vec<String>,
+        /// Unset a setting key. May be repeated.
+        #[arg(long, value_name = "KEY")]
+        unset: Vec<String>,
+        /// List the current settings (default when no other flag is given).
+        #[arg(long)]
+        list: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1010,6 +1031,13 @@ fn main() {
             HandCommands::InstallDeps { id } => cmd_hand_install_deps(&id),
             HandCommands::Pause { id } => cmd_hand_pause(&id),
             HandCommands::Resume { id } => cmd_hand_resume(&id),
+            HandCommands::Config {
+                id,
+                get,
+                set,
+                unset,
+                list,
+            } => cmd_hand_config(&id, get.as_deref(), &set, &unset, list),
         },
         Some(Commands::Config(sub)) => match sub {
             ConfigCommands::Show => cmd_config_show(),
@@ -4565,6 +4593,167 @@ fn cmd_hand_resume(id: &str) {
     }
 }
 
+/// Parse a `KEY=VALUE` pair passed to `--set`.
+///
+/// Empty keys are rejected so `--set =foo` or `--set  =bar` surface a clear
+/// error rather than silently writing a blank setting name.
+fn parse_hand_config_pair(pair: &str) -> Result<(String, String), String> {
+    let (key, value) = pair
+        .split_once('=')
+        .ok_or_else(|| format!("Invalid --set '{pair}': expected KEY=VALUE"))?;
+    let key = key.trim();
+    if key.is_empty() {
+        return Err(format!("Invalid --set '{pair}': empty key"));
+    }
+    Ok((key.to_string(), value.to_string()))
+}
+
+fn cmd_hand_config(
+    id: &str,
+    get: Option<&str>,
+    set_pairs: &[String],
+    unset_keys: &[String],
+    list: bool,
+) {
+    let base = require_daemon("hand config");
+    let client = daemon_client();
+
+    // Always fetch current state first so we can merge updates and print
+    // a useful view even when the target hand has no active instance.
+    let url = format!("{base}/api/hands/{id}/settings");
+    let body = daemon_json(client.get(&url).send());
+
+    if let Some(err) = body.get("error").and_then(|v| v.as_str()) {
+        ui::error(&format!("Hand '{id}': {err}"));
+        std::process::exit(1);
+    }
+
+    let mut current: std::collections::BTreeMap<String, serde_json::Value> = body
+        .get("current_values")
+        .and_then(|v| v.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .unwrap_or_default();
+
+    let schema_defaults: std::collections::BTreeMap<String, String> = body
+        .get("settings")
+        .and_then(|v| v.get("settings"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| {
+                    let key = s.get("key").and_then(|v| v.as_str())?.to_string();
+                    let default = s
+                        .get("default")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    Some((key, default))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Pure read paths — no mutation, no daemon round-trip beyond the GET.
+    if let Some(key) = get {
+        match current
+            .get(key)
+            .map(value_to_display)
+            .or_else(|| schema_defaults.get(key).cloned())
+        {
+            Some(val) => println!("{val}"),
+            None => {
+                ui::error(&format!("No setting '{key}' on hand '{id}'"));
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    let is_mutation = !set_pairs.is_empty() || !unset_keys.is_empty();
+    if !is_mutation {
+        print_hand_config(id, &current, &schema_defaults, list);
+        return;
+    }
+
+    for pair in set_pairs {
+        match parse_hand_config_pair(pair) {
+            Ok((k, v)) => {
+                current.insert(k, serde_json::Value::String(v));
+            }
+            Err(e) => {
+                ui::error(&e);
+                std::process::exit(1);
+            }
+        }
+    }
+    for key in unset_keys {
+        let key = key.trim();
+        if key.is_empty() {
+            ui::error("Invalid --unset: empty key");
+            std::process::exit(1);
+        }
+        current.remove(key);
+    }
+
+    let payload: serde_json::Map<String, serde_json::Value> = current.clone().into_iter().collect();
+    let resp = daemon_json(
+        client
+            .put(&url)
+            .json(&serde_json::Value::Object(payload))
+            .send(),
+    );
+    if let Some(err) = resp.get("error").and_then(|v| v.as_str()) {
+        ui::error(&format!("Failed to update hand '{id}' settings: {err}"));
+        if err.contains("No active instance") {
+            ui::hint(&format!(
+                "Activate the hand first: openfang hand activate {id}"
+            ));
+        }
+        std::process::exit(1);
+    }
+    ui::success(&format!("Updated settings for hand '{id}'."));
+    print_hand_config(id, &current, &schema_defaults, true);
+}
+
+/// Human-readable display for a JSON setting value.
+fn value_to_display(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn print_hand_config(
+    id: &str,
+    current: &std::collections::BTreeMap<String, serde_json::Value>,
+    schema_defaults: &std::collections::BTreeMap<String, String>,
+    _list: bool,
+) {
+    if current.is_empty() && schema_defaults.is_empty() {
+        println!("No settings configured for hand '{id}'.");
+        return;
+    }
+
+    println!("Settings for hand '{id}':");
+    let mut keys: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for k in current.keys() {
+        keys.insert(k.as_str());
+    }
+    for k in schema_defaults.keys() {
+        keys.insert(k.as_str());
+    }
+    for key in keys {
+        match current.get(key) {
+            Some(v) => println!("  {key} = {}", value_to_display(v)),
+            None => {
+                let default = schema_defaults.get(key).map(|s| s.as_str()).unwrap_or("");
+                println!("  {key} = {default}  (default)");
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Provider / API key helpers
 // ---------------------------------------------------------------------------
@@ -7026,6 +7215,55 @@ args = ["-y", "@modelcontextprotocol/server-github"]
     }
 
     // --- Uninstall command unit tests ---
+
+    // --- hand config command unit tests ---
+
+    #[test]
+    fn test_hand_config_parse_pair_ok() {
+        let (k, v) = super::parse_hand_config_pair("headless=true").unwrap();
+        assert_eq!(k, "headless");
+        assert_eq!(v, "true");
+    }
+
+    #[test]
+    fn test_hand_config_parse_pair_value_may_contain_equals() {
+        let (k, v) = super::parse_hand_config_pair("url=https://example.com?a=b").unwrap();
+        assert_eq!(k, "url");
+        assert_eq!(v, "https://example.com?a=b");
+    }
+
+    #[test]
+    fn test_hand_config_parse_pair_value_may_be_empty() {
+        // Empty values are valid (useful to explicitly blank a setting before
+        // PUT). Empty keys are the failure case.
+        let (k, v) = super::parse_hand_config_pair("foo=").unwrap();
+        assert_eq!(k, "foo");
+        assert_eq!(v, "");
+    }
+
+    #[test]
+    fn test_hand_config_parse_pair_rejects_empty_key() {
+        assert!(super::parse_hand_config_pair("=bar").is_err());
+        assert!(super::parse_hand_config_pair("   =bar").is_err());
+    }
+
+    #[test]
+    fn test_hand_config_parse_pair_requires_equals() {
+        assert!(super::parse_hand_config_pair("headless").is_err());
+    }
+
+    #[test]
+    fn test_hand_config_parse_multiple_pairs_round_trip() {
+        let inputs = ["a=1", "b=two", "c=http://x.y"];
+        let mut map = std::collections::BTreeMap::new();
+        for pair in inputs {
+            let (k, v) = super::parse_hand_config_pair(pair).unwrap();
+            map.insert(k, v);
+        }
+        assert_eq!(map.get("a"), Some(&"1".to_string()));
+        assert_eq!(map.get("b"), Some(&"two".to_string()));
+        assert_eq!(map.get("c"), Some(&"http://x.y".to_string()));
+    }
 
     #[test]
     fn test_uninstall_path_line_filter() {

--- a/crates/openfang-hands/src/registry.rs
+++ b/crates/openfang-hands/src/registry.rs
@@ -1144,4 +1144,60 @@ metrics = []
         let err = reg.activate("test-hand", HashMap::new(), None).unwrap_err();
         assert!(matches!(err, HandError::AlreadyActive(_)));
     }
+
+    /// Integration test for issue #809: `hand config` round-trip.
+    ///
+    /// Simulates what `openfang hand config <id> --set KEY=VAL` does against
+    /// the registry: read current config, merge updates, write back, read
+    /// again. Persists to a tempdir so the restart path also sees the change.
+    #[test]
+    fn test_hand_config_round_trip_via_registry() {
+        let reg = test_registry_with_dummy_hand("browser");
+        let inst = reg.activate("browser", HashMap::new(), None).unwrap();
+
+        // Read-modify-write cycle mirroring the CLI's --set behavior.
+        let mut cfg = reg.get_instance(inst.instance_id).unwrap().config;
+        cfg.insert(
+            "headless".to_string(),
+            serde_json::Value::String("true".into()),
+        );
+        cfg.insert(
+            "user_agent".to_string(),
+            serde_json::Value::String("openfang/1".into()),
+        );
+        reg.update_config(inst.instance_id, cfg.clone()).unwrap();
+
+        let after = reg.get_instance(inst.instance_id).unwrap();
+        assert_eq!(
+            after.config.get("headless"),
+            Some(&serde_json::Value::String("true".into()))
+        );
+        assert_eq!(
+            after.config.get("user_agent"),
+            Some(&serde_json::Value::String("openfang/1".into()))
+        );
+
+        // --unset path: drop a key and confirm it's gone.
+        cfg.remove("user_agent");
+        reg.update_config(inst.instance_id, cfg).unwrap();
+        let after_unset = reg.get_instance(inst.instance_id).unwrap();
+        assert!(!after_unset.config.contains_key("user_agent"));
+        assert_eq!(
+            after_unset.config.get("headless"),
+            Some(&serde_json::Value::String("true".into()))
+        );
+
+        // State survives a persist+load round-trip through a tempdir sidecar.
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file = tmp.path().join("hands.json");
+        reg.persist_state(&state_file).unwrap();
+        let reloaded = HandRegistry::load_state(&state_file);
+        assert_eq!(reloaded.len(), 1);
+        let (hand_id, config, _agent_id) = &reloaded[0];
+        assert_eq!(hand_id, "browser");
+        assert_eq!(
+            config.get("headless"),
+            Some(&serde_json::Value::String("true".into()))
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #809.

The docs at https://www.openfang.sh/docs/hands advertise
`openfang hand config browser --set headless=true`, but that command
was never wired into the CLI — `openfang hand --help` only exposes
`list / active / install / activate / deactivate / info / check-deps /
install-deps / pause / resume`.

### Choice: implement (not docs-only)

Hand settings are already a real concept today. Each `HAND.toml`
declares a `[[settings]]` schema, and the API server has working
`GET /api/hands/{id}/settings` and `PUT /api/hands/{id}/settings`
routes that read and update the live instance config (which the
registry persists to `~/.openfang/hands_state.json` via
`persist_state`).

That meant the doc example was plausible and the shortest path to
success for users was to ship the command, not retroactively reword
the docs. This PR implements `openfang hand config` as a thin wrapper
over those existing routes.

### UX

```
openfang hand config <id>                  # print current settings (merged with schema defaults)
openfang hand config <id> --get KEY        # print one value
openfang hand config <id> --set KEY=VAL    # update one or more settings (repeatable)
openfang hand config <id> --unset KEY      # remove a setting
openfang hand config <id> --list           # explicit alias of the default view
```

- Empty keys are rejected in `--set` / `--unset` so bad input fails
  loudly instead of silently persisting a blank key.
- When no instance is active for the hand, the daemon's existing 404
  is surfaced along with a hint to run `openfang hand activate <id>`
  first.

### Tests

- Unit tests in `openfang-cli` cover the `KEY=VALUE` parser:
  empty keys rejected, equals signs inside values preserved (URLs),
  blank values allowed, multiple `--set` pairs round-trip into a map.
- Integration test in `openfang-hands` drives the registry's
  `update_config` path end-to-end — set two keys, unset one, then
  persist/load through a tempdir to confirm the CLI's semantics
  match what the daemon actually stores across restarts.

### Quality

- `cargo check -p openfang-cli -p openfang-hands` — clean.
- `cargo test -p openfang-hands --lib` — 52 passed.
- `cargo test -p openfang-cli --bin openfang tests::test_hand_config` — 6 passed.
- `cargo clippy -p openfang-hands --all-targets -- -D warnings` — clean.
- `cargo fmt` — applied.

## Test plan

- [ ] CI passes `cargo check`, `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`.
- [ ] Manual sanity:
  ```
  openfang start &
  openfang hand activate browser
  openfang hand config browser
  openfang hand config browser --set headless=true --set user_agent=openfang/1
  openfang hand config browser --get headless   # -> true
  openfang hand config browser --unset user_agent
  ```
