### PR TITLE
feat(media): add audio_base_url override for local OpenAI-compat Whisper (closes #1051)

### DIFF
--- a/crates/openfang-runtime/src/media_understanding.rs
+++ b/crates/openfang-runtime/src/media_understanding.rs
@@ -114,16 +114,54 @@ impl MediaEngine {
 
         let model = default_audio_model(provider);
 
-        // Build API request
+        // Build API request.
+        //
+        // `audio_base_url` (config.media.audio_base_url) overrides the hardcoded
+        // provider URL when set, allowing the same OpenAI-compatible multipart
+        // wire format to be sent to a local Whisper service (speaches,
+        // faster-whisper-server, LM Studio, etc.) instead of the cloud provider.
+        // The Authorization header is still built from the provider's standard
+        // env var (`*_API_KEY`); local services typically accept any non-empty
+        // bearer token. Closes #1051.
         let (api_url, api_key) = match provider {
-            "groq" => (
-                "https://api.groq.com/openai/v1/audio/transcriptions",
-                std::env::var("GROQ_API_KEY").map_err(|_| "GROQ_API_KEY not set")?,
-            ),
-            "openai" => (
-                "https://api.openai.com/v1/audio/transcriptions",
-                std::env::var("OPENAI_API_KEY").map_err(|_| "OPENAI_API_KEY not set")?,
-            ),
+            "groq" => {
+                let url = self
+                    .config
+                    .audio_base_url
+                    .as_deref()
+                    .map(|base| {
+                        format!(
+                            "{}/v1/audio/transcriptions",
+                            base.trim_end_matches('/')
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        "https://api.groq.com/openai/v1/audio/transcriptions".to_string()
+                    });
+                (
+                    url,
+                    std::env::var("GROQ_API_KEY").map_err(|_| "GROQ_API_KEY not set")?,
+                )
+            }
+            "openai" => {
+                let url = self
+                    .config
+                    .audio_base_url
+                    .as_deref()
+                    .map(|base| {
+                        format!(
+                            "{}/v1/audio/transcriptions",
+                            base.trim_end_matches('/')
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        "https://api.openai.com/v1/audio/transcriptions".to_string()
+                    });
+                (
+                    url,
+                    std::env::var("OPENAI_API_KEY").map_err(|_| "OPENAI_API_KEY not set")?,
+                )
+            }
             other => return Err(format!("Unsupported audio provider: {}", other)),
         };
 
@@ -141,7 +179,7 @@ impl MediaEngine {
 
         let client = reqwest::Client::new();
         let resp = client
-            .post(api_url)
+            .post(&api_url)
             .bearer_auth(&api_key)
             .multipart(form)
             .timeout(std::time::Duration::from_secs(60))
@@ -410,6 +448,62 @@ mod tests {
         let engine = MediaEngine::new(config);
         // Semaphore was clamped to 8
         assert!(engine.semaphore.available_permits() <= 8);
+    }
+
+    /// Closes #1051: when `audio_base_url` is set, the URL building logic
+    /// must use the override (with `/v1/audio/transcriptions` appended) and
+    /// strip any trailing slash from the user-supplied base. When unset, the
+    /// hardcoded provider URL is used.
+    #[test]
+    fn test_audio_base_url_override_logic() {
+        // Helper closure mirroring the URL construction in `transcribe_audio`
+        // for both providers, kept in sync intentionally.
+        fn build(provider: &str, base: Option<&str>) -> String {
+            match provider {
+                "groq" => base
+                    .map(|b| format!("{}/v1/audio/transcriptions", b.trim_end_matches('/')))
+                    .unwrap_or_else(|| {
+                        "https://api.groq.com/openai/v1/audio/transcriptions".to_string()
+                    }),
+                "openai" => base
+                    .map(|b| format!("{}/v1/audio/transcriptions", b.trim_end_matches('/')))
+                    .unwrap_or_else(|| {
+                        "https://api.openai.com/v1/audio/transcriptions".to_string()
+                    }),
+                _ => unreachable!(),
+            }
+        }
+
+        // Default: hardcoded provider URLs preserved (backward compatibility).
+        assert_eq!(
+            build("openai", None),
+            "https://api.openai.com/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            build("groq", None),
+            "https://api.groq.com/openai/v1/audio/transcriptions"
+        );
+
+        // Override applied for both providers.
+        assert_eq!(
+            build("openai", Some("http://127.0.0.1:8000")),
+            "http://127.0.0.1:8000/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            build("groq", Some("http://localhost:9000")),
+            "http://localhost:9000/v1/audio/transcriptions"
+        );
+
+        // Trailing slash on the user-supplied base is stripped to avoid
+        // double slashes in the final URL.
+        assert_eq!(
+            build("openai", Some("http://127.0.0.1:8000/")),
+            "http://127.0.0.1:8000/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            build("openai", Some("https://whisper.example.com/")),
+            "https://whisper.example.com/v1/audio/transcriptions"
+        );
     }
 
     #[tokio::test]

--- a/crates/openfang-types/src/media.rs
+++ b/crates/openfang-types/src/media.rs
@@ -75,6 +75,27 @@ pub struct MediaConfig {
     pub image_provider: Option<String>,
     /// Preferred audio transcription provider (auto-detect if None).
     pub audio_provider: Option<String>,
+    /// Optional override for the audio transcription endpoint base URL.
+    ///
+    /// When set, replaces the hardcoded provider URL with
+    /// `<audio_base_url>/v1/audio/transcriptions`. Use this to point to a
+    /// local OpenAI-compat Whisper service (e.g., speaches, faster-whisper-server,
+    /// LM Studio) while keeping the same multipart wire format and the
+    /// `audio_provider` semantics ("openai" or "groq" still selects which
+    /// `*_API_KEY` env var is used for the Authorization header).
+    ///
+    /// Closes <https://github.com/RightNow-AI/openfang/issues/1051>.
+    ///
+    /// Example:
+    /// ```toml
+    /// [media]
+    /// audio_provider = "openai"
+    /// audio_base_url = "http://127.0.0.1:8000"
+    /// # → POST http://127.0.0.1:8000/v1/audio/transcriptions
+    /// #   with Authorization: Bearer $OPENAI_API_KEY (any non-empty string
+    /// #   works for most local OpenAI-compat servers).
+    /// ```
+    pub audio_base_url: Option<String>,
 }
 
 impl Default for MediaConfig {
@@ -86,6 +107,7 @@ impl Default for MediaConfig {
             max_concurrency: 2,
             image_provider: None,
             audio_provider: None,
+            audio_base_url: None,
         }
     }
 }
@@ -359,6 +381,38 @@ mod tests {
         assert!(!config.video_description);
         assert_eq!(config.max_concurrency, 2);
         assert!(config.image_provider.is_none());
+        assert!(config.audio_base_url.is_none());
+    }
+
+    #[test]
+    fn test_media_config_audio_base_url_serde_roundtrip() {
+        let mut config = MediaConfig::default();
+        config.audio_base_url = Some("http://127.0.0.1:8000".to_string());
+        config.audio_provider = Some("openai".to_string());
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: MediaConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.audio_base_url.as_deref(),
+            Some("http://127.0.0.1:8000")
+        );
+        assert_eq!(parsed.audio_provider.as_deref(), Some("openai"));
+    }
+
+    #[test]
+    fn test_media_config_backward_compat_no_audio_base_url() {
+        // Old TOML/JSON without `audio_base_url` must still parse with None,
+        // thanks to #[serde(default)] on the struct.
+        let legacy_json = r#"{
+            "image_description": true,
+            "audio_transcription": true,
+            "video_description": false,
+            "max_concurrency": 2,
+            "image_provider": null,
+            "audio_provider": "openai"
+        }"#;
+        let parsed: MediaConfig = serde_json::from_str(legacy_json).unwrap();
+        assert!(parsed.audio_base_url.is_none());
+        assert_eq!(parsed.audio_provider.as_deref(), Some("openai"));
     }
 
     #[test]


### PR DESCRIPTION
Adds optional `audio_base_url` to `MediaConfig` that overrides the hardcoded provider URLs in `media_understanding::transcribe_audio`, allowing the same OpenAI-compatible multipart wire format to be sent to a local Whisper service (Speaches, faster-whisper-server, LM Studio, etc.).

**Closes #1051.**

## Wire format unchanged

```
POST <audio_base_url>/v1/audio/transcriptions
Authorization: Bearer $<provider>_API_KEY
Content-Type: multipart/form-data
fields: file (binary), model, response_format=text
```

Any OpenAI-compatible Whisper server is drop-in. Local servers usually accept any non-empty bearer string, so `OPENAI_API_KEY=anything` works for auth.

## Configuration

```toml
[media]
audio_provider = "openai"
audio_base_url = "http://127.0.0.1:8000"
# → POST http://127.0.0.1:8000/v1/audio/transcriptions
```

Trailing slash on the user-supplied base is stripped to avoid double-slash URLs.

## Backward compatibility

- `MediaConfig` already uses `#[serde(default)]` → existing configs without `audio_base_url` deserialize as `None` and behave exactly as before (cloud URLs).
- `Default` impl extended; `parakeet-mlx` path untouched; no new deps; no public API breaking changes.

## Tests added

- `test_media_config_default` asserts `audio_base_url.is_none()`.
- `test_media_config_audio_base_url_serde_roundtrip` — set + JSON roundtrip.
- `test_media_config_backward_compat_no_audio_base_url` — legacy JSON parses with the new field as `None`.
- `test_audio_base_url_override_logic` — pure-function test exercising URL building branches (defaults preserved unset, override applied for both providers, trailing-slash strip).

The runtime branch in `transcribe_audio` is a straight `if Some / else default` to minimize the diff.

## Why this matters

Self-hosted / sovereignty-conscious / rate-limited deployments need to route audio transcription to a local Whisper backend while keeping `media_transcribe` and `speech_to_text` working as native tools — without helper scripts, `shell_exec`, or DNS-spoofing tricks. Today the URLs at `media_understanding.rs:118-128` are literal `&'static str`, so neither `OPENAI_BASE_URL` nor `provider_urls` (which the LLM drivers already respect) is read for audio. The same gap existed for embeddings and was addressable via `provider_urls`; this change keeps the pattern symmetric for media at the simplest possible surface area.

## Build & verify

I'm patching this from a NixOS dev environment without `cargo` in `$PATH`. The diff is small and deliberately keeps the existing match-arm structure, so I'm confident it compiles, but I have not run `cargo build / test / clippy` on my end. Reviewer verification is welcome — happy to amend if the URL building helper should be extracted, or if you'd prefer this be wired through `provider_urls.openai_audio` (existing map) instead of a new field. I went with a new field because:

1. `provider_urls` is currently an `LLM-only` concept and conceptually `audio_base_url` matches similar audio-specific config like `audio_provider` already on `MediaConfig`.
2. Discoverability: a top-level `[media] audio_base_url` is easy to document and grep for.

Open to either approach; tell me which you prefer and I'll rework.