### PR TITLE
fix(kernel): sync all agent.toml fields to DB on restart

### DIFF
--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -1196,7 +1196,11 @@ impl OpenFangKernel {
                                     &toml_str,
                                 ) {
                                     Ok(disk_manifest) => {
-                                        // Compare key fields to detect changes
+                                        // Compare key fields to detect changes.
+                                        // IMPORTANT: keep this list in sync with AgentManifest
+                                        // fields that users may legitimately edit in agent.toml.
+                                        // Missing a field here means changes to it are silently
+                                        // ignored until the agent is deleted and recreated.
                                         let changed = disk_manifest.name != entry.manifest.name
                                             || disk_manifest.description
                                                 != entry.manifest.description
@@ -1214,7 +1218,19 @@ impl OpenFangKernel {
                                                 != entry.manifest.tool_blocklist
                                             || disk_manifest.skills != entry.manifest.skills
                                             || disk_manifest.mcp_servers
-                                                != entry.manifest.mcp_servers;
+                                                != entry.manifest.mcp_servers
+                                            // Fields previously missing from this check (#1087):
+                                            // Only compare workspace when the TOML explicitly sets
+                                            // one, so the kernel-assigned default path in the DB
+                                            // is not overwritten for agents that omit the field.
+                                            || disk_manifest.workspace.as_ref().is_some_and(
+                                                |w| Some(w) != entry.manifest.workspace.as_ref(),
+                                            )
+                                            || disk_manifest.schedule != entry.manifest.schedule
+                                            || disk_manifest.autonomous != entry.manifest.autonomous
+                                            || disk_manifest.resources != entry.manifest.resources
+                                            || disk_manifest.exec_policy
+                                                != entry.manifest.exec_policy;
                                         if changed {
                                             info!(
                                                 agent = %name,

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -67,7 +67,7 @@ impl Default for ModelRoutingConfig {
 }
 
 /// Autonomous agent configuration — guardrails for 24/7 agents.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct AutonomousConfig {
     /// Cron expression for quiet hours (e.g., "0 22 * * *" to "0 6 * * *").
@@ -223,7 +223,7 @@ impl AgentMode {
 }
 
 /// How an agent is scheduled to run.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScheduleMode {
     /// Agent wakes up when a message/event arrives (default).
@@ -245,7 +245,7 @@ fn default_check_interval() -> u64 {
 }
 
 /// Resource limits for an agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ResourceQuota {
     /// Maximum WASM memory in bytes.

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -858,7 +858,7 @@ pub enum ExecSecurityMode {
 }
 
 /// Shell/exec security policy.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ExecPolicy {
     /// Security mode: "deny" blocks all, "allowlist" only allows listed,


### PR DESCRIPTION
Fixes #1087

## Problem

The TOML-vs-DB change detection at boot time only compared a subset of
`AgentManifest` fields (`name`, `description`, `model.*`, `capabilities.tools`,
`tool_allowlist`, `tool_blocklist`, `skills`, `mcp_servers`). Key fields like
`workspace`, `schedule`, `resources`, `autonomous`, and `exec_policy` were
silently skipped, so editing them in `agent.toml` and restarting OpenFang had
no effect — the old values from the SQL database were used instead.

## Solution

- Derive `PartialEq` on `ScheduleMode`, `AutonomousConfig`, `ResourceQuota`,
  and `ExecPolicy` so they can be compared directly.
- Extend the `changed` predicate in the boot-time TOML sync loop to cover all
  the previously missing fields.
- The `workspace` comparison is guarded: if the TOML omits the field (`None`),
  the kernel-assigned default path already in the DB is preserved rather than
  being overwritten. If the TOML explicitly sets a path, that path is compared
  against the DB and an update is triggered when they differ.

## Testing

Manually verified the fix by:
1. Spawning an agent without an explicit `workspace` in its `agent.toml`.
2. Adding `workspace = "/tmp/custom-workspace"` to `agent.toml`.
3. Restarting OpenFang — confirmed the new workspace was applied to the DB and
   used by the agent.
4. Removing the `workspace` line — confirmed restart preserves the previously
   set path rather than reverting to the auto-generated default.