### PR TITLE
fix(feishu): respect region setting for WebSocket endpoint URL

### DIFF
--- a/crates/openfang-api/src/channel_bridge.rs
+++ b/crates/openfang-api/src/channel_bridge.rs
@@ -1458,9 +1458,10 @@ pub async fn start_channel_bridge_with_config(
                     encrypt_key,
                     fs_config.bot_names.clone(),
                 )),
-                FeishuMode::Websocket => Arc::new(FeishuAdapter::new_websocket(
+                FeishuMode::Websocket => Arc::new(FeishuAdapter::new_websocket_with_region(
                     fs_config.app_id.clone(),
                     secret,
+                    region,
                 )),
             };
             adapters.push((adapter, fs_config.default_agent.clone()));

--- a/crates/openfang-channels/src/feishu.rs
+++ b/crates/openfang-channels/src/feishu.rs
@@ -42,8 +42,8 @@ const MAX_MESSAGE_LEN: usize = 4000;
 /// Token refresh buffer — refresh 5 minutes before actual expiry.
 const TOKEN_REFRESH_BUFFER_SECS: u64 = 300;
 
-/// Feishu websocket endpoint discovery API.
-const FEISHU_WS_ENDPOINT_URL: &str = "https://open.feishu.cn/callback/ws/endpoint";
+/// WebSocket endpoint path (appended to the region domain).
+const FEISHU_WS_ENDPOINT_PATH: &str = "/callback/ws/endpoint";
 
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
@@ -269,13 +269,24 @@ impl FeishuAdapter {
     ///
     /// WebSocket mode does not require a public IP or webhook configuration.
     pub fn new_websocket(app_id: String, app_secret: String) -> Self {
+        Self::new_websocket_with_region(app_id, app_secret, FeishuRegion::Cn)
+    }
+
+    /// Create a new Feishu adapter in WebSocket mode with an explicit region.
+    ///
+    /// Use this when the app is registered on Lark international (`open.larksuite.com`).
+    pub fn new_websocket_with_region(
+        app_id: String,
+        app_secret: String,
+        region: FeishuRegion,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             app_id,
             app_secret: Zeroizing::new(app_secret),
             connection_mode: FeishuConnectionMode::WebSocket,
             webhook_port: 0,
-            region: FeishuRegion::Cn,
+            region,
             webhook_path: String::new(),
             verification_token: None,
             encrypt_key: None,
@@ -918,9 +929,10 @@ struct FeishuAdapterClone {
 impl FeishuAdapterClone {
     /// Get WebSocket endpoint from Feishu API.
     async fn get_websocket_endpoint(&self) -> Result<FeishuWsEndpoint, Box<dyn std::error::Error>> {
+        let url = format!("{}{}", self.region.domain(), FEISHU_WS_ENDPOINT_PATH);
         let resp = self
             .client
-            .post(FEISHU_WS_ENDPOINT_URL)
+            .post(&url)
             .json(&serde_json::json!({
                 "AppID": self.app_id,
                 "AppSecret": self.app_secret.as_str(),


### PR DESCRIPTION
Fixes #1081

## Problem

When a user configures the Feishu/Lark channel with `mode = "websocket"` and `region = "lark"` (international), the WebSocket connection fails with:

```
ERROR openfang_channels::feishu: Feishu WebSocket error: Feishu WebSocket endpoint error:
WARN  openfang_channels::feishu: Feishu WebSocket reconnecting in 1s
```

This happens because of two bugs:

1. `FEISHU_WS_ENDPOINT_URL` was hardcoded to `https://open.feishu.cn/callback/ws/endpoint`. Lark international apps register on `open.larksuite.com`, so their credentials are rejected by the Chinese endpoint.

2. `FeishuAdapter::new_websocket()` always set `region = FeishuRegion::Cn`, completely ignoring the `region` field parsed from `config.toml` in `channel_bridge.rs`.

## Solution

- Renamed `FEISHU_WS_ENDPOINT_URL` to `FEISHU_WS_ENDPOINT_PATH` (stores just the path suffix `/callback/ws/endpoint`).
- In `FeishuAdapterClone::get_websocket_endpoint()`, compute the full URL using `self.region.domain()` so Lark international users hit `open.larksuite.com` and Feishu CN users hit `open.feishu.cn`.
- Added `FeishuAdapter::new_websocket_with_region(app_id, app_secret, region)` constructor.
- Updated `channel_bridge.rs` to call `new_websocket_with_region` and pass the parsed region, so the user's `region` config field is now respected in WebSocket mode.

## Testing

The existing unit tests pass. The fix was verified by code inspection: the `FeishuAdapterClone` already had a `region` field that was correctly cloned from the parent adapter — it was just never used in `get_websocket_endpoint` and never set correctly for WebSocket mode.