### PR TITLE
fix: flake.nix nativeBuildInputs for successful build on NixOS.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,11 +22,13 @@
         ...
       }: {
         rust-project.src = lib.sources.cleanSource ./.;
+        rust-project.defaults.perCrate.crane.args.nativeBuildInputs = with pkgs; [
+          perl
+          pkg-config
+        ];
         rust-project.defaults.perCrate.crane.args.buildInputs = with pkgs; [
           clang
           openssl
-          perl
-          pkg-config
         ];
         rust-project.crates.openfang-desktop.crane.args.buildInputs = with pkgs; [
           atk


### PR DESCRIPTION
## Summary

The pull request fixes failing build of OpenFang on NixOS and enables installation on NixOS via flake.nix.

## Changes

Moved `perl` and `pkg-config` to nativeBuildInputs from buildInputs.

## Testing

Does not apply.

## Security

Does not apply.