### PR TITLE
fix(runtime): pass HOME/TMP/TEMP to stdio MCP servers on all platforms

### DIFF
--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -247,6 +247,13 @@ impl McpConnection {
             if let Ok(path) = std::env::var("PATH") {
                 cmd.env("PATH", path);
             }
+            // Some stdio MCP servers launched via node/npx require a usable home
+            // directory even when they do not declare any explicit secret env vars.
+            for var in &["HOME", "TMP", "TEMP"] {
+                if let Ok(val) = std::env::var(var) {
+                    cmd.env(var, val);
+                }
+            }
             // On Windows, npm/node need extra vars
             if cfg!(windows) {
                 for var in &[
@@ -254,9 +261,6 @@ impl McpConnection {
                     "LOCALAPPDATA",
                     "USERPROFILE",
                     "SystemRoot",
-                    "TEMP",
-                    "TMP",
-                    "HOME",
                     "HOMEDRIVE",
                     "HOMEPATH",
                 ] {


### PR DESCRIPTION
## Problem

stdio MCP servers launched via `npx` (Gmail, AgentMail, Exa, and community servers generally) fail or misbehave on Linux and macOS because `HOME`, `TMP`, and `TEMP` are not passed through to the child process. npm, node, and npx need a writable `HOME` for the npm cache and `TMP` for scratch files; without them they error with `EACCES` against `/nonexistent` or fall over silently.

The existing code passes these three variables only inside a `cfg!(windows)` guard, so Linux/macOS hosts running stdio MCP servers via `npx` hit the failure.

## Fix

Move the `HOME`/`TMP`/`TEMP` passthrough above the `cfg!(windows)` guard so it applies on every platform, and remove the now-redundant entries from the Windows-only list.

## Test notes

Verified locally on WSL2 (Ubuntu, rustc 1.95.0) by rebuilding against this branch and confirming three `npx`-backed stdio MCP servers initialize cleanly from a fresh spawn:

- `@gongrzhe/server-gmail-autoauth-mcp` — 19 tools
- `agentmail-mcp` — 11 tools
- `exa-mcp-server` — 3 tools

All three would fail on the parent branch without this patch (npm cache write errors against a non-existent `HOME`).

Windows behavior is unchanged — the same three variables are still passed, just via the universal block instead of the Windows-only block.

## Scope

Pure runtime fix, one file, 10 lines. No API surface changes, no new dependencies, no behavioral change on Windows.