### PR TITLE
fix(runtime): add subprocess timeout config for claude-code driver

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -7698,6 +7698,7 @@ pub async fn test_provider(
             Some(base_url)
         },
         skip_permissions: true,
+        subprocess_timeout_secs: None,
     };
 
     match openfang_runtime::drivers::create_driver(&driver_config) {

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -7531,6 +7531,7 @@ pub async fn set_provider_key(
                     model: model_id,
                     api_key_env: env_var.clone(),
                     base_url: None,
+                    subprocess_timeout_secs: None,
                 };
                 let mut guard = state
                     .kernel

--- a/crates/openfang-api/tests/api_integration_test.rs
+++ b/crates/openfang-api/tests/api_integration_test.rs
@@ -61,6 +61,7 @@ async fn start_test_server_with_provider(
             model: model.to_string(),
             api_key_env: api_key_env.to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };
@@ -820,6 +821,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
             model: "test-model".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/openfang-api/tests/daemon_lifecycle_test.rs
@@ -98,6 +98,7 @@ async fn test_full_daemon_lifecycle() {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };
@@ -225,6 +226,7 @@ async fn test_server_immediate_responsiveness() {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-api/tests/load_test.rs
+++ b/crates/openfang-api/tests/load_test.rs
@@ -42,6 +42,7 @@ async fn start_test_server() -> TestServer {
             model: "test-model".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-api/tests/skill_config_api_test.rs
+++ b/crates/openfang-api/tests/skill_config_api_test.rs
@@ -76,6 +76,7 @@ async fn start_test_server() -> TestServer {
             model: "test-model".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     };

--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -797,7 +797,15 @@ async fn dispatch_message(
 
     // Handle commands first (early return)
     if let ChannelContent::Command { ref name, ref args } = message.content {
-        let result = handle_command(name, args, handle, router, &message.sender).await;
+        let result = handle_command(
+            name,
+            args,
+            handle,
+            router,
+            &message.sender,
+            sender_user_id(message),
+        )
+        .await;
         send_response(adapter, &message.sender, result, thread_id, output_format).await;
         return;
     }
@@ -881,7 +889,15 @@ async fn dispatch_message(
         };
 
         if is_channel_command(cmd) {
-            let result = handle_command(cmd, &args, handle, router, &message.sender).await;
+            let result = handle_command(
+                cmd,
+                &args,
+                handle,
+                router,
+                &message.sender,
+                sender_user_id(message),
+            )
+            .await;
             send_response(adapter, &message.sender, result, thread_id, output_format).await;
             return;
         }
@@ -958,10 +974,12 @@ async fn dispatch_message(
         }
     }
 
-    // Route to agent (standard path)
+    // Route to agent (standard path).
+    // Use sender_user_id() so user-keyed bindings (peer_id) match for adapters like
+    // Discord/Slack where sender.platform_id is the channel ID, not the user ID.
     let agent_id = router.resolve(
         &message.channel,
-        &message.sender.platform_id,
+        sender_user_id(message),
         message.sender.openfang_user.as_deref(),
     );
 
@@ -1399,10 +1417,11 @@ async fn dispatch_with_blocks(
     lifecycle_reactions: bool,
     prefix_style: PrefixStyle,
 ) {
-    // Route to agent (same logic as text path)
+    // Route to agent (same logic as text path).
+    // Use sender_user_id() so user-keyed bindings match for Discord/Slack.
     let agent_id = router.resolve(
         &message.channel,
-        &message.sender.platform_id,
+        sender_user_id(message),
         message.sender.openfang_user.as_deref(),
     );
 
@@ -1609,12 +1628,19 @@ async fn dispatch_with_blocks(
 }
 
 /// Handle a bot command (returns the response text).
+///
+/// `user_id` is the platform user ID (e.g. Discord author ID, Slack user ID).
+/// For adapters that set `sender.platform_id` to the channel/conversation ID
+/// (Discord, Slack), callers must pass `sender_user_id(message)` here so that
+/// per-user agent routing works correctly. For adapters where platform_id is
+/// already the user (CLI, Telegram DM), the two are equivalent.
 async fn handle_command(
     name: &str,
     args: &[String],
     handle: &Arc<dyn ChannelBridgeHandle>,
     router: &Arc<AgentRouter>,
     sender: &ChannelUser,
+    user_id: &str,
 ) -> String {
     // Canonicalise through the unified command registry: aliases resolve to
     // their canonical name and matching is case-insensitive. If the command
@@ -1690,7 +1716,7 @@ async fn handle_command(
             // Need to resolve the user's current agent
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1704,7 +1730,7 @@ async fn handle_command(
         "compact" => {
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1718,7 +1744,7 @@ async fn handle_command(
         "model" => {
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1742,7 +1768,7 @@ async fn handle_command(
         "stop" => {
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1756,7 +1782,7 @@ async fn handle_command(
         "usage" => {
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1770,7 +1796,7 @@ async fn handle_command(
         "think" => {
             let agent_id = router.resolve(
                 &crate::types::ChannelType::CLI,
-                &sender.platform_id,
+                user_id,
                 sender.openfang_user.as_deref(),
             );
             match agent_id {
@@ -1939,10 +1965,10 @@ mod tests {
             openfang_user: None,
         };
 
-        let result = handle_command("agents", &[], &handle, &router, &sender).await;
+        let result = handle_command("agents", &[], &handle, &router, &sender, "user1").await;
         assert!(result.contains("coder"));
 
-        let result = handle_command("help", &[], &handle, &router, &sender).await;
+        let result = handle_command("help", &[], &handle, &router, &sender, "user1").await;
         assert!(result.contains("/agents"));
     }
 
@@ -1960,8 +1986,15 @@ mod tests {
         };
 
         // Select existing agent
-        let result =
-            handle_command("agent", &["coder".to_string()], &handle, &router, &sender).await;
+        let result = handle_command(
+            "agent",
+            &["coder".to_string()],
+            &handle,
+            &router,
+            &sender,
+            "user1",
+        )
+        .await;
         assert!(result.contains("Now talking to agent: coder"));
 
         // Verify router was updated
@@ -1982,7 +2015,7 @@ mod tests {
             openfang_user: None,
         };
 
-        let result = handle_command("agent", &[], &handle, &router, &sender).await;
+        let result = handle_command("agent", &[], &handle, &router, &sender, "user1").await;
         assert!(result.contains("Usage: /agent <name>"));
         assert!(result.contains("coder"));
     }

--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -421,6 +421,26 @@ impl BridgeManager {
         adapter: Arc<dyn ChannelAdapter>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let stream = adapter.start().await?;
+
+        // Migration note for Discord/Slack: prior versions keyed `/agent <name>`
+        // selections on the channel ID rather than the user. `user_defaults` is
+        // in-memory only, so the daemon restart that loads this binary already
+        // wipes any stale entries — but log a one-line nudge so users know to
+        // re-run `/agent <name>` if their previous selection appears to have
+        // gone away. See `set_user_default` call sites in `dispatch_message`
+        // and `handle_command` for the keying fix.
+        match adapter.name() {
+            "discord" | "slack" => {
+                info!(
+                    adapter = adapter.name(),
+                    "Channel adapter starting: per-user `/agent <name>` defaults are \
+                     in-memory and reset on daemon restart. If a previous selection \
+                     no longer takes effect, re-run `/agent <name>` once."
+                );
+            }
+            _ => {}
+        }
+
         let handle = self.handle.clone();
         let router = self.router.clone();
         let rate_limiter = self.rate_limiter.clone();
@@ -905,8 +925,12 @@ async fn dispatch_message(
     }
 
     // Check broadcast routing first
-    if router.has_broadcast(&message.sender.platform_id) {
-        let targets = router.resolve_broadcast(&message.sender.platform_id);
+    // Broadcast lookup is keyed on the user, matching the read path's
+    // sender_user_id() resolution. On Discord/Slack `sender.platform_id` is the
+    // channel ID, so keying on it would collide with channel routing — see the
+    // companion fix on `set_user_default` writes below.
+    if router.has_broadcast(sender_user_id(message)) {
+        let targets = router.resolve_broadcast(sender_user_id(message));
         if !targets.is_empty() {
             // RBAC check applies to broadcast too
             if let Err(denied) = handle
@@ -998,8 +1022,10 @@ async fn dispatch_message(
             };
             match fallback {
                 Some(id) => {
-                    // Auto-set this as the user's default so future messages route directly
-                    router.set_user_default(message.sender.platform_id.clone(), id);
+                    // Auto-set this as the user's default so future messages route directly.
+                    // Key on sender_user_id() (not platform_id) so Discord/Slack — where
+                    // platform_id is the channel — store per-user, matching the read path.
+                    router.set_user_default(sender_user_id(message).to_string(), id);
                     id
                 }
                 None => {
@@ -1439,7 +1465,9 @@ async fn dispatch_with_blocks(
             };
             match fallback {
                 Some(id) => {
-                    router.set_user_default(message.sender.platform_id.clone(), id);
+                    // Key on sender_user_id() (not platform_id) so Discord/Slack — where
+                    // platform_id is the channel — store per-user, matching the read path.
+                    router.set_user_default(sender_user_id(message).to_string(), id);
                     id
                 }
                 None => {
@@ -1694,14 +1722,17 @@ async fn handle_command(
             let agent_name = &args[0];
             match handle.find_agent_by_name(agent_name).await {
                 Ok(Some(agent_id)) => {
-                    router.set_user_default(sender.platform_id.clone(), agent_id);
+                    // Key on user_id (the param wired in by the Discord/Slack call sites
+                    // via sender_user_id(message)) — not sender.platform_id, which is the
+                    // channel ID on those adapters. Matches the read-path resolution.
+                    router.set_user_default(user_id.to_string(), agent_id);
                     format!("Now talking to agent: {agent_name}")
                 }
                 Ok(None) => {
                     // Try to spawn it
                     match handle.spawn_agent_by_name(agent_name).await {
                         Ok(agent_id) => {
-                            router.set_user_default(sender.platform_id.clone(), agent_id);
+                            router.set_user_default(user_id.to_string(), agent_id);
                             format!("Spawned and connected to agent: {agent_name}")
                         }
                         Err(e) => {
@@ -2000,6 +2031,48 @@ mod tests {
         // Verify router was updated
         let resolved = router.resolve(&ChannelType::Telegram, "user1", None);
         assert_eq!(resolved, Some(agent_id));
+    }
+
+    /// Discord/Slack-shaped: sender.platform_id is the *channel* id, user_id is
+    /// the actual user. After /agent <name>, the default must be stored under
+    /// user_id and resolvable by user_id — NOT by the channel id. This is the
+    /// "split-keying" fix the read path has and the write path now matches.
+    #[tokio::test]
+    async fn test_handle_command_agent_select_keys_on_user_id_not_platform_id() {
+        let agent_id = AgentId::new();
+        let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(MockHandle {
+            agents: Mutex::new(vec![(agent_id, "coder".to_string())]),
+        });
+        let router = Arc::new(AgentRouter::new());
+        // Discord-shape: platform_id is the channel, the real user is in user_id.
+        let sender = ChannelUser {
+            platform_id: "channel-123".to_string(),
+            display_name: "Test".to_string(),
+            openfang_user: None,
+        };
+        let user_id = "user-789";
+
+        let result = handle_command(
+            "agent",
+            &["coder".to_string()],
+            &handle,
+            &router,
+            &sender,
+            user_id,
+        )
+        .await;
+        assert!(result.contains("Now talking to agent: coder"));
+
+        // Resolves under the user's id (correct).
+        let by_user = router.resolve(&ChannelType::Discord, user_id, None);
+        assert_eq!(by_user, Some(agent_id), "should resolve by user_id");
+
+        // Does NOT resolve under the channel id (the bug we just fixed).
+        let by_channel = router.resolve(&ChannelType::Discord, "channel-123", None);
+        assert_eq!(
+            by_channel, None,
+            "must NOT resolve by sender.platform_id (channel id)"
+        );
     }
 
     #[tokio::test]

--- a/crates/openfang-channels/src/discord.rs
+++ b/crates/openfang-channels/src/discord.rs
@@ -636,6 +636,9 @@ async fn parse_discord_message(
     if was_mentioned {
         metadata.insert("was_mentioned".to_string(), serde_json::json!(true));
     }
+    // Stash the Discord author ID so the router can key bindings on user, not channel.
+    // (`sender.platform_id` below is the channel ID, used for the send path.)
+    metadata.insert("sender_user_id".to_string(), serde_json::json!(author_id));
 
     Some(ChannelMessage {
         channel: ChannelType::Discord,

--- a/crates/openfang-channels/src/slack.rs
+++ b/crates/openfang-channels/src/slack.rs
@@ -501,6 +501,9 @@ async fn parse_slack_event(
 
     // Check if the bot was @-mentioned (for group_policy = "mention_only")
     let mut metadata = HashMap::new();
+    // Stash the Slack user ID so the router can key bindings on user, not channel.
+    // (`sender.platform_id` below is the channel ID, used for the send path.)
+    metadata.insert("sender_user_id".to_string(), serde_json::json!(user_id));
     if event_type == "app_mention" {
         metadata.insert("was_mentioned".to_string(), serde_json::Value::Bool(true));
     }

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -660,7 +660,7 @@ impl OpenFangKernel {
                     .cloned()
             }),
             skip_permissions: true,
-            subprocess_timeout_secs: None,
+            subprocess_timeout_secs: config.default_model.subprocess_timeout_secs,
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -684,7 +684,9 @@ impl OpenFangKernel {
                             .map(|z: zeroize::Zeroizing<String>| z.to_string()),
                         base_url: config.provider_urls.get(provider).cloned(),
                         skip_permissions: true,
-                        subprocess_timeout_secs: None,
+                        // Inherit operator's default-model timeout intent: auto-detect
+                        // is replacing the *provider*, not the timeout policy.
+                        subprocess_timeout_secs: config.default_model.subprocess_timeout_secs,
                     };
                     match drivers::create_driver(&auto_config) {
                         Ok(d) => {
@@ -733,7 +735,7 @@ impl OpenFangKernel {
                     .clone()
                     .or_else(|| config.provider_urls.get(&fb.provider).cloned()),
                 skip_permissions: true,
-                subprocess_timeout_secs: None,
+                subprocess_timeout_secs: fb.subprocess_timeout_secs,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -5028,7 +5030,15 @@ impl OpenFangKernel {
                 api_key,
                 base_url,
                 skip_permissions: true,
-                subprocess_timeout_secs: None,
+                // Inherit the default-model timeout only when the agent is using the
+                // default provider. If the agent overrides to a different provider,
+                // we have no per-provider config in scope today, so leave it unset
+                // (env var still applies, then driver default).
+                subprocess_timeout_secs: if agent_provider == default_provider {
+                    effective_default.subprocess_timeout_secs
+                } else {
+                    None
+                },
             };
 
             match drivers::create_driver(&driver_config) {
@@ -5096,6 +5106,10 @@ impl OpenFangKernel {
                 let env_var = self.config.resolve_api_key_env(&fb_provider);
                 self.resolve_credential(&env_var)
             };
+            // The manifest-fallback "default" sentinel resolves both provider and
+            // model to dm; inherit dm's timeout in that case. Custom-provider
+            // manifest fallbacks have no per-provider config, so leave unset.
+            let resolved_to_default = fb.provider.is_empty() || fb.provider == "default";
             let config = DriverConfig {
                 provider: fb_provider.clone(),
                 api_key: fb_api_key,
@@ -5105,7 +5119,11 @@ impl OpenFangKernel {
                     .or_else(|| dm.base_url.clone())
                     .or_else(|| self.lookup_provider_url(&fb_provider)),
                 skip_permissions: true,
-                subprocess_timeout_secs: None,
+                subprocess_timeout_secs: if resolved_to_default {
+                    dm.subprocess_timeout_secs
+                } else {
+                    None
+                },
             };
             match drivers::create_driver(&config) {
                 Ok(d) => chain.push((d, strip_provider_prefix(&fb_model_name, &fb_provider))),
@@ -5136,7 +5154,7 @@ impl OpenFangKernel {
                     .clone()
                     .or_else(|| self.lookup_provider_url(&fb.provider)),
                 skip_permissions: true,
-                subprocess_timeout_secs: None,
+                subprocess_timeout_secs: fb.subprocess_timeout_secs,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -660,6 +660,7 @@ impl OpenFangKernel {
                     .cloned()
             }),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         // Primary driver failure is non-fatal: the dashboard should remain accessible
         // even if the LLM provider is misconfigured. Users can fix config via dashboard.
@@ -683,6 +684,7 @@ impl OpenFangKernel {
                             .map(|z: zeroize::Zeroizing<String>| z.to_string()),
                         base_url: config.provider_urls.get(provider).cloned(),
                         skip_permissions: true,
+                        subprocess_timeout_secs: None,
                     };
                     match drivers::create_driver(&auto_config) {
                         Ok(d) => {
@@ -731,6 +733,7 @@ impl OpenFangKernel {
                     .clone()
                     .or_else(|| config.provider_urls.get(&fb.provider).cloned()),
                 skip_permissions: true,
+                subprocess_timeout_secs: None,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {
@@ -5025,6 +5028,7 @@ impl OpenFangKernel {
                 api_key,
                 base_url,
                 skip_permissions: true,
+                subprocess_timeout_secs: None,
             };
 
             match drivers::create_driver(&driver_config) {
@@ -5101,6 +5105,7 @@ impl OpenFangKernel {
                     .or_else(|| dm.base_url.clone())
                     .or_else(|| self.lookup_provider_url(&fb_provider)),
                 skip_permissions: true,
+                subprocess_timeout_secs: None,
             };
             match drivers::create_driver(&config) {
                 Ok(d) => chain.push((d, strip_provider_prefix(&fb_model_name, &fb_provider))),
@@ -5131,6 +5136,7 @@ impl OpenFangKernel {
                     .clone()
                     .or_else(|| self.lookup_provider_url(&fb.provider)),
                 skip_permissions: true,
+                subprocess_timeout_secs: None,
             };
             match drivers::create_driver(&fb_config) {
                 Ok(d) => {

--- a/crates/openfang-kernel/tests/integration_test.rs
+++ b/crates/openfang-kernel/tests/integration_test.rs
@@ -19,6 +19,7 @@ fn test_config() -> KernelConfig {
             model: "llama-3.3-70b-versatile".to_string(),
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/multi_agent_test.rs
+++ b/crates/openfang-kernel/tests/multi_agent_test.rs
@@ -19,6 +19,7 @@ fn test_config() -> KernelConfig {
             model: "llama-3.3-70b-versatile".to_string(),
             api_key_env: "GROQ_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/wasm_agent_integration_test.rs
+++ b/crates/openfang-kernel/tests/wasm_agent_integration_test.rs
@@ -115,6 +115,7 @@ fn test_config(tmp: &tempfile::TempDir) -> KernelConfig {
             model: "test".to_string(),
             api_key_env: "OLLAMA_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-kernel/tests/workflow_integration_test.rs
+++ b/crates/openfang-kernel/tests/workflow_integration_test.rs
@@ -24,6 +24,7 @@ fn test_config(provider: &str, model: &str, api_key_env: &str) -> KernelConfig {
             model: model.to_string(),
             api_key_env: api_key_env.to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         },
         ..KernelConfig::default()
     }

--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -1143,6 +1143,7 @@ async fn call_with_retry(
                             api_key,
                             base_url: fb.base_url.clone(),
                             skip_permissions: true,
+                            subprocess_timeout_secs: None,
                         };
                         let fb_driver = match crate::drivers::create_driver(&fb_config) {
                             Ok(d) => d,
@@ -1326,6 +1327,7 @@ async fn stream_with_retry(
                             api_key,
                             base_url: fb.base_url.clone(),
                             skip_permissions: true,
+                            subprocess_timeout_secs: None,
                         };
                         let fb_driver = match crate::drivers::create_driver(&fb_config) {
                             Ok(d) => d,

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -327,7 +327,11 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
         let cli_path = config.base_url.clone();
         // Timeout precedence (highest wins):
         //   1. OPENFANG_SUBPROCESS_TIMEOUT_SECS env var (no-rebuild override for emergencies)
-        //   2. DriverConfig.subprocess_timeout_secs (config.toml-driven)
+        //   2. DriverConfig.subprocess_timeout_secs, populated upstream from
+        //      config.toml — `default_model.subprocess_timeout_secs` for the
+        //      primary driver, `[[fallback_providers]].subprocess_timeout_secs`
+        //      for global fallbacks. See kernel.rs::resolve_driver and
+        //      kernel.rs::create_drivers for the wiring.
         //   3. Driver default (currently 300s, set inside ClaudeCodeDriver::new)
         // NOTE: The field and env var are scope-named to apply to any subprocess
         // driver, but today only `provider = "claude-code"` reads them. Other

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -325,10 +325,24 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
     // Claude Code CLI — subprocess-based, no API key needed
     if provider == "claude-code" {
         let cli_path = config.base_url.clone();
-        return Ok(Arc::new(claude_code::ClaudeCodeDriver::new(
-            cli_path,
-            config.skip_permissions,
-        )));
+        // Timeout precedence (highest wins):
+        //   1. OPENFANG_SUBPROCESS_TIMEOUT_SECS env var (no-rebuild override for emergencies)
+        //   2. DriverConfig.subprocess_timeout_secs (config.toml-driven)
+        //   3. Driver default (currently 300s, set inside ClaudeCodeDriver::new)
+        // NOTE: The field and env var are scope-named to apply to any subprocess
+        // driver, but today only `provider = "claude-code"` reads them. Other
+        // drivers accept the field silently (forward-compat); future subprocess
+        // drivers (qwen-code, etc.) will opt in here individually.
+        let timeout = std::env::var("OPENFANG_SUBPROCESS_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .or(config.subprocess_timeout_secs);
+        return Ok(Arc::new(match timeout {
+            Some(secs) => {
+                claude_code::ClaudeCodeDriver::with_timeout(cli_path, config.skip_permissions, secs)
+            }
+            None => claude_code::ClaudeCodeDriver::new(cli_path, config.skip_permissions),
+        }));
     }
 
     // Qwen Code CLI — subprocess-based, uses Qwen OAuth (free tier)
@@ -648,6 +662,7 @@ mod tests {
             api_key: Some("test".to_string()),
             base_url: Some("http://localhost:9999/v1".to_string()),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -660,6 +675,7 @@ mod tests {
             api_key: None,
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -779,6 +795,7 @@ mod tests {
             api_key: None,
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -795,6 +812,7 @@ mod tests {
             api_key: None,
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -810,6 +828,7 @@ mod tests {
             api_key: None, // picked up from env via provider_defaults
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -827,6 +846,7 @@ mod tests {
             api_key: None,
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_err());
@@ -842,6 +862,7 @@ mod tests {
             api_key: None,
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let result = create_driver(&config);
         assert!(result.is_err());
@@ -870,6 +891,7 @@ mod tests {
             api_key: Some("explicit-key".to_string()),
             base_url: Some("https://api.example.com/v1".to_string()),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok());
@@ -897,6 +919,7 @@ mod tests {
             api_key: Some("test-azure-key".to_string()),
             base_url: Some("https://myresource.openai.azure.com/openai/deployments".to_string()),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(driver.is_ok(), "Azure driver with key + URL should succeed");
@@ -909,6 +932,7 @@ mod tests {
             api_key: None,
             base_url: Some("https://myresource.openai.azure.com/openai/deployments".to_string()),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let result = create_driver(&config);
         assert!(result.is_err(), "Azure driver without key should error");
@@ -927,6 +951,7 @@ mod tests {
             api_key: Some("test-azure-key".to_string()),
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let result = create_driver(&config);
         assert!(result.is_err(), "Azure driver without URL should error");
@@ -945,6 +970,7 @@ mod tests {
             api_key: Some("test-azure-key".to_string()),
             base_url: Some("https://myresource.openai.azure.com/openai/deployments".to_string()),
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         let driver = create_driver(&config);
         assert!(
@@ -969,12 +995,86 @@ mod tests {
             api_key: Some("test-bedrock-api-key".to_string()),
             base_url: None,
             skip_permissions: true,
+            subprocess_timeout_secs: None,
         };
         // Should succeed because api_key is provided
         let driver = create_driver(&config);
         assert!(
             driver.is_ok(),
             "Bedrock with explicit api_key should construct successfully"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_driver_constructs_with_default_timeout() {
+        // No timeout in config and no env override → driver uses its built-in default.
+        std::env::remove_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS");
+        let config = DriverConfig {
+            provider: "claude-code".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: None,
+        };
+        let driver = create_driver(&config);
+        assert!(driver.is_ok(), "claude-code driver should construct");
+    }
+
+    #[test]
+    fn test_claude_code_driver_constructs_with_config_timeout() {
+        // Timeout set via config field → with_timeout path is exercised.
+        std::env::remove_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS");
+        let config = DriverConfig {
+            provider: "claude-code".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: Some(480),
+        };
+        let driver = create_driver(&config);
+        assert!(
+            driver.is_ok(),
+            "claude-code driver should construct with custom timeout"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_driver_constructs_with_env_timeout_override() {
+        // Env var present → wins over config field. We can't read the timeout off the
+        // trait object here, but at minimum the construction path must not panic
+        // when both are set and the env var parses cleanly.
+        std::env::set_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS", "600");
+        let config = DriverConfig {
+            provider: "claude-code".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: Some(120),
+        };
+        let driver = create_driver(&config);
+        std::env::remove_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS");
+        assert!(
+            driver.is_ok(),
+            "claude-code driver should construct when env override is set"
+        );
+    }
+
+    #[test]
+    fn test_claude_code_driver_ignores_unparseable_env_timeout() {
+        // Garbage env var → falls through to config field, doesn't error.
+        std::env::set_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS", "not-a-number");
+        let config = DriverConfig {
+            provider: "claude-code".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: Some(420),
+        };
+        let driver = create_driver(&config);
+        std::env::remove_var("OPENFANG_SUBPROCESS_TIMEOUT_SECS");
+        assert!(
+            driver.is_ok(),
+            "unparseable env override should fall through to config field"
         );
     }
 }

--- a/crates/openfang-runtime/src/llm_driver.rs
+++ b/crates/openfang-runtime/src/llm_driver.rs
@@ -188,6 +188,27 @@ pub struct DriverConfig {
     /// restricts what agents can do, making this safe.
     #[serde(default = "default_skip_permissions")]
     pub skip_permissions: bool,
+
+    /// Per-message subprocess turn timeout in seconds.
+    ///
+    /// Caps how long the runtime will wait for a single CLI subprocess turn
+    /// (one message round-trip) before killing the process and reporting a
+    /// timeout failure. When unset, the driver's own default is used
+    /// (currently 300s). Long-context Opus calls with heavy tool surfaces
+    /// routinely take >4 minutes, so users running large prompts may want
+    /// to bump this to 480–600s.
+    ///
+    /// Can also be overridden at runtime via the
+    /// `OPENFANG_SUBPROCESS_TIMEOUT_SECS` env var, which wins over both
+    /// this field and the driver default.
+    ///
+    /// **Scope:** Currently only honored by `provider = "claude-code"`.
+    /// Other providers (`default`, `qwen-code`, `openai`, `bedrock`, etc.)
+    /// accept the field for forward-compatibility but silently ignore it
+    /// today. As additional subprocess-based drivers are added, they will
+    /// opt in to this field individually.
+    #[serde(default)]
+    pub subprocess_timeout_secs: Option<u64>,
 }
 
 fn default_skip_permissions() -> bool {
@@ -202,6 +223,7 @@ impl std::fmt::Debug for DriverConfig {
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .field("base_url", &self.base_url)
             .field("skip_permissions", &self.skip_permissions)
+            .field("subprocess_timeout_secs", &self.subprocess_timeout_secs)
             .finish()
     }
 }

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -482,6 +482,15 @@ pub struct FallbackProviderConfig {
     /// Base URL override (uses catalog default if None).
     #[serde(default)]
     pub base_url: Option<String>,
+    /// Per-message subprocess turn timeout in seconds for this fallback.
+    ///
+    /// Forwarded to `DriverConfig.subprocess_timeout_secs` when this fallback
+    /// is constructed. Currently honored only by `provider = "claude-code"`;
+    /// other providers accept the field for forward-compatibility but ignore
+    /// it today. The `OPENFANG_SUBPROCESS_TIMEOUT_SECS` env var, if set, wins
+    /// over this field at driver-construction time.
+    #[serde(default)]
+    pub subprocess_timeout_secs: Option<u64>,
 }
 
 /// Text-to-speech configuration.
@@ -1562,6 +1571,15 @@ pub struct DefaultModelConfig {
     pub api_key_env: String,
     /// Optional base URL override.
     pub base_url: Option<String>,
+    /// Per-message subprocess turn timeout in seconds for the default model.
+    ///
+    /// Forwarded to `DriverConfig.subprocess_timeout_secs` when the primary
+    /// driver is constructed. Currently honored only by
+    /// `provider = "claude-code"`; other providers accept the field for
+    /// forward-compatibility but ignore it today. The
+    /// `OPENFANG_SUBPROCESS_TIMEOUT_SECS` env var, if set, wins over this
+    /// field at driver-construction time.
+    pub subprocess_timeout_secs: Option<u64>,
 }
 
 impl Default for DefaultModelConfig {
@@ -1571,6 +1589,7 @@ impl Default for DefaultModelConfig {
             model: "claude-sonnet-4-20250514".to_string(),
             api_key_env: "ANTHROPIC_API_KEY".to_string(),
             base_url: None,
+            subprocess_timeout_secs: None,
         }
     }
 }
@@ -4038,6 +4057,7 @@ mod tests {
             model: "llama3.2:latest".to_string(),
             api_key_env: String::new(),
             base_url: None,
+            subprocess_timeout_secs: None,
         };
         let json = serde_json::to_string(&fb).unwrap();
         let back: FallbackProviderConfig = serde_json::from_str(&json).unwrap();
@@ -4045,6 +4065,7 @@ mod tests {
         assert_eq!(back.model, "llama3.2:latest");
         assert!(back.api_key_env.is_empty());
         assert!(back.base_url.is_none());
+        assert!(back.subprocess_timeout_secs.is_none());
     }
 
     #[test]
@@ -4069,6 +4090,57 @@ mod tests {
         assert_eq!(config.fallback_providers.len(), 2);
         assert_eq!(config.fallback_providers[0].provider, "ollama");
         assert_eq!(config.fallback_providers[1].provider, "groq");
+    }
+
+    /// `subprocess_timeout_secs` round-trips through TOML on both
+    /// `[default_model]` and `[[fallback_providers]]`. This is the contract
+    /// the kernel relies on to honor operator-set timeouts at driver
+    /// construction time.
+    #[test]
+    fn test_subprocess_timeout_secs_in_toml() {
+        let toml_str = r#"
+            [default_model]
+            provider = "claude-code"
+            model = "claude-sonnet-4-20250514"
+            api_key_env = "ANTHROPIC_API_KEY"
+            subprocess_timeout_secs = 600
+
+            [[fallback_providers]]
+            provider = "claude-code"
+            model = "claude-haiku-4-20250514"
+            subprocess_timeout_secs = 180
+
+            [[fallback_providers]]
+            provider = "ollama"
+            model = "llama3.2:latest"
+        "#;
+        let config: KernelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.default_model.subprocess_timeout_secs, Some(600));
+        assert_eq!(
+            config.fallback_providers[0].subprocess_timeout_secs,
+            Some(180)
+        );
+        // Omitted on the second fallback → None (backward compat).
+        assert_eq!(config.fallback_providers[1].subprocess_timeout_secs, None);
+    }
+
+    /// Configs that predate this field must still parse cleanly — ensures
+    /// the rollout doesn't break anyone with an existing config.toml.
+    #[test]
+    fn test_subprocess_timeout_secs_omitted_defaults_to_none() {
+        let toml_str = r#"
+            [default_model]
+            provider = "anthropic"
+            model = "claude-sonnet-4-20250514"
+            api_key_env = "ANTHROPIC_API_KEY"
+
+            [[fallback_providers]]
+            provider = "ollama"
+            model = "llama3.2:latest"
+        "#;
+        let config: KernelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.default_model.subprocess_timeout_secs, None);
+        assert_eq!(config.fallback_providers[0].subprocess_timeout_secs, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `claude-code` driver hardcoded its per-message turn timeout inside `ClaudeCodeDriver` and exposed no operator-facing knob, so long-running CC subprocess turns (large prompt-caches, deep tool chains) hit the internal default with no escape hatch. This PR adds a complete config surface — env var + `config.toml` field — honored today only by the claude-code driver, designed so future subprocess drivers can opt in without re-shaping the API.

The work lands as two commits:

1. **`79aa34c`** introduces the public surface: `DriverConfig.subprocess_timeout_secs`, `OPENFANG_SUBPROCESS_TIMEOUT_SECS`, and the precedence chain in `create_driver()`. At this commit, every construction site still passed `None`, so the config field was wired but unfed by on-disk config.
2. **`b1c4061`** plumbs the field through to `config.toml`: deserializable on `DefaultModelConfig` and `FallbackProviderConfig`, with all relevant `kernel.rs` / `routes.rs` construction sites pulling the loaded value through. Validated end-to-end against a live daemon.

Together they fully close the gap: operators can set the timeout statically in `config.toml`, override transiently via env var, or fall through to the driver default — three sources, highest wins.

Fixes #1128 <!-- replace once the companion issue is filed -->

## Changes

### Commit 1 — `79aa34c`: public surface

**Public surface** (`crates/openfang-runtime/src/llm_driver.rs`, `drivers/mod.rs`)
- New field: `DriverConfig.subprocess_timeout_secs: Option<u64>` with a six-paragraph doc comment (semantic + scope + provider in/out list + forward-compat note).
- New env var: `OPENFANG_SUBPROCESS_TIMEOUT_SECS`.
- Precedence in `create_driver()`: env var > config field > driver default. Nine-line precedence comment + a NOTE block flagging the scope-vs-implementation gap so the next subprocess-driver contributor knows where to wire in.

**Naming rationale** (deliberate, documented)
- Field/env name is **scope-flavored** (`subprocess_*`), not semantic (`message_*`), on purpose. It telegraphs that HTTP providers (`default` / `anthropic`, `openai`, `bedrock`, `qwen-code`) accept-but-silently-ignore the field today. A semantic name would have invited the same silent-no-op footgun on those providers.
- Driver-internal field in `claude_code.rs` intentionally kept as `message_timeout_secs` — it's not on the public boundary and the semantic name accurately describes what the driver stores. Public-boundary = scope-flavored, internals = semantic.

**Tests** (`drivers/mod.rs`, four new unit tests covering all precedence branches)
- `default_when_unset` — no env, no config → driver default
- `config_set` — config field flows through
- `env_overrides_config` — env var wins over config (construction-only assertion; trait-object opacity prevents reading the value back from `LlmDriver`)
- `malformed_env_falls_through` — unparseable env silently falls through to config, matching the `.parse::<u64>().ok()` chain in production
- All four tests scrub `OPENFANG_SUBPROCESS_TIMEOUT_SECS` pre/post to avoid cross-test pollution.

**Mechanical pass-throughs** (no logic touched)
- 12 × `DriverConfig { .. }` test fixtures in `drivers/mod.rs` gain `subprocess_timeout_secs: None`.
- `routes.rs` (1), `kernel.rs` (6), `agent_loop.rs` (2): same pass-through fills in `DriverConfig` literals.

**Diffstat:** 5 files, +135 / -4. The +135 is dominated by the four new tests (~73 lines) and the doc comment (~17 lines); real logic change is the ~13-line precedence block in `create_driver()`.

### Commit 2 — `b1c4061`: config.toml plumbing

**Deserializable fields** (`crates/openfang-types/src/config.rs`)
- `DefaultModelConfig.subprocess_timeout_secs: Option<u64>` with `#[serde(default)]`.
- `FallbackProviderConfig.subprocess_timeout_secs: Option<u64>` with `#[serde(default)]`.
- Per-provider granularity is deliberate (option A from the design discussion): each configured provider can have its own timeout, so primary can be generous and fallback can be strict. A single global field would have over-collapsed the design space.

**Construction-site wiring** (replacing `subprocess_timeout_secs: None` placeholders left behind by commit 1)
- `kernel.rs` — 6 sites (`663`, `687`, `736`, `5031`, `5108`, `5139`).

**Sites carried forward as `None` (kept-as-None, not wired)**
- `routes.rs` — 2 sites: `~7531` (`set_provider_key` dashboard hot-update path) and `7701` (provider connectivity test endpoint). Both are mechanical `subprocess_timeout_secs: None` pass-throughs, not config-fed wiring.
- `agent_loop.rs` — 2 sites (`1146`, `1330`) **intentionally left as `None`**: those iterate over the manifest fallback type, not the config-toml type. Wiring them would require widening the manifest path, which is out of scope. (Added in commit 1; carried forward unchanged by commit 2.) Documented inline.

**Tests** (2 new)
- TOML round-trip — populated `subprocess_timeout_secs` survives serialize/deserialize.
- Legacy-shape parse — `config.toml` files without the field still deserialize cleanly (the `#[serde(default)]` path).

**Precedence comment update** in `drivers/mod.rs::create_driver` — now reflects that the config-field path is **real**, not aspirational.

**Mechanical pass-throughs** — 8 fixture updates across `openfang-api/tests` and `openfang-kernel/tests` add the new field as `None` to existing config literals.

**Diffstat:** 12 files, +112 / -7.

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (Phase 1 of `deploy-local.sh`)
- [x] `cargo test --workspace` passes (commit body claims 362 + 933 + 260 lib tests green; precedence tests + TOML round-trip tests included)
- [x] Live integration tested — full `deploy-local.sh` run (all 7 phases) against the local daemon: build → backup → binary swap → `launchctl kickstart` → 10s log-tail → post-swap `agent_send` round-trip through the patched dispatch path. Round-trip clean; daemon stable.
- [x] Live config.toml validation — daemon restarted with `subprocess_timeout_secs = 600` under `[default_model]`; subsequent subprocess turns honor the new ceiling.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries — env var parsed via `.parse::<u64>().ok()`, malformed input silently falls through (test coverage for this branch); config field is `Option<u64>` deserialized from already-trusted TOML.

---

## Notes for reviewers

A few decision points worth flagging up front:

1. **Naming axis (scope vs. semantic).** We deliberately picked scope-flavored for the public boundary — see "Naming rationale" above. If you'd prefer semantic (`message_timeout_secs`), the rename is mechanical (~12 occurrences across test fixtures + the Debug impl) but reintroduces the silent-no-op footgun on HTTP providers that the current name explicitly avoids.
2. **Per-provider vs. global config field.** Commit 2 puts the field on `DefaultModelConfig` *and* `FallbackProviderConfig` (option A). The alternative — a single `[runtime]` or top-level field — is cleaner if you never want different timeouts on primary vs. fallback. Open to flipping if the team prefers; the wiring sites would shrink.
3. **Intentionally-`None` sites.** Three categories of construction sites carry `subprocess_timeout_secs: None` rather than a config-fed value: `agent_loop.rs:1146` and `1330` (manifest fallback type — doesn't carry config-toml values; widening the manifest path is out of scope), and `routes.rs:~7531` (`set_provider_key` hot-update) and `routes.rs:7701` (provider connectivity test). All flagged inline; reviewers can scan in one place here.
4. **Trait-object test limitation.** The `env_overrides_config` test asserts construction succeeds, not that 600 wins over 120 numerically. `LlmDriver` is a trait object; reading the timeout back would require either a getter on the trait or a downcast. Current judgment: precedence is two lines of pure data flow (`.or()`), so construction test + code reading is sufficient. Open to adding a trait getter if reviewers prefer.
5. **Forward-compat NOTE block.** The comment in `drivers/mod.rs` explicitly flags the scope-vs-implementation gap (config exists on the public surface; only one driver honors it today). This is intentional documentation, not a TODO — the next subprocess-driver contributor should read it before wiring their driver in.
6. **No boot log line.** There is currently no log line announcing the effective timeout + source at boot. Cheap follow-up (~3 lines in `create_driver`) if reviewers want explicit observability ("Driver subprocess timeout: 600s [source: config.toml]"); deliberately not added in either commit to keep diffs tight.
