### PR TITLE
fix: expose MiniMax in openfang init

### DIFF
--- a/crates/openfang-cli/src/main.rs
+++ b/crates/openfang-cli/src/main.rs
@@ -1476,7 +1476,28 @@ fn provider_list() -> Vec<(&'static str, &'static str, &'static str, &'static st
             "openrouter/google/gemini-2.5-flash",
             "OpenRouter",
         ),
+        ("minimax", "MINIMAX_API_KEY", "MiniMax-M2.7", "MiniMax"),
     ]
+}
+
+#[cfg(test)]
+mod provider_list_tests {
+    use super::provider_list;
+
+    #[test]
+    fn provider_list_includes_minimax() {
+        let minimax = provider_list()
+            .into_iter()
+            .find(|(provider, _, _, _)| *provider == "minimax");
+        assert!(
+            minimax.is_some(),
+            "MiniMax should be exposed by provider_list()"
+        );
+        let (_, env_var, model, display) = minimax.unwrap();
+        assert_eq!(env_var, "MINIMAX_API_KEY");
+        assert_eq!(model, "MiniMax-M2.7");
+        assert_eq!(display, "MiniMax");
+    }
 }
 
 /// Quick probe to check if Ollama is running on localhost.

--- a/crates/openfang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/init_wizard.rs
@@ -149,6 +149,14 @@ const PROVIDERS: &[ProviderInfo] = &[
         hint: "",
     },
     ProviderInfo {
+        name: "minimax",
+        display: "MiniMax",
+        env_var: "MINIMAX_API_KEY",
+        default_model: "MiniMax-M2.7",
+        needs_key: true,
+        hint: "",
+    },
+    ProviderInfo {
         name: "huggingface",
         display: "Hugging Face",
         env_var: "HUGGINGFACE_API_KEY",
@@ -256,6 +264,23 @@ pub enum InitResult {
         launch: LaunchChoice,
     },
     Cancelled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PROVIDERS;
+
+    #[test]
+    fn init_wizard_lists_minimax_provider() {
+        let minimax = PROVIDERS.iter().find(|provider| provider.name == "minimax");
+        assert!(
+            minimax.is_some(),
+            "MiniMax should be selectable in openfang init"
+        );
+        let minimax = minimax.unwrap();
+        assert_eq!(minimax.env_var, "MINIMAX_API_KEY");
+        assert_eq!(minimax.default_model, "MiniMax-M2.7");
+    }
 }
 
 // ── Internal state ─────────────────────────────────────────────────────────

--- a/crates/openfang-cli/src/tui/screens/wizard.rs
+++ b/crates/openfang-cli/src/tui/screens/wizard.rs
@@ -86,6 +86,12 @@ const PROVIDERS: &[ProviderInfo] = &[
         needs_key: true,
     },
     ProviderInfo {
+        name: "minimax",
+        env_var: "MINIMAX_API_KEY",
+        default_model: "MiniMax-M2.7",
+        needs_key: true,
+    },
+    ProviderInfo {
         name: "perplexity",
         env_var: "PERPLEXITY_API_KEY",
         default_model: "sonar-pro",
@@ -687,5 +693,22 @@ fn draw_done(f: &mut Frame, area: Rect, state: &WizardState) {
             theme::dim_style(),
         )]));
         f.render_widget(cont, chunks[1]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PROVIDERS;
+
+    #[test]
+    fn wizard_lists_minimax_provider() {
+        let minimax = PROVIDERS.iter().find(|provider| provider.name == "minimax");
+        assert!(
+            minimax.is_some(),
+            "MiniMax should be selectable in wizard provider list"
+        );
+        let minimax = minimax.unwrap();
+        assert_eq!(minimax.env_var, "MINIMAX_API_KEY");
+        assert_eq!(minimax.default_model, "MiniMax-M2.7");
     }
 }


### PR DESCRIPTION
## Summary
- add MiniMax to the `openfang init` provider picker
- add MiniMax to the legacy setup wizard provider list
- expose MiniMax in the quick provider list and cover all three paths with regression tests

## Validation
- `cargo test -p openfang-cli minimax -- --nocapture`
- `cargo clippy -p openfang-cli --all-targets -- -D warnings`

Closes #1079.
