### PR TITLE
fix(chat): support Shift+Enter for multi-line input and proper newline display

### DIFF
--- a/crates/openfang-api/static/index_body.html
+++ b/crates/openfang-api/static/index_body.html
@@ -739,7 +739,7 @@
                   <span class="text-xs" style="color:var(--danger)" x-text="formatRecordingTime()"></span>
                 </div>
                 <textarea id="msg-input" rows="1" :placeholder="recording ? 'Recording... release to send' : 'Message OpenFang... (/ for commands)'"
-                          @keydown.enter.prevent="if(!$event.isComposing && $event.keyCode !== 229 && !$event.shiftKey){if(showModelPicker && filteredModelPicker.length){pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else{sendMessage()}}"
+                          @keydown.enter="if(!$event.isComposing && $event.keyCode !== 229 && !$event.shiftKey){$event.preventDefault();if(showModelPicker && filteredModelPicker.length){pickModel(filteredModelPicker[modelPickerIdx].id)}else if(showSlashMenu && filteredSlashCommands.length){executeSlashCommand(filteredSlashCommands[slashIdx].cmd)}else{sendMessage()}}"
                           @keydown.escape="showSlashMenu = false; showModelPicker = false"
                           @keydown.arrow-up.prevent="if(showModelPicker){modelPickerIdx = Math.max(0, modelPickerIdx - 1)}else if(showSlashMenu){slashIdx = Math.max(0, slashIdx - 1)}"
                           @keydown.arrow-down.prevent="if(showModelPicker){modelPickerIdx = Math.min(filteredModelPicker.length - 1, modelPickerIdx + 1)}else if(showSlashMenu){slashIdx = Math.min(filteredSlashCommands.length - 1, slashIdx + 1)}"

--- a/crates/openfang-api/static/js/app.js
+++ b/crates/openfang-api/static/js/app.js
@@ -18,7 +18,7 @@ if (typeof marked !== 'undefined') {
 function escapeHtml(text) {
   var div = document.createElement('div');
   div.textContent = text || '';
-  return div.innerHTML;
+  return div.innerHTML.replace(/\n/g, '<br>');
 }
 
 function renderMarkdown(text) {


### PR DESCRIPTION

## Summary

Fixes #1141 - Add Shift+Enter to insert new line in chat input

## Changes

- **Web UI textarea**: Modified @keydown.enter handler to only call preventDefault() when Shift is NOT held, allowing Shift+Enter to insert newlines naturally
- **escapeHtml function**: Added .replace(/\n/g, '<br>') to convert newlines to <br> tags so user messages display with proper line breaks in the chat UI

## Testing

- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries (sanitization already exists in sanitize_user_input() / sanitize_text())
