### PR TITLE
runtime/claude_code: materialize image blocks to tmpfile + extract image_cache module

### DIFF
--- a/crates/openfang-api/src/openai_compat.rs
+++ b/crates/openfang-api/src/openai_compat.rs
@@ -216,7 +216,11 @@ fn convert_messages(oai_messages: &[OaiMessage]) -> Vec<Message> {
                                             .unwrap_or(parts[0])
                                             .to_string();
                                         let data = parts[1].to_string();
-                                        Some(ContentBlock::Image { media_type, data })
+                                        Some(ContentBlock::Image {
+                                            media_type,
+                                            data,
+                                            source_url: None,
+                                        })
                                     } else {
                                         None
                                     }

--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -287,6 +287,7 @@ pub fn resolve_attachments(
                 blocks.push(openfang_types::message::ContentBlock::Image {
                     media_type: content_type,
                     data: b64,
+                    source_url: None,
                 });
             }
             Err(e) => {
@@ -520,6 +521,7 @@ pub async fn get_agent_session(
                                 openfang_types::message::ContentBlock::Image {
                                     media_type,
                                     data,
+                                    ..
                                 } => {
                                     texts.push("[Image]".to_string());
                                     // Persist image to upload dir so it can be

--- a/crates/openfang-channels/src/bridge.rs
+++ b/crates/openfang-channels/src/bridge.rs
@@ -1688,7 +1688,14 @@ async fn download_image_to_blocks(url: &str, caption: Option<&str>) -> Vec<Conte
         }
     }
 
-    blocks.push(ContentBlock::Image { media_type, data });
+    blocks.push(ContentBlock::Image {
+        media_type,
+        data,
+        // Preserve the original CDN/source URL so text-only drivers (e.g.
+        // Claude Code) can reference it, and vision-capable drivers retain
+        // it for diagnostics.
+        source_url: Some(url.to_string()),
+    });
 
     blocks
 }
@@ -2585,6 +2592,7 @@ mod tests {
             ContentBlock::Image {
                 media_type: "image/jpeg".to_string(),
                 data: "base64data".to_string(),
+                source_url: None,
             },
         ];
 
@@ -2607,6 +2615,7 @@ mod tests {
         let blocks = vec![ContentBlock::Image {
             media_type: "image/png".to_string(),
             data: "base64data".to_string(),
+            source_url: None,
         }];
 
         // Default impl sends empty text when no text blocks
@@ -2809,5 +2818,66 @@ mod tests {
             media_type_from_url("https://api.telegram.org/file/bot123/photos/file_42"),
             "image/jpeg"
         );
+    }
+
+    /// Regression test: `download_image_to_blocks` must populate the
+    /// `source_url` field on the resulting `ContentBlock::Image`. Text-only
+    /// drivers (e.g. Claude Code) rely on this URL to reference the image
+    /// without re-uploading bytes; a regression here silently breaks vision
+    /// for those drivers.
+    ///
+    /// Spins up a local TCP listener that serves a stub PNG response so we
+    /// can drive the function end-to-end without external dependencies.
+    #[tokio::test]
+    async fn download_image_to_blocks_populates_source_url() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/test.png");
+
+        // Body is arbitrary — the function trusts the Content-Type header
+        // when it starts with `image/`. PNG signature is included so any
+        // future magic-byte fallback also matches.
+        let body: &[u8] = b"\x89PNG\r\n\x1a\nfakepngbytes";
+        let response_head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            // Drain the request — we don't care what reqwest sent.
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            sock.write_all(response_head.as_bytes()).await.unwrap();
+            sock.write_all(body).await.unwrap();
+            let _ = sock.shutdown().await;
+        });
+
+        let blocks = download_image_to_blocks(&url, Some("hello")).await;
+
+        // Caption first, image second.
+        assert_eq!(blocks.len(), 2, "expected caption + image blocks");
+        match &blocks[0] {
+            ContentBlock::Text { text, .. } => assert_eq!(text, "hello"),
+            other => panic!("expected text caption block, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::Image {
+                source_url,
+                media_type,
+                ..
+            } => {
+                assert_eq!(
+                    source_url.as_deref(),
+                    Some(url.as_str()),
+                    "source_url must round-trip the fetched URL"
+                );
+                assert_eq!(media_type, "image/png");
+            }
+            other => panic!("expected image block, got {other:?}"),
+        }
     }
 }

--- a/crates/openfang-runtime/src/agent_loop.rs
+++ b/crates/openfang-runtime/src/agent_loop.rs
@@ -3602,6 +3602,7 @@ mod tests {
         ContentBlock::Image {
             media_type: "image/png".to_string(),
             data: "aGVsbG8=".to_string(),
+            source_url: None,
         }
     }
 

--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -400,8 +400,31 @@ fn build_conversation_text(messages: &[Message], config: &CompactionConfig) -> S
                             conversation_text
                                 .push_str(&format!("[Tool result ({status}): {preview}]\n\n"));
                         }
-                        ContentBlock::Image { media_type, .. } => {
-                            conversation_text.push_str(&format!("[Image: {media_type}]\n\n"));
+                        ContentBlock::Image {
+                            media_type,
+                            source_url,
+                            ..
+                        } => {
+                            // Preserve the original CDN URL across compaction so the
+                            // outbound Discord path (PR-C) can re-attach the image by
+                            // re-fetching it. Only http(s) URLs are exposed: local
+                            // `file://` tmpfile paths are an internal materialization
+                            // detail and shouldn't leak into compacted summaries that
+                            // may be persisted, logged, or sent across processes.
+                            match source_url.as_deref() {
+                                Some(url)
+                                    if url.starts_with("http://")
+                                        || url.starts_with("https://") =>
+                                {
+                                    conversation_text.push_str(&format!(
+                                        "[Image: {media_type} @ {url}]\n\n"
+                                    ));
+                                }
+                                _ => {
+                                    conversation_text
+                                        .push_str(&format!("[Image: {media_type}]\n\n"));
+                                }
+                            }
                         }
                         ContentBlock::Thinking { .. } => {}
                         ContentBlock::RedactedThinking { .. } => {}
@@ -1285,6 +1308,75 @@ mod tests {
         assert!(text.contains("web_search"));
         assert!(text.contains("Tool result (OK)"));
         assert!(text.contains("[Image: image/png]"));
+    }
+
+    #[test]
+    fn test_build_conversation_text_image_source_url_https() {
+        // https:// CDN URL is exposed post-compaction so the outbound path
+        // can re-fetch the image.
+        let config = CompactionConfig::default();
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: "base64data".to_string(),
+                source_url: Some("https://cdn.discordapp.com/attachments/x/y.png".to_string()),
+            }]),
+        }];
+        let text = build_conversation_text(&messages, &config);
+        assert!(
+            text.contains("[Image: image/png @ https://cdn.discordapp.com/attachments/x/y.png]"),
+            "https source_url should be preserved, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_build_conversation_text_image_source_url_http() {
+        // Plain http (rare but valid) is also exposed.
+        let config = CompactionConfig::default();
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::Image {
+                media_type: "image/jpeg".to_string(),
+                data: "base64data".to_string(),
+                source_url: Some("http://example.com/foo.jpg".to_string()),
+            }]),
+        }];
+        let text = build_conversation_text(&messages, &config);
+        assert!(
+            text.contains("[Image: image/jpeg @ http://example.com/foo.jpg]"),
+            "http source_url should be preserved, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_build_conversation_text_image_source_url_file_falls_back() {
+        // file:// URLs (local tmpfile materialization) MUST NOT leak into
+        // compacted summaries — fall back to the legacy mime-only form.
+        let config = CompactionConfig::default();
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::Image {
+                media_type: "image/png".to_string(),
+                data: "base64data".to_string(),
+                source_url: Some(
+                    "file:///Users/x/.openfang/tmp/images/abc.png".to_string(),
+                ),
+            }]),
+        }];
+        let text = build_conversation_text(&messages, &config);
+        assert!(
+            text.contains("[Image: image/png]"),
+            "file:// source_url should fall back to legacy form, got: {text}"
+        );
+        assert!(
+            !text.contains("file://"),
+            "file:// path must not leak post-compaction, got: {text}"
+        );
+        assert!(
+            !text.contains(".openfang"),
+            "local tmpfile path must not leak post-compaction, got: {text}"
+        );
     }
 
     #[test]

--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -1322,6 +1322,7 @@ mod tests {
                 data: "base64data".to_string(),
                 source_url: Some("https://cdn.discordapp.com/attachments/x/y.png".to_string()),
             }]),
+        ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(
@@ -1341,6 +1342,7 @@ mod tests {
                 data: "base64data".to_string(),
                 source_url: Some("http://example.com/foo.jpg".to_string()),
             }]),
+        ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(
@@ -1363,6 +1365,7 @@ mod tests {
                     "file:///Users/x/.openfang/tmp/images/abc.png".to_string(),
                 ),
             }]),
+        ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(

--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -1273,6 +1273,7 @@ mod tests {
                 content: MessageContent::Blocks(vec![ContentBlock::Image {
                     media_type: "image/png".to_string(),
                     data: "base64data".to_string(),
+                    source_url: None,
                 }]),
                 ..Default::default()
             },

--- a/crates/openfang-runtime/src/compactor.rs
+++ b/crates/openfang-runtime/src/compactor.rs
@@ -416,9 +416,8 @@ fn build_conversation_text(messages: &[Message], config: &CompactionConfig) -> S
                                     if url.starts_with("http://")
                                         || url.starts_with("https://") =>
                                 {
-                                    conversation_text.push_str(&format!(
-                                        "[Image: {media_type} @ {url}]\n\n"
-                                    ));
+                                    conversation_text
+                                        .push_str(&format!("[Image: {media_type} @ {url}]\n\n"));
                                 }
                                 _ => {
                                     conversation_text
@@ -1322,7 +1321,7 @@ mod tests {
                 data: "base64data".to_string(),
                 source_url: Some("https://cdn.discordapp.com/attachments/x/y.png".to_string()),
             }]),
-        ..Default::default()
+            ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(
@@ -1342,7 +1341,7 @@ mod tests {
                 data: "base64data".to_string(),
                 source_url: Some("http://example.com/foo.jpg".to_string()),
             }]),
-        ..Default::default()
+            ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(
@@ -1361,11 +1360,9 @@ mod tests {
             content: MessageContent::Blocks(vec![ContentBlock::Image {
                 media_type: "image/png".to_string(),
                 data: "base64data".to_string(),
-                source_url: Some(
-                    "file:///Users/x/.openfang/tmp/images/abc.png".to_string(),
-                ),
+                source_url: Some("file:///Users/x/.openfang/tmp/images/abc.png".to_string()),
             }]),
-        ..Default::default()
+            ..Default::default()
         }];
         let text = build_conversation_text(&messages, &config);
         assert!(

--- a/crates/openfang-runtime/src/drivers/anthropic.rs
+++ b/crates/openfang-runtime/src/drivers/anthropic.rs
@@ -695,7 +695,7 @@ fn convert_message(msg: &Message) -> ApiMessage {
                     ContentBlock::Text { text, .. } => {
                         Some(ApiContentBlock::Text { text: text.clone() })
                     }
-                    ContentBlock::Image { media_type, data } => Some(ApiContentBlock::Image {
+                    ContentBlock::Image { media_type, data, .. } => Some(ApiContentBlock::Image {
                         source: ApiImageSource {
                             source_type: "base64".to_string(),
                             media_type: media_type.clone(),

--- a/crates/openfang-runtime/src/drivers/anthropic.rs
+++ b/crates/openfang-runtime/src/drivers/anthropic.rs
@@ -695,7 +695,9 @@ fn convert_message(msg: &Message) -> ApiMessage {
                     ContentBlock::Text { text, .. } => {
                         Some(ApiContentBlock::Text { text: text.clone() })
                     }
-                    ContentBlock::Image { media_type, data, .. } => Some(ApiContentBlock::Image {
+                    ContentBlock::Image {
+                        media_type, data, ..
+                    } => Some(ApiContentBlock::Image {
                         source: ApiImageSource {
                             source_type: "base64".to_string(),
                             media_type: media_type.clone(),

--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -118,8 +118,28 @@ fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<PathBuf
         warn!(dir = ?dir, error = %e, "failed to create claude_code image tmp dir");
         return None;
     }
-    if let Err(e) = std::fs::write(&path, &bytes) {
-        warn!(path = ?path, error = %e, "failed to write claude_code image tmpfile");
+    // Atomic publish: write to a unique tmp sibling, then rename into place.
+    // Two concurrent renders of the same image each write their own tmpfile;
+    // the rename(2) is atomic on the same filesystem, so the Read tool never
+    // sees a torn or partially-written file. If the destination already exists
+    // by the time we rename (loser of a race), the rename still succeeds
+    // (POSIX replaces) — and the contents are identical anyway by construction.
+    let tmp_path = dir.join(format!(
+        "{hex}.{pid}.{nanos}.tmp",
+        pid = std::process::id(),
+        nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    if let Err(e) = std::fs::write(&tmp_path, &bytes) {
+        warn!(path = ?tmp_path, error = %e, "failed to write claude_code image tmpfile");
+        return None;
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        warn!(from = ?tmp_path, to = ?path, error = %e, "failed to rename claude_code image tmpfile into place");
+        // Best-effort cleanup of the orphan tmpfile.
+        let _ = std::fs::remove_file(&tmp_path);
         return None;
     }
     Some(path)

--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -8,16 +8,14 @@
 //! Tracks active subprocess PIDs and enforces message timeouts to prevent
 //! hung CLI processes from blocking agents indefinitely.
 
+use crate::image_cache::{image_tmp_dir, materialize_image, spawn_sweep_once};
 use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmDriver, LlmError, StreamEvent};
 use async_trait::async_trait;
-use base64::Engine;
 use dashmap::DashMap;
 use openfang_types::message::{ContentBlock, MessageContent, Role, StopReason, TokenUsage};
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
-use std::sync::Once;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 use tracing::{debug, info, warn};
 
@@ -56,129 +54,10 @@ const SENSITIVE_SUFFIXES: &[&str] = &["_SECRET", "_TOKEN", "_PASSWORD"];
 /// Default subprocess timeout in seconds (5 minutes).
 const DEFAULT_MESSAGE_TIMEOUT_SECS: u64 = 300;
 
-/// TTL for materialized image tmpfiles (24 hours). Files older than this
-/// are swept on driver init.
-const IMAGE_TMP_TTL_SECS: u64 = 24 * 60 * 60;
-
-/// One-shot guard so the TTL sweep only fires once per process.
-static IMAGE_TMP_SWEEP_ONCE: Once = Once::new();
-
-/// Resolve the directory used for materializing image attachments.
-///
-/// Lives under `$HOME/.openfang/tmp/images` so it travels with the OpenFang
-/// install. Falls back to the OS temp dir when `$HOME` isn't set (which
-/// shouldn't happen in our deployed daemon but is handled defensively).
-fn image_tmp_dir() -> PathBuf {
-    if let Ok(home) = std::env::var("HOME") {
-        let mut p = PathBuf::from(home);
-        p.push(".openfang");
-        p.push("tmp");
-        p.push("images");
-        p
-    } else {
-        let mut p = std::env::temp_dir();
-        p.push("openfang-images");
-        p
-    }
-}
-
-/// Map a MIME type to a sensible filename extension.
-fn ext_for_mime(media_type: &str) -> &'static str {
-    match media_type.to_ascii_lowercase().as_str() {
-        "image/png" => "png",
-        "image/jpeg" | "image/jpg" => "jpg",
-        "image/gif" => "gif",
-        "image/webp" => "webp",
-        "image/heic" => "heic",
-        "image/heif" => "heif",
-        "image/bmp" => "bmp",
-        "image/svg+xml" => "svg",
-        _ => "bin",
-    }
-}
-
-/// Decode the base64 image and write it to a content-addressed file under
-/// `dir`. Idempotent: if a file with the same content hash already exists,
-/// the existing path is returned without rewriting. Returns `None` on
-/// decode or I/O failure (caller falls back to the textual placeholder).
-fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<PathBuf> {
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(data.as_bytes())
-        .ok()?;
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let hash = hasher.finalize();
-    let hex: String = hash.iter().take(16).map(|b| format!("{:02x}", b)).collect();
-    let filename = format!("{hex}.{ext}", ext = ext_for_mime(media_type));
-    let path = dir.join(filename);
-    if path.exists() {
-        return Some(path);
-    }
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        warn!(dir = ?dir, error = %e, "failed to create claude_code image tmp dir");
-        return None;
-    }
-    // Atomic publish: write to a unique tmp sibling, then rename into place.
-    // Two concurrent renders of the same image each write their own tmpfile;
-    // the rename(2) is atomic on the same filesystem, so the Read tool never
-    // sees a torn or partially-written file. If the destination already exists
-    // by the time we rename (loser of a race), the rename still succeeds
-    // (POSIX replaces) — and the contents are identical anyway by construction.
-    let tmp_path = dir.join(format!(
-        "{hex}.{pid}.{nanos}.tmp",
-        pid = std::process::id(),
-        nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    ));
-    if let Err(e) = std::fs::write(&tmp_path, &bytes) {
-        warn!(path = ?tmp_path, error = %e, "failed to write claude_code image tmpfile");
-        return None;
-    }
-    if let Err(e) = std::fs::rename(&tmp_path, &path) {
-        warn!(from = ?tmp_path, to = ?path, error = %e, "failed to rename claude_code image tmpfile into place");
-        // Best-effort cleanup of the orphan tmpfile.
-        let _ = std::fs::remove_file(&tmp_path);
-        return None;
-    }
-    Some(path)
-}
-
-/// Delete image tmpfiles older than [`IMAGE_TMP_TTL_SECS`]. Best-effort:
-/// any error is logged at debug and the sweep moves on.
-fn sweep_old_image_tmpfiles(dir: &Path) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(e) => {
-            debug!(dir = ?dir, error = %e, "image tmp sweep: read_dir failed (likely missing dir, fine)");
-            return;
-        }
-    };
-    let now = std::time::SystemTime::now();
-    let ttl = std::time::Duration::from_secs(IMAGE_TMP_TTL_SECS);
-    let mut removed = 0u32;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Ok(meta) = entry.metadata() else { continue };
-        if !meta.is_file() {
-            continue;
-        }
-        let Ok(modified) = meta.modified() else { continue };
-        if let Ok(age) = now.duration_since(modified) {
-            if age > ttl {
-                if let Err(e) = std::fs::remove_file(&path) {
-                    debug!(path = ?path, error = %e, "image tmp sweep: remove failed");
-                } else {
-                    removed += 1;
-                }
-            }
-        }
-    }
-    if removed > 0 {
-        info!(removed, "swept stale claude_code image tmpfiles");
-    }
-}
+// Image materialization helpers (image_tmp_dir, ext_for_mime,
+// materialize_image, sweep_old_image_tmpfiles, TTL constants, sweep guard)
+// live in crate::image_cache so the outbound file-sharing path can reuse
+// the same content-addressed cache without a circular dep on this driver.
 
 /// LLM driver that delegates to the Claude Code CLI.
 pub struct ClaudeCodeDriver {
@@ -207,10 +86,7 @@ impl ClaudeCodeDriver {
         }
 
         // Best-effort sweep of stale image tmpfiles, once per process.
-        IMAGE_TMP_SWEEP_ONCE.call_once(|| {
-            let dir = image_tmp_dir();
-            std::thread::spawn(move || sweep_old_image_tmpfiles(&dir));
-        });
+        spawn_sweep_once();
 
         Self {
             cli_path: cli_path

--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -483,6 +483,14 @@ impl LlmDriver for ClaudeCodeDriver {
             cmd.arg("--model").arg(model);
         }
 
+        // Grant the CLI's Read tool access to our image tmp dir, which lives
+        // outside the agent's workspace cwd. Without --add-dir the CLI would
+        // refuse Read on `$HOME/.openfang/tmp/images/*` (unless
+        // --dangerously-skip-permissions is set) and the materialization would
+        // be a dead-end. Cheap and idempotent — the dir is per-user and
+        // content-addressed.
+        cmd.arg("--add-dir").arg(image_tmp_dir());
+
         Self::apply_env_filter(&mut cmd);
 
         // Inject HOME so the CLI can find its credentials (~/.claude/) when
@@ -678,6 +686,9 @@ impl LlmDriver for ClaudeCodeDriver {
         if let Some(ref model) = model_flag {
             cmd.arg("--model").arg(model);
         }
+
+        // Same image-tmp-dir grant as the non-streaming path; see complete().
+        cmd.arg("--add-dir").arg(image_tmp_dir());
 
         Self::apply_env_filter(&mut cmd);
 

--- a/crates/openfang-runtime/src/drivers/claude_code.rs
+++ b/crates/openfang-runtime/src/drivers/claude_code.rs
@@ -10,10 +10,14 @@
 
 use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmDriver, LlmError, StreamEvent};
 use async_trait::async_trait;
+use base64::Engine;
 use dashmap::DashMap;
 use openfang_types::message::{ContentBlock, MessageContent, Role, StopReason, TokenUsage};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::Once;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 use tracing::{debug, info, warn};
 
@@ -52,6 +56,110 @@ const SENSITIVE_SUFFIXES: &[&str] = &["_SECRET", "_TOKEN", "_PASSWORD"];
 /// Default subprocess timeout in seconds (5 minutes).
 const DEFAULT_MESSAGE_TIMEOUT_SECS: u64 = 300;
 
+/// TTL for materialized image tmpfiles (24 hours). Files older than this
+/// are swept on driver init.
+const IMAGE_TMP_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// One-shot guard so the TTL sweep only fires once per process.
+static IMAGE_TMP_SWEEP_ONCE: Once = Once::new();
+
+/// Resolve the directory used for materializing image attachments.
+///
+/// Lives under `$HOME/.openfang/tmp/images` so it travels with the OpenFang
+/// install. Falls back to the OS temp dir when `$HOME` isn't set (which
+/// shouldn't happen in our deployed daemon but is handled defensively).
+fn image_tmp_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        let mut p = PathBuf::from(home);
+        p.push(".openfang");
+        p.push("tmp");
+        p.push("images");
+        p
+    } else {
+        let mut p = std::env::temp_dir();
+        p.push("openfang-images");
+        p
+    }
+}
+
+/// Map a MIME type to a sensible filename extension.
+fn ext_for_mime(media_type: &str) -> &'static str {
+    match media_type.to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/heic" => "heic",
+        "image/heif" => "heif",
+        "image/bmp" => "bmp",
+        "image/svg+xml" => "svg",
+        _ => "bin",
+    }
+}
+
+/// Decode the base64 image and write it to a content-addressed file under
+/// `dir`. Idempotent: if a file with the same content hash already exists,
+/// the existing path is returned without rewriting. Returns `None` on
+/// decode or I/O failure (caller falls back to the textual placeholder).
+fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<PathBuf> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data.as_bytes())
+        .ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = hasher.finalize();
+    let hex: String = hash.iter().take(16).map(|b| format!("{:02x}", b)).collect();
+    let filename = format!("{hex}.{ext}", ext = ext_for_mime(media_type));
+    let path = dir.join(filename);
+    if path.exists() {
+        return Some(path);
+    }
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        warn!(dir = ?dir, error = %e, "failed to create claude_code image tmp dir");
+        return None;
+    }
+    if let Err(e) = std::fs::write(&path, &bytes) {
+        warn!(path = ?path, error = %e, "failed to write claude_code image tmpfile");
+        return None;
+    }
+    Some(path)
+}
+
+/// Delete image tmpfiles older than [`IMAGE_TMP_TTL_SECS`]. Best-effort:
+/// any error is logged at debug and the sweep moves on.
+fn sweep_old_image_tmpfiles(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            debug!(dir = ?dir, error = %e, "image tmp sweep: read_dir failed (likely missing dir, fine)");
+            return;
+        }
+    };
+    let now = std::time::SystemTime::now();
+    let ttl = std::time::Duration::from_secs(IMAGE_TMP_TTL_SECS);
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(modified) = meta.modified() else { continue };
+        if let Ok(age) = now.duration_since(modified) {
+            if age > ttl {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    debug!(path = ?path, error = %e, "image tmp sweep: remove failed");
+                } else {
+                    removed += 1;
+                }
+            }
+        }
+    }
+    if removed > 0 {
+        info!(removed, "swept stale claude_code image tmpfiles");
+    }
+}
+
 /// LLM driver that delegates to the Claude Code CLI.
 pub struct ClaudeCodeDriver {
     cli_path: String,
@@ -77,6 +185,12 @@ impl ClaudeCodeDriver {
                  OpenFang's own capability/RBAC system enforces access control."
             );
         }
+
+        // Best-effort sweep of stale image tmpfiles, once per process.
+        IMAGE_TMP_SWEEP_ONCE.call_once(|| {
+            let dir = image_tmp_dir();
+            std::thread::spawn(move || sweep_old_image_tmpfiles(&dir));
+        });
 
         Self {
             cli_path: cli_path
@@ -139,6 +253,7 @@ impl ClaudeCodeDriver {
     /// attachment, but it knows the attachment exists and can acknowledge
     /// it coherently instead of confabulating.
     fn build_prompt(request: &CompletionRequest) -> String {
+        let tmp_dir = image_tmp_dir();
         let mut parts = Vec::new();
 
         for msg in &request.messages {
@@ -147,7 +262,7 @@ impl ClaudeCodeDriver {
                 Role::Assistant => "Assistant",
                 Role::System => "System",
             };
-            let rendered = Self::render_content(&msg.content);
+            let rendered = Self::render_content(&msg.content, Some(&tmp_dir));
             if !rendered.is_empty() {
                 parts.push(format!("[{role_label}]\n{rendered}"));
             }
@@ -158,12 +273,17 @@ impl ClaudeCodeDriver {
 
     /// Render message content for the text-only CLI prompt.
     ///
-    /// Text blocks pass through verbatim. Image blocks are rendered as
-    /// `[attachment: <media_type> image, ~N KB — not viewable on this
-    /// provider]` so the model receives a positive signal that an
+    /// Text blocks pass through verbatim. Image blocks are materialized to
+    /// an on-disk tmpfile (when `image_dir` is provided) so the model can
+    /// view them via the CLI's `Read` tool — Claude Code is multimodal and
+    /// will load the file as native image content. We render a directive
+    /// telling the model exactly which path to read, plus the original
+    /// `source_url` (e.g. Discord CDN) when known. If materialization
+    /// fails or `image_dir` is `None` (test path), we fall back to the
+    /// legacy textual placeholder so the model at least knows an
     /// attachment arrived. ToolUse/ToolResult/Thinking are omitted —
     /// the CLI manages its own tool loop.
-    fn render_content(content: &MessageContent) -> String {
+    fn render_content(content: &MessageContent, image_dir: Option<&Path>) -> String {
         match content {
             MessageContent::Text(s) => s.clone(),
             MessageContent::Blocks(blocks) => blocks
@@ -176,11 +296,28 @@ impl ClaudeCodeDriver {
                             Some(text.clone())
                         }
                     }
-                    ContentBlock::Image { media_type, data } => {
+                    ContentBlock::Image {
+                        media_type,
+                        data,
+                        source_url,
+                    } => {
                         // base64 → ~3/4 the length in decoded bytes.
                         let approx_kb = (data.len().saturating_mul(3) / 4) / 1024;
+                        let url_suffix = match source_url {
+                            Some(u) => format!(" (original: {u})"),
+                            None => String::new(),
+                        };
+                        if let Some(dir) = image_dir {
+                            if let Some(path) = materialize_image(media_type, data, dir) {
+                                return Some(format!(
+                                    "[attachment: {media_type} image, ~{approx_kb} KB — view with the Read tool at {path}{url_suffix}]",
+                                    path = path.display()
+                                ));
+                            }
+                        }
+                        // Fallback: at least surface the URL if we have one.
                         Some(format!(
-                            "[attachment: {media_type} image, ~{approx_kb} KB — not viewable on this provider]"
+                            "[attachment: {media_type} image, ~{approx_kb} KB — not viewable on this provider{url_suffix}]"
                         ))
                     }
                     ContentBlock::ToolUse { .. }
@@ -791,6 +928,7 @@ mod tests {
                     ContentBlock::Image {
                         media_type: "image/png".to_string(),
                         data: fake_b64,
+                        source_url: None,
                     },
                 ]),
                 ..Default::default()
@@ -808,9 +946,13 @@ mod tests {
             prompt.contains("[attachment: image/png image"),
             "image rendered as synthetic attachment marker, got: {prompt}"
         );
+        // Either materialized to a tmpfile (preferred) or fell back to
+        // the legacy "not viewable" placeholder. Both are acceptable
+        // outcomes for this test; we just need the marker to be emitted.
         assert!(
-            prompt.contains("not viewable on this provider"),
-            "marker explains the limitation, got: {prompt}"
+            prompt.contains("view with the Read tool at")
+                || prompt.contains("not viewable on this provider"),
+            "marker either points at a tmpfile or explains the limitation, got: {prompt}"
         );
     }
 
@@ -825,6 +967,7 @@ mod tests {
                 content: MessageContent::Blocks(vec![ContentBlock::Image {
                     media_type: "image/jpeg".to_string(),
                     data: "Zm9v".to_string(),
+                    source_url: Some("https://cdn.example/foo.jpg".to_string()),
                 }]),
                 ..Default::default()
             }],

--- a/crates/openfang-runtime/src/drivers/gemini.rs
+++ b/crates/openfang-runtime/src/drivers/gemini.rs
@@ -298,7 +298,7 @@ fn convert_messages(
                                 thought_signature,
                             });
                         }
-                        ContentBlock::Image { media_type, data } => {
+                        ContentBlock::Image { media_type, data, .. } => {
                             parts.push(GeminiPart::InlineData {
                                 inline_data: GeminiInlineData {
                                     mime_type: media_type.clone(),

--- a/crates/openfang-runtime/src/drivers/gemini.rs
+++ b/crates/openfang-runtime/src/drivers/gemini.rs
@@ -298,7 +298,9 @@ fn convert_messages(
                                 thought_signature,
                             });
                         }
-                        ContentBlock::Image { media_type, data, .. } => {
+                        ContentBlock::Image {
+                            media_type, data, ..
+                        } => {
                             parts.push(GeminiPart::InlineData {
                                 inline_data: GeminiInlineData {
                                     mime_type: media_type.clone(),

--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -525,7 +525,7 @@ impl LlmDriver for OpenAIDriver {
                             ContentBlock::Text { text, .. } => {
                                 parts.push(OaiContentPart::Text { text: text.clone() });
                             }
-                            ContentBlock::Image { media_type, data } => {
+                            ContentBlock::Image { media_type, data, .. } => {
                                 parts.push(OaiContentPart::ImageUrl {
                                     image_url: OaiImageUrl {
                                         url: format!("data:{media_type};base64,{data}"),

--- a/crates/openfang-runtime/src/drivers/openai.rs
+++ b/crates/openfang-runtime/src/drivers/openai.rs
@@ -525,7 +525,9 @@ impl LlmDriver for OpenAIDriver {
                             ContentBlock::Text { text, .. } => {
                                 parts.push(OaiContentPart::Text { text: text.clone() });
                             }
-                            ContentBlock::Image { media_type, data, .. } => {
+                            ContentBlock::Image {
+                                media_type, data, ..
+                            } => {
                                 parts.push(OaiContentPart::ImageUrl {
                                     image_url: OaiImageUrl {
                                         url: format!("data:{media_type};base64,{data}"),

--- a/crates/openfang-runtime/src/drivers/vertex.rs
+++ b/crates/openfang-runtime/src/drivers/vertex.rs
@@ -356,7 +356,7 @@ fn convert_messages(
                                 },
                             });
                         }
-                        ContentBlock::Image { media_type, data } => {
+                        ContentBlock::Image { media_type, data, .. } => {
                             parts.push(VertexPart::InlineData {
                                 inline_data: VertexInlineData {
                                     mime_type: media_type.clone(),

--- a/crates/openfang-runtime/src/drivers/vertex.rs
+++ b/crates/openfang-runtime/src/drivers/vertex.rs
@@ -356,7 +356,9 @@ fn convert_messages(
                                 },
                             });
                         }
-                        ContentBlock::Image { media_type, data, .. } => {
+                        ContentBlock::Image {
+                            media_type, data, ..
+                        } => {
                             parts.push(VertexPart::InlineData {
                                 inline_data: VertexInlineData {
                                     mime_type: media_type.clone(),

--- a/crates/openfang-runtime/src/image_cache.rs
+++ b/crates/openfang-runtime/src/image_cache.rs
@@ -81,6 +81,17 @@ pub fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<Pat
     let filename = format!("{hex}.{ext}", ext = ext_for_mime(media_type));
     let path = dir.join(filename);
     if path.exists() {
+        // Refresh mtime on cache hit so the TTL sweep (which gates on
+        // `meta.modified()`) does not GC a tmpfile still being actively
+        // referenced. Without this, a long-running conversation that
+        // outlives `IMAGE_TMP_TTL_SECS` would lose its image bytes
+        // mid-thread, even though the content block is still in scope.
+        // Best-effort: any failure is debug-logged and the cached path
+        // is returned anyway — the worst case is the legacy 24h-GC
+        // behavior we just had.
+        if let Err(e) = touch_mtime(&path) {
+            debug!(path = ?path, error = %e, "failed to refresh image tmpfile mtime");
+        }
         return Some(path);
     }
     if let Err(e) = std::fs::create_dir_all(dir) {
@@ -112,6 +123,16 @@ pub fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<Pat
         return None;
     }
     Some(path)
+}
+
+/// Refresh the mtime of `path` to "now" so it survives the next TTL
+/// sweep. Uses `File::set_modified`, which on Unix calls `futimens(2)`.
+/// Opening read-only is sufficient — `futimens` does not require the fd
+/// to be writable, only that the caller own the file (which we do, since
+/// the daemon writes them).
+fn touch_mtime(path: &Path) -> std::io::Result<()> {
+    let f = std::fs::File::open(path)?;
+    f.set_modified(std::time::SystemTime::now())
 }
 
 /// Delete image tmpfiles older than [`IMAGE_TMP_TTL_SECS`]. Best-effort:
@@ -157,4 +178,88 @@ pub fn spawn_sweep_once() {
         let dir = image_tmp_dir();
         std::thread::spawn(move || sweep_old_image_tmpfiles(&dir));
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use std::time::{Duration, SystemTime};
+
+    /// A 1×1 transparent PNG, base64-encoded. Tiny enough to keep tests fast.
+    const TINY_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+    #[test]
+    fn materialize_image_refreshes_mtime_on_cache_hit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        // First call materializes.
+        let path = materialize_image("image/png", TINY_PNG_B64, dir)
+            .expect("first materialization should succeed");
+        assert!(path.exists());
+
+        // Backdate mtime to ~25 hours ago — past IMAGE_TMP_TTL_SECS.
+        let stale = SystemTime::now() - Duration::from_secs(IMAGE_TMP_TTL_SECS + 3600);
+        let f = std::fs::File::open(&path).unwrap();
+        f.set_modified(stale).unwrap();
+        drop(f);
+        let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        // Second call should hit cache AND refresh mtime.
+        let path2 = materialize_image("image/png", TINY_PNG_B64, dir)
+            .expect("cache hit should return Some");
+        assert_eq!(path, path2);
+        let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert!(
+            mtime_after > mtime_before,
+            "mtime should be refreshed on cache hit (before={mtime_before:?}, after={mtime_after:?})"
+        );
+
+        // And the now-touched file must NOT be GC'd by a sweep that
+        // would have caught the stale mtime.
+        sweep_old_image_tmpfiles(dir);
+        assert!(
+            path.exists(),
+            "refreshed tmpfile should survive the TTL sweep"
+        );
+    }
+
+    #[test]
+    fn sweep_removes_stale_tmpfiles() {
+        // Sanity check that the sweep actually GCs old files — pairs with
+        // the test above to prove the refresh is what saves the file.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let path = materialize_image("image/png", TINY_PNG_B64, dir).unwrap();
+
+        let stale = SystemTime::now() - Duration::from_secs(IMAGE_TMP_TTL_SECS + 3600);
+        let f = std::fs::File::open(&path).unwrap();
+        f.set_modified(stale).unwrap();
+        drop(f);
+
+        sweep_old_image_tmpfiles(dir);
+        assert!(!path.exists(), "stale tmpfile should have been swept");
+    }
+
+    #[test]
+    fn ext_for_mime_known_and_unknown() {
+        assert_eq!(ext_for_mime("image/png"), "png");
+        assert_eq!(ext_for_mime("IMAGE/JPEG"), "jpg");
+        assert_eq!(ext_for_mime("image/webp"), "webp");
+        assert_eq!(ext_for_mime("application/octet-stream"), "bin");
+    }
+
+    #[test]
+    fn materialize_image_rejects_invalid_base64() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(materialize_image("image/png", "!!!not-base64!!!", tmp.path()).is_none());
+    }
+
+    // Force-reference base64 engine to keep imports tidy in case someone
+    // refactors and the const is the only consumer.
+    #[allow(dead_code)]
+    fn _b64_compile_check() {
+        let _ = base64::engine::general_purpose::STANDARD.decode(TINY_PNG_B64);
+    }
 }

--- a/crates/openfang-runtime/src/image_cache.rs
+++ b/crates/openfang-runtime/src/image_cache.rs
@@ -1,0 +1,160 @@
+//! Content-addressed image tmpfile cache.
+//!
+//! Decodes base64 image payloads (the `ContentBlock::Image` shape used by
+//! all LLM drivers) and writes them to a content-addressed file under
+//! `$HOME/.openfang/tmp/images/` so out-of-process consumers — initially
+//! the Claude Code CLI's Read tool, soon the outbound Discord bridge —
+//! can reach the bytes by path.
+//!
+//! Originally lived inside `drivers/claude_code.rs`; lifted here so the
+//! outbound file-sharing path can reuse the same cache without a circular
+//! dep on the driver crate. Behavior is byte-identical to the previous
+//! private implementation.
+//!
+//! Properties:
+//! - **Idempotent.** Filename is the first 64 bits of SHA-256(bytes), so
+//!   re-rendering the same image hits the cache.
+//! - **Atomic publish.** Bytes are written to a unique sibling tmpfile
+//!   then `rename(2)`-d into place; readers never see a torn file.
+//! - **Time-bounded.** A best-effort sweep on first call (per process)
+//!   removes files older than [`IMAGE_TMP_TTL_SECS`].
+
+use base64::Engine;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+use tracing::{debug, info, warn};
+
+/// TTL for materialized image tmpfiles (24 hours). Files older than this
+/// are swept on first use.
+pub const IMAGE_TMP_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// One-shot guard so the TTL sweep only fires once per process.
+static IMAGE_TMP_SWEEP_ONCE: Once = Once::new();
+
+/// Resolve the directory used for materializing image attachments.
+///
+/// Lives under `$HOME/.openfang/tmp/images` so it travels with the OpenFang
+/// install. Falls back to the OS temp dir when `$HOME` isn't set (which
+/// shouldn't happen in our deployed daemon but is handled defensively).
+pub fn image_tmp_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        let mut p = PathBuf::from(home);
+        p.push(".openfang");
+        p.push("tmp");
+        p.push("images");
+        p
+    } else {
+        let mut p = std::env::temp_dir();
+        p.push("openfang-images");
+        p
+    }
+}
+
+/// Map a MIME type to a sensible filename extension.
+pub fn ext_for_mime(media_type: &str) -> &'static str {
+    match media_type.to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/heic" => "heic",
+        "image/heif" => "heif",
+        "image/bmp" => "bmp",
+        "image/svg+xml" => "svg",
+        _ => "bin",
+    }
+}
+
+/// Decode the base64 image and write it to a content-addressed file under
+/// `dir`. Idempotent: if a file with the same content hash already exists,
+/// the existing path is returned without rewriting. Returns `None` on
+/// decode or I/O failure (caller falls back to a textual placeholder).
+pub fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<PathBuf> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data.as_bytes())
+        .ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = hasher.finalize();
+    let hex: String = hash.iter().take(16).map(|b| format!("{:02x}", b)).collect();
+    let filename = format!("{hex}.{ext}", ext = ext_for_mime(media_type));
+    let path = dir.join(filename);
+    if path.exists() {
+        return Some(path);
+    }
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        warn!(dir = ?dir, error = %e, "failed to create openfang image tmp dir");
+        return None;
+    }
+    // Atomic publish: write to a unique tmp sibling, then rename into place.
+    // Two concurrent renders of the same image each write their own tmpfile;
+    // the rename(2) is atomic on the same filesystem, so consumers never see
+    // a torn or partially-written file. If the destination already exists by
+    // the time we rename (loser of a race), the rename still succeeds (POSIX
+    // replaces) — and the contents are identical anyway by construction.
+    let tmp_path = dir.join(format!(
+        "{hex}.{pid}.{nanos}.tmp",
+        pid = std::process::id(),
+        nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    if let Err(e) = std::fs::write(&tmp_path, &bytes) {
+        warn!(path = ?tmp_path, error = %e, "failed to write openfang image tmpfile");
+        return None;
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        warn!(from = ?tmp_path, to = ?path, error = %e, "failed to rename openfang image tmpfile into place");
+        // Best-effort cleanup of the orphan tmpfile.
+        let _ = std::fs::remove_file(&tmp_path);
+        return None;
+    }
+    Some(path)
+}
+
+/// Delete image tmpfiles older than [`IMAGE_TMP_TTL_SECS`]. Best-effort:
+/// any error is logged at debug and the sweep moves on.
+pub fn sweep_old_image_tmpfiles(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            debug!(dir = ?dir, error = %e, "image tmp sweep: read_dir failed (likely missing dir, fine)");
+            return;
+        }
+    };
+    let now = std::time::SystemTime::now();
+    let ttl = std::time::Duration::from_secs(IMAGE_TMP_TTL_SECS);
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(modified) = meta.modified() else { continue };
+        if let Ok(age) = now.duration_since(modified) {
+            if age > ttl {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    debug!(path = ?path, error = %e, "image tmp sweep: remove failed");
+                } else {
+                    removed += 1;
+                }
+            }
+        }
+    }
+    if removed > 0 {
+        info!(removed, "swept stale openfang image tmpfiles");
+    }
+}
+
+/// Spawn the once-per-process TTL sweep in a background thread. Safe to
+/// call from any number of driver inits — the [`Once`] guard ensures only
+/// the first call does work.
+pub fn spawn_sweep_once() {
+    IMAGE_TMP_SWEEP_ONCE.call_once(|| {
+        let dir = image_tmp_dir();
+        std::thread::spawn(move || sweep_old_image_tmpfiles(&dir));
+    });
+}

--- a/crates/openfang-runtime/src/image_cache.rs
+++ b/crates/openfang-runtime/src/image_cache.rs
@@ -34,11 +34,15 @@ static IMAGE_TMP_SWEEP_ONCE: Once = Once::new();
 
 /// Resolve the directory used for materializing image attachments.
 ///
-/// Lives under `$HOME/.openfang/tmp/images` so it travels with the OpenFang
-/// install. Falls back to the OS temp dir when `$HOME` isn't set (which
-/// shouldn't happen in our deployed daemon but is handled defensively).
+/// Lives under `$HOME/.openfang/tmp/images` (or `%USERPROFILE%\.openfang\tmp\images`
+/// on Windows) so it travels with the OpenFang install. Falls back to the OS
+/// temp dir when neither `$HOME` nor `%USERPROFILE%` is set (which shouldn't
+/// happen in our deployed daemon but is handled defensively).
+///
+/// The `HOME` → `USERPROFILE` order matches the convention used elsewhere in
+/// the kernel (see `crates/openfang-runtime/src/drivers/mod.rs`).
 pub fn image_tmp_dir() -> PathBuf {
-    if let Ok(home) = std::env::var("HOME") {
+    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
         let mut p = PathBuf::from(home);
         p.push(".openfang");
         p.push("tmp");

--- a/crates/openfang-runtime/src/image_cache.rs
+++ b/crates/openfang-runtime/src/image_cache.rs
@@ -130,12 +130,13 @@ pub fn materialize_image(media_type: &str, data: &str, dir: &Path) -> Option<Pat
 }
 
 /// Refresh the mtime of `path` to "now" so it survives the next TTL
-/// sweep. Uses `File::set_modified`, which on Unix calls `futimens(2)`.
-/// Opening read-only is sufficient — `futimens` does not require the fd
-/// to be writable, only that the caller own the file (which we do, since
-/// the daemon writes them).
+/// sweep. Uses `File::set_modified`, which calls `futimens(2)` on Unix
+/// and `SetFileTime` on Windows. The handle must be opened with write
+/// access on Windows (NTFS `SetFileTime` requires `FILE_WRITE_ATTRIBUTES`);
+/// Unix `futimens` is happy with a read-only fd as long as the caller owns
+/// the file, but `OpenOptions::write(true)` is correct on both platforms.
 fn touch_mtime(path: &Path) -> std::io::Result<()> {
-    let f = std::fs::File::open(path)?;
+    let f = std::fs::OpenOptions::new().write(true).open(path)?;
     f.set_modified(std::time::SystemTime::now())
 }
 
@@ -158,7 +159,9 @@ pub fn sweep_old_image_tmpfiles(dir: &Path) {
         if !meta.is_file() {
             continue;
         }
-        let Ok(modified) = meta.modified() else { continue };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
         if let Ok(age) = now.duration_since(modified) {
             if age > ttl {
                 if let Err(e) = std::fs::remove_file(&path) {
@@ -205,7 +208,9 @@ mod tests {
 
         // Backdate mtime to ~25 hours ago — past IMAGE_TMP_TTL_SECS.
         let stale = SystemTime::now() - Duration::from_secs(IMAGE_TMP_TTL_SECS + 3600);
-        let f = std::fs::File::open(&path).unwrap();
+        // Open with write access — `File::set_modified` requires a write-capable
+        // handle on Windows (NTFS `SetFileTime` needs `FILE_WRITE_ATTRIBUTES`).
+        let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
         f.set_modified(stale).unwrap();
         drop(f);
         let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
@@ -238,7 +243,8 @@ mod tests {
         let path = materialize_image("image/png", TINY_PNG_B64, dir).unwrap();
 
         let stale = SystemTime::now() - Duration::from_secs(IMAGE_TMP_TTL_SECS + 3600);
-        let f = std::fs::File::open(&path).unwrap();
+        // Open with write access — see note in `materialize_image_refreshes_mtime_on_cache_hit`.
+        let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
         f.set_modified(stale).unwrap();
         drop(f);
 

--- a/crates/openfang-runtime/src/lib.rs
+++ b/crates/openfang-runtime/src/lib.rs
@@ -25,6 +25,7 @@ pub mod embedding;
 pub mod graceful_shutdown;
 pub mod hooks;
 pub mod host_functions;
+pub mod image_cache;
 pub mod image_gen;
 pub mod kernel_handle;
 pub mod link_understanding;

--- a/crates/openfang-types/src/message.rs
+++ b/crates/openfang-types/src/message.rs
@@ -102,6 +102,12 @@ pub enum ContentBlock {
         media_type: String,
         /// Base64-encoded image data.
         data: String,
+        /// Original source URL (e.g. Discord CDN), if the image was
+        /// materialized from a remote attachment. Preserved alongside
+        /// `data` so text-only drivers can reference the URL and
+        /// vision-capable drivers retain it for diagnostics.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_url: Option<String>,
     },
     /// A tool use request from the assistant.
     #[serde(rename = "tool_use")]
@@ -403,6 +409,7 @@ mod tests {
         let block = ContentBlock::Image {
             media_type: "image/png".to_string(),
             data: "base64data".to_string(),
+            source_url: None,
         };
         let json = serde_json::to_value(&block).unwrap();
         assert_eq!(json["type"], "image");
@@ -597,6 +604,7 @@ mod tests {
             ContentBlock::Image {
                 media_type: "image/jpeg".to_string(),
                 data: "base64data".to_string(),
+                source_url: None,
             },
         ];
         let msg = Message::user_with_blocks(blocks);


### PR DESCRIPTION
# PR #1151 — Updated Body (refresh of existing OPEN PR)

**Title (unchanged):** `runtime/claude_code: materialize image blocks to tmpfile + extract image_cache module`

**Base:** `main` (upstream) · **Head:** `feat/runtime-image-cache`

---

## Summary

Makes inbound image `ContentBlock`s viewable by the Claude Code CLI driver, which cannot fetch URLs or read in-memory bytes — it can only `Read` files on disk. Images are now materialized to a content-addressed tmpfile under `$HOME/.openfang/tmp/images/`, the directory is granted to the CLI via `--add-dir`, and the cache is extracted into a sibling module for reuse by outbound channel adapters.

Ten commits, no merge commits. CI runs are pending a fresh push; the prior failures (Windows-test ACL + Format) are addressed by commits 9 and 10 in the list below.

## Validation evidence

End-to-end confirmation captured 2026-05-22 against `local-main`:

- Inbound Discord image (~120 KB JPEG) → adapter emitted `Multipart([Text, Image{url}])` → bridge downloaded and cached to `~/.openfang/tmp/images/<hash>.jpg` → `claude_code` driver rendered the placeholder with the tmpfile path → CLI `Read` returned pixels → model described image contents accurately.
- Full daemon-log signature observed: `dispatch_message Multipart` → `download_image_to_blocks start` → `download_image_to_blocks complete` → `render_content Image` → `render_content materialized image to /tmp/...`.

## Commits

1. **`3525a70` runtime/claude_code: materialize images to tmpfile so the CLI's Read tool can view them**
   Adds tmpfile materialization in the `claude_code` driver. Introduces `ContentBlock::Image::source_url: Option<String>` in `openfang-types` and threads it through every consumer (api, channels/bridge, all four model drivers for pattern-match exhaustiveness, agent_loop, compactor). Field is wired through serde and matches but is not consumed by any driver on this branch — it is the load-bearing schema change for outbound Discord (separate PR). Regression test `bridge::tests::download_image_to_blocks_populates_source_url` asserts `source_url` is populated on the HTTP fetch path.

2. **`e1d694f` fix(runtime/claude_code): atomically publish materialized image tmpfiles**
   Replaces non-atomic `fs::write` with write-tmp + `rename(2)`. Closes a torn-file window where a re-render racing a `Read` could read a partially-written image. Orphan `.tmp` files are reaped by the existing 24h TTL sweep.

3. **`1bc37b1` fix(runtime/claude_code): pass `--add-dir` for materialized image tmpfiles**
   The CLI's `Read` tool refuses paths outside the agent workspace unless `--add-dir`'d. Adds the grant to both streaming and non-streaming command builders. Directory is per-user and content-addressed, so the grant is narrow.

4. **`e772e53` refactor(runtime): extract image_cache module**
   Lifts cache helpers (`image_tmp_dir`, `ext_for_mime`, `materialize_image`, `sweep_old_image_tmpfiles`, `IMAGE_TMP_TTL_SECS`, sweep guard) out of the driver into `crates/openfang-runtime/src/image_cache.rs`. No behavior change — extracted helpers are byte-identical. Module is `pub` so channel adapters can resolve cached paths from base64 image blocks before forwarding them outbound.

5. **`2c19aab` fix(runtime/image_cache): refresh mtime on cache hit**
   The 24h TTL sweep evicts by mtime; without this, a frequently-accessed image could be reaped mid-session. Touches the file on every cache hit so hot entries stay resident.

6. **`4377c4c` fix(runtime/compactor): preserve http(s) source_url across compaction**
   Compactor was stripping `source_url` along with `file://` paths, breaking re-materialization on long sessions for Anthropic/OpenAI drivers (which can refetch URLs). Now only `file://` is stripped; `http(s)://` round-trips through compaction.

7. **`0d4666f` fix(runtime/image_cache): add USERPROFILE fallback in image_tmp_dir for Windows**
   Resolves the Windows-test CI failure on the prior push — `HOME` is unset on Windows runners; `USERPROFILE` is the canonical fallback.

8. **`66fcce1` fix(runtime/compactor): use Default for Message in source_url tests**
   Minor test fixup after `Message` struct gained new required fields elsewhere on `main`.

9. **`d9a7b77` style: cargo fmt --all**
   Mechanical reformat. Picks up rustfmt drift across `compactor.rs` and the four LLM drivers that accumulated through the rebase + Windows-fallback work. No behavior change. Fixes the `Format` CI check.

10. **`2d97731` fix(runtime/image_cache): open tmpfile with write access for set_modified on Windows**
    `File::set_modified` lowers to `SetFileTime` on Windows, which requires `FILE_WRITE_ATTRIBUTES` — a read-only `File::open` returns `ERROR_ACCESS_DENIED`. Switches all three call sites (production `touch_mtime` + two test setups) to `OpenOptions::write(true)`, which is correct on both platforms. Fixes the two Windows-test failures (`sweep_removes_stale_tmpfiles`, `materialize_image_refreshes_mtime_on_cache_hit`) and the equivalent latent bug in production `touch_mtime` that would have silently failed cache-hit mtime refresh on a real Windows daemon.

## Notes for reviewers

- **`source_url` field added but not consumed on this branch.** Wired through every pattern match for exhaustiveness; consumer lives in the outbound-Discord PR (forthcoming, stacks on this one).
- **Scope is runtime + types.** No Discord, no channel-adapter behavior changes (the `bridge.rs` edit only sets the new field on download).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p openfang-channels --lib` clean
- [x] `cargo test -p openfang-runtime --lib` clean (compactor source_url preservation tests included)
- [x] Inbound image via Discord URL → Claude Code driver materializes → CLI `Read` succeeds (end-to-end live repro 2026-05-22, signature captured above)
- [x] `download_image_to_blocks` populates `source_url` on the resulting `ContentBlock::Image` (regression test)
- [ ] CI fresh run pending push — prior Windows-test ACL + Format failures expected to clear with commits 9 and 10 (push landed 2026-05-22, all 11 jobs in flight at body-update time)
