### PR TITLE
Add Directory Authentication and Role Mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Thumbs.db
 
 # Personal deploy scripts
 scripts/deploy-remote.sh
+
+# Stakpak session files
+.stakpak/session*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lber"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
+dependencies = [
+ "bytes",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "ldap3"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fe89f5e7cfb7e4701e3a38ff9f00358e026a9aee940355d88ee9d81e5c7503"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "lber",
+ "log",
+ "native-tls",
+ "nom 7.1.3",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3741,16 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -4000,6 +4049,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "openfang-auth"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ldap3",
+ "log",
+ "native-tls",
+ "openfang-types",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-test",
+ "tracing",
+]
+
+[[package]]
 name = "openfang-channels"
 version = "0.6.8"
 dependencies = [
@@ -4154,6 +4223,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
+ "openfang-auth",
  "openfang-channels",
  "openfang-extensions",
  "openfang-hands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/openfang-types",
     "crates/openfang-memory",
     "crates/openfang-runtime",
+    "crates/openfang-auth",
     "crates/openfang-wire",
     "crates/openfang-api",
     "crates/openfang-kernel",

--- a/crates/openfang-auth/Cargo.toml
+++ b/crates/openfang-auth/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "openfang-auth"
+version = "0.1.0"
+edition = "2021"
+description = "External authentication providers for OpenFang"
+license = "MIT"
+
+[dependencies]
+# Core dependencies
+async-trait = "0.1.80"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.117"
+thiserror = "1.0.59"
+chrono = { version = "0.4.38", features = ["serde"] }
+tokio = { version = "1.38", features = ["sync", "rt-multi-thread", "time"] }
+regex = "1.10.4"
+
+# LDAP support
+ldap3 = "0.12.1"
+native-tls = "0.2.12"
+tokio-native-tls = "0.3.1"
+
+# OpenFang types
+openfang-types = { path = "../openfang-types" }
+
+# Logging
+tracing = "0.1.40"
+log = "0.4.21"
+
+[dev-dependencies]
+tokio-test = "0.4.4"
+
+[features]
+default = []
+ldap = []  # Enable LDAP provider (enabled by default)

--- a/crates/openfang-auth/src/lib.rs
+++ b/crates/openfang-auth/src/lib.rs
@@ -1,0 +1,189 @@
+//! External authentication provider trait and types.
+//!
+//! This module defines the trait interface for external directory authentication
+//! providers (LDAP, SAML, OIDC) and common types used across all providers.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use thiserror::Error;
+
+use openfang_types::config::ExternalAuthConfig;
+use openfang_types::agent::UserId;
+
+/// Authentication credentials for external directory providers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthCredentials {
+    /// Username or email for authentication.
+    pub username: String,
+    /// Password for authentication.
+    pub password: String,
+    /// Optional additional context (e.g., IP address, user agent).
+    #[serde(default)]
+    pub context: HashMap<String, String>,
+}
+
+/// Result of a successful authentication.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthResult {
+    /// OpenFang user ID (auto-generated or from directory).
+    pub user_id: UserId,
+    /// Assigned role based on directory group membership.
+    pub role: String,
+    /// User profile attributes from directory.
+    pub attributes: serde_json::Value,
+    /// External authentication provider name.
+    pub provider: String,
+    /// Last sync timestamp.
+    pub last_sync: chrono::DateTime<chrono::Utc>,
+}
+
+/// Errors that can occur during authentication.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("Configuration error: {0}")]
+    ConfigurationError(String),
+
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+
+    #[error("User not found in directory")]
+    UserNotFound,
+
+    #[error("Token expired or invalid")]
+    TokenExpired,
+
+    #[error("Role mapping failed: {0}")]
+    RoleMappingError(String),
+
+    #[error("Group sync failed: {0}")]
+    GroupSyncError(String),
+
+    #[error("Not implemented: {0}")]
+    NotImplemented(String),
+
+    #[error("Internal error: {0}")]
+    InternalError(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Trait for external directory authentication providers.
+///
+/// All directory providers (LDAP, SAML, OIDC) must implement this trait
+/// to integrate with OpenFang's RBAC system.
+#[async_trait]
+pub trait ExternalAuthProviderTrait: Send + Sync {
+    /// Authenticate user and return identity.
+    ///
+    /// # Arguments
+    /// * `credentials` - Username and password
+    ///
+    /// # Returns
+    /// * `Ok(AuthResult)` - User authenticated successfully with profile data
+    /// * `Err(AuthError)` - Authentication failed
+    async fn authenticate(&self, credentials: &AuthCredentials) -> Result<AuthResult, AuthError>;
+
+    /// Sync users from directory (for batch provisioning).
+    ///
+    /// # Returns
+    /// * `Ok(Vec<AuthResult>)` - List of users synced from directory
+    /// * `Err(AuthError)` - Sync failed
+    async fn sync_users(&self) -> Result<Vec<AuthResult>, AuthError>;
+
+    /// Get user by external ID.
+    ///
+    /// # Arguments
+    /// * `external_id` - User identifier from directory (e.g., sAMAccountName)
+    ///
+    /// # Returns
+    /// * `Ok(Some(AuthResult))` - User found
+    /// * `Ok(None)` - User not found
+    /// * `Err(AuthError)` - Error occurred
+    async fn get_user_by_external_id(&self, external_id: &str) -> Result<Option<AuthResult>, AuthError>;
+
+    /// Refresh user's group membership and role.
+    ///
+    /// # Arguments
+    /// * `user_id` - OpenFang user ID
+    ///
+    /// # Returns
+    /// * `Ok(AuthResult)` - User refreshed with updated groups/role
+    /// * `Err(AuthError)` - Refresh failed
+    async fn refresh_user(&self, user_id: UserId) -> Result<AuthResult, AuthError>;
+
+    /// Validate session/token.
+    ///
+    /// # Arguments
+    /// * `session_token` - Session token to validate
+    ///
+    /// # Returns
+    /// * `Ok(Some(UserId))` - Token valid, returns user ID
+    /// * `Ok(None)` - Token invalid or expired
+    /// * `Err(AuthError)` - Error occurred
+    async fn validate_session(&self, session_token: &str) -> Result<Option<UserId>, AuthError>;
+
+    /// Get provider type (e.g., "ldap", "saml", "oidc").
+    fn provider_type(&self) -> &str;
+
+    /// Get provider name (human-readable).
+    fn provider_name(&self) -> &str;
+}
+
+/// Factory function to create authentication providers from configuration.
+pub fn create_provider(config: ExternalAuthConfig) -> Result<Box<dyn ExternalAuthProviderTrait>, AuthError> {
+    match config.provider_type.as_str() {
+        "ldap" => {
+            #[cfg(feature = "ldap")]
+            {
+                use crate::providers::ldap::LdapAuthProvider;
+                Ok(Box::new(LdapAuthProvider::new(config)?))
+            }
+            #[cfg(not(feature = "ldap"))]
+            Err(AuthError::ConfigurationError(
+                "LDAP provider not compiled in. Enable 'ldap' feature.".into(),
+            ))
+        }
+        "saml" => Err(AuthError::NotImplemented(
+            "SAML provider not yet implemented".into(),
+        )),
+        "oidc" => Err(AuthError::NotImplemented(
+            "OIDC provider not yet implemented".into(),
+        )),
+        _ => Err(AuthError::ConfigurationError(format!(
+            "Unknown provider type: {}",
+            config.provider_type
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_error_display() {
+        let err = AuthError::AuthenticationFailed("Invalid credentials".into());
+        assert_eq!(
+            format!("{}", err),
+            "Authentication failed: Invalid credentials"
+        );
+    }
+
+    #[test]
+    fn test_auth_credentials_serialization() {
+        let creds = AuthCredentials {
+            username: "testuser".to_string(),
+            password: "testpass".to_string(),
+            context: HashMap::new(),
+        };
+
+        let json = serde_json::to_string(&creds).unwrap();
+        assert!(json.contains("testuser"));
+        assert!(json.contains("testpass"));
+    }
+}

--- a/crates/openfang-auth/src/providers/ldap.rs
+++ b/crates/openfang-auth/src/providers/ldap.rs
@@ -1,0 +1,614 @@
+//! LDAP Authentication Provider Implementation
+//!
+//! This module provides LDAP/Active Directory authentication support for OpenFang.
+//! It implements the `ExternalAuthProviderTrait` to enable:
+//! - User authentication against LDAP directory
+//! - Group membership resolution
+//! - Automatic user provisioning based on directory groups
+//! - Role mapping from LDAP groups to OpenFang RBAC roles
+//!
+//! # Security Features
+//! - LDAPS (LDAP over SSL/TLS) support with certificate validation
+//! - Self-signed certificate support via CA certificate path configuration
+//! - Credential separation (bind DN/password stored in environment/vault)
+//! - Connection timeout enforcement
+//! - StartTLS support as alternative to LDAPS
+//!
+//! # Configuration Example
+//! ```toml
+//! [[external_auth_providers]]
+//! type = "ldap"
+//! name = "active-directory"
+//! uri = "ldaps://dc01.example.com:636"
+//! bind_dn = "CN=Service Account,OU=Service Accounts,DC=example,DC=com"
+//! bind_password_env = "LDAP_BIND_PASSWORD"
+//! base_dn = "DC=example,DC=com"
+//!
+//! [external_auth_providers.attribute_mapping]
+//! user_id_attr = "sAMAccountName"
+//! name_attr = "displayName"
+//! email_attr = "mail"
+//! group_attr = "memberOf"
+//!
+//! [external_auth_providers.role_mappings]
+//! { group_pattern = "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com", role = "admin" }
+//! ```
+
+use std::collections::HashSet;
+use std::time::Duration;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use native_tls::{Certificate, TlsConnector};
+use regex::Regex;
+use tokio_native_tls::{native_tls, TlsConnectorExt};
+
+use crate::auth::{ExternalAuthProviderTrait, AuthCredentials, AuthResult, AuthError};
+use openfang_types::config::ExternalAuthConfig;
+use openfang_types::agent::UserId;
+
+/// LDAP Authentication Provider
+///
+/// Handles authentication against LDAP/Active Directory servers with support for:
+/// - LDAPS (port 636) and StartTLS
+/// - Self-signed certificate validation
+/// - Group membership resolution
+/// - Dynamic user provisioning
+/// - Role mapping from directory groups
+#[derive(Clone)]
+pub struct LdapAuthProvider {
+    /// Configuration for this LDAP provider
+    config: Arc<ExternalAuthConfig>,
+    /// Regex patterns for role mapping (pre-compiled for performance)
+    role_patterns: Vec<RoleMappingRule>,
+    /// Cache for authenticated users (in-memory, short-lived)
+    user_cache: Arc<tokio::sync::RwLock<HashSet<UserId>>>,
+}
+
+/// Role mapping rule combining regex pattern matching with role assignment
+struct RoleMappingRule {
+    /// Compiled regex pattern for group DN matching
+    pattern: Regex,
+    /// OpenFang role to assign when pattern matches
+    role: String,
+}
+
+impl LdapAuthProvider {
+    /// Create a new LDAP authentication provider from configuration
+    ///
+    /// # Arguments
+    /// * `config` - LDAP provider configuration
+    ///
+    /// # Returns
+    /// * `Ok(Self)` - Provider initialized successfully
+    /// * `Err(AuthError)` - Configuration or setup failure
+    pub fn new(config: ExternalAuthConfig) -> Result<Self, AuthError> {
+        // Compile role mapping patterns
+        let role_patterns = config
+            .role_mappings
+            .iter()
+            .map(|mapping| {
+                let pattern = mapping.group_pattern.replace('.', r"\.").replace('*', ".*");
+                Regex::new(&format!("^{}$", pattern))
+                    .map(|regex| RoleMappingRule {
+                        pattern: regex,
+                        role: mapping.role.clone(),
+                    })
+                    .map_err(|e| AuthError::InternalError(e.into()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let user_cache = Arc::new(tokio::sync::RwLock::new(HashSet::new()));
+
+        Ok(Self {
+            config: Arc::new(config),
+            role_patterns,
+            user_cache,
+        })
+    }
+
+    /// Parse the bind password from environment variable
+    fn get_bind_password(&self) -> Result<String, AuthError> {
+        self.config
+            .bind_password_env
+            .as_ref()
+            .and_then(|env_var| std::env::var(env_var).ok())
+            .ok_or_else(|| AuthError::ConfigurationError("LDAP_BIND_PASSWORD not set".into()))
+    }
+
+    /// Build TLS connector with custom CA certificate support
+    fn build_tls_connector(&self) -> Result<TlsConnector, AuthError> {
+        let mut builder = native_tls::TlsConnector::builder();
+
+        // Load CA certificate if specified (for self-signed server certs)
+        if let Some(ca_cert_path) = &self.config.connection.ca_cert_path {
+            let ca_cert_data = std::fs::read(ca_cert_path)
+                .map_err(|e| AuthError::ConfigurationError(format!("Failed to read CA cert: {}", e)))?;
+            
+            let cert = Certificate::from_pem(&ca_cert_data)
+                .map_err(|e| AuthError::ConfigurationError(format!("Invalid CA certificate: {}", e)))?;
+            
+            builder.add_root_certificate(cert);
+        }
+
+        // Configure certificate verification
+        if self.config.connection.disable_tls_verify.unwrap_or(false) {
+            warn!("WARNING: TLS certificate verification disabled for LDAP provider '{}'!", 
+                  self.config.name);
+            builder.danger_accept_invalid_certs(true);
+        }
+
+        builder.build()
+            .map_err(|e| AuthError::ConfigurationError(format!("Failed to build TLS connector: {}", e)))
+    }
+
+    /// Create LDAP connection with TLS support
+    async fn create_ldap_connection(&self) -> Result<ldap3::LdapConnAsync, AuthError> {
+        let tls_connector = self.build_tls_connector()?;
+        
+        let url = self.config.uri.as_str();
+        
+        // Parse URL to determine connection type
+        let (connector, url) = if url.starts_with("ldaps://") {
+            // Direct LDAPS connection
+            (Some(tls_connector), url.to_string())
+        } else if self.config.connection.start_tls.unwrap_or(false) {
+            // Clear text LDAP with StartTLS upgrade
+            (Some(tls_connector), format!("ldap://{}", &url["ldap://".len()..]))
+        } else {
+            // Plain LDAP (not recommended for production)
+            (None, url.to_string())
+        };
+
+        let settings = ldap3::LdapConnSettings::new()
+            .set_conn_timeout(Duration::from_secs(self.config.connection.timeout_secs))
+            .set_starttls(self.config.connection.start_tls.unwrap_or(false));
+
+        let (conn, mut ldap) = if let Some(tls) = connector {
+            settings
+                .set_connector(tls)
+                .from_url(&url)
+                .await
+                .map_err(|e| AuthError::ConnectionError(format!("LDAP connection failed: {}", e)))?
+        } else {
+            ldap3::LdapConnAsync::from_url(&url)
+                .await
+                .map_err(|e| AuthError::ConnectionError(format!("LDAP connection failed: {}", e)))?
+        };
+
+        ldap3::drive!(conn);
+        Ok(ldap)
+    }
+
+    /// Authenticate user with credentials
+    async fn authenticate_user(&self, username: &str, password: &str) -> Result<ldap3::Entry, AuthError> {
+        // Attempt direct bind with user DN
+        let bind_dn = self.build_user_dn(username)?;
+        
+        let mut ldap = self.create_ldap_connection().await?;
+        
+        // Bind as user
+        ldap.bind(&bind_dn, password)
+            .await
+            .map_err(|e| AuthError::AuthenticationFailed(format!("LDAP bind failed: {}", e)))?
+            .success()
+            .map_err(|e| AuthError::AuthenticationFailed(format!("Bind rejected: {}", e)))?;
+
+        // Search for user entry to get full profile
+        let user_filter = self.config.attribute_mapping.user_filter
+            .as_ref()
+            .map(|f| f.replace("{username}", username))
+            .unwrap_or_else(|| format!("(&(objectClass=user)(sAMAccountName={}))", username));
+
+        let search_base = &self.config.base_dn;
+        
+        let attrs: Vec<String> = vec![
+            self.config.attribute_mapping.user_id_attr.clone(),
+            self.config.attribute_mapping.name_attr.clone(),
+            self.config.attribute_mapping.email_attr.clone(),
+            self.config.attribute_mapping.group_attr.clone(),
+        ];
+
+        let (mut search_results, result) = ldap
+            .search(search_base, ldap3::Scope::Subtree, &user_filter, attrs)
+            .await
+            .map_err(|e| AuthError::InternalError(e.into()))?
+            .success()
+            .map_err(|e| AuthError::AuthenticationFailed(format!("Search failed: {}", e)))?;
+
+        // Get first result (should be only user entry)
+        let entry = search_results
+            .pop()
+            .ok_or_else(|| AuthError::AuthenticationFailed("User not found in directory".into()))?;
+
+        Ok(entry)
+    }
+
+    /// Build user's DN from username and configuration
+    fn build_user_dn(&self, username: &str) -> Result<String, AuthError> {
+        // Check if custom user_dn_template is configured
+        if let Some(template) = &self.config.attribute_mapping.user_dn_template {
+            let dn = template.replace("{username}", username)
+                .replace("{user_id}", username);
+            Ok(dn)
+        } else {
+            // Default: assume username is the sAMAccountName and build standard AD DN
+            Ok(format!(
+                "CN={},{}",
+                username,
+                self.config.base_dn
+            ))
+        }
+    }
+
+    /// Extract user attributes from LDAP entry
+    fn extract_user_attributes(&self, entry: &ldap3::Entry) -> Result<serde_json::Value, AuthError> {
+        let mut attrs = serde_json::Map::new();
+
+        // Extract user ID
+        if let Some(user_id_attr) = entry.get_first_value_str(&self.config.attribute_mapping.user_id_attr) {
+            attrs.insert("user_id".to_string(), serde_json::Value::String(user_id_attr));
+        }
+
+        // Extract display name
+        if let Some(name_attr) = entry.get_first_value_str(&self.config.attribute_mapping.name_attr) {
+            attrs.insert("name".to_string(), serde_json::Value::String(name_attr));
+        }
+
+        // Extract email
+        if let Some(email_attr) = entry.get_first_value_str(&self.config.attribute_mapping.email_attr) {
+            attrs.insert("email".to_string(), serde_json::Value::String(email_attr));
+        }
+
+        // Extract groups
+        if let Some(groups_val) = self.extract_groups(entry)? {
+            attrs.insert("groups".to_string(), serde_json::Value::Array(groups_val));
+        }
+
+        Ok(serde_json::Value::Object(attrs))
+    }
+
+    /// Extract group membership from LDAP entry
+    fn extract_groups(&self, entry: &ldap3::Entry) -> Result<Option<Vec<serde_json::Value>>, AuthError> {
+        let group_attr_name = &self.config.attribute_mapping.group_attr;
+        
+        // Try to get group values
+        let groups = entry.get_all_values(group_attr_name);
+        
+        if groups.is_empty() {
+            return Ok(None);
+        }
+
+        // Extract group DNs
+        let group_dns: Vec<String> = groups.iter()
+            .filter_map(|g| g.as_str())
+            .map(|s| s.to_string())
+            .collect();
+
+        Ok(Some(group_dns.into_iter()
+            .map(|g| serde_json::Value::String(g))
+            .collect()))
+    }
+
+    /// Map LDAP groups to OpenFang roles
+    fn map_groups_to_roles(&self, groups: &[String]) -> String {
+        let mut highest_role = None;
+        let mut highest_level = 0;
+
+        for group_dn in groups {
+            for rule in &self.role_patterns {
+                if rule.pattern.is_match(group_dn) {
+                    // Get role level (higher = more privileged)
+                    let level = Self::get_role_level(&rule.role);
+                    if level > highest_level {
+                        highest_level = level;
+                        highest_role = Some(rule.role.clone());
+                    }
+                }
+            }
+        }
+
+        highest_role.unwrap_or_else(|| "viewer".to_string())
+    }
+
+    /// Get numeric level for role (for comparison)
+    fn get_role_level(role: &str) -> u8 {
+        match role {
+            "owner" => 4,
+            "admin" => 3,
+            "user" => 2,
+            _ => 1, // viewer or unknown
+        }
+    }
+
+    /// Sync all users from directory (for batch provisioning)
+    async fn sync_all_users(&self) -> Result<Vec<AuthResult>, AuthError> {
+        let mut ldap = self.create_ldap_connection().await?;
+        
+        // Bind as service account
+        let bind_password = self.get_bind_password()?;
+        ldap.bind(&self.config.bind_dn, &bind_password)
+            .await
+            .map_err(|e| AuthError::ConnectionError(format!("Service bind failed: {}", e)))?
+            .success()
+            .map_err(|e| AuthError::ConnectionError(format!("Service bind rejected: {}", e)))?;
+
+        // Search for all users
+        let user_filter = self.config.attribute_mapping.user_filter
+            .as_ref()
+            .unwrap_or("(&(objectClass=user)(objectClass=person))");
+
+        let attrs: Vec<String> = vec![
+            self.config.attribute_mapping.user_id_attr.clone(),
+            self.config.attribute_mapping.name_attr.clone(),
+            self.config.attribute_mapping.email_attr.clone(),
+            self.config.attribute_mapping.group_attr.clone(),
+        ];
+
+        let search_base = &self.config.base_dn;
+        
+        let (results, _) = ldap
+            .search(search_base, ldap3::Scope::Subtree, user_filter, attrs)
+            .await
+            .map_err(|e| AuthError::InternalError(e.into()))?
+            .success()
+            .map_err(|e| AuthError::InternalError(e.into()))?;
+
+        // Process each user entry
+        let mut auth_results = Vec::new();
+        for entry in results {
+            match self.process_user_entry(entry) {
+                Ok(auth_result) => auth_results.push(auth_result),
+                Err(e) => {
+                    error!("Failed to process user entry: {}", e);
+                    // Continue processing other users
+                }
+            }
+        }
+
+        Ok(auth_results)
+    }
+
+    /// Process a single LDAP user entry
+    fn process_user_entry(&self, entry: ldap3::Entry) -> Result<AuthResult, AuthError> {
+        let attributes = self.extract_user_attributes(&entry)?;
+        let groups = attributes.get("groups")
+            .and_then(|g| g.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        let role = self.map_groups_to_roles(&groups);
+
+        let user_id = attributes.get("user_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        Ok(AuthResult {
+            user_id: UserId::new(user_id),
+            role: role.clone(),
+            attributes,
+            provider: self.config.name.clone(),
+            last_sync: chrono::Utc::now(),
+        })
+    }
+}
+
+#[async_trait]
+impl ExternalAuthProviderTrait for LdapAuthProvider {
+    /// Authenticate a user against LDAP directory
+    ///
+    /// # Arguments
+    /// * `credentials` - Username and password
+    ///
+    /// # Returns
+    /// * `Ok(AuthResult)` - User authenticated successfully with profile data
+    /// * `Err(AuthError)` - Authentication failed
+    async fn authenticate(&self, credentials: &AuthCredentials) -> Result<AuthResult, AuthError> {
+        let username = &credentials.username;
+        let password = &credentials.password;
+
+        // Authenticate user
+        let entry = self.authenticate_user(username, password).await?;
+
+        // Extract user attributes and map to OpenFang
+        let attributes = self.extract_user_attributes(&entry)?;
+        
+        // Get groups and determine role
+        let groups = attributes.get("groups")
+            .and_then(|g| g.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        let role = self.map_groups_to_roles(&groups);
+
+        let user_id = attributes.get("user_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(username)
+            .to_string();
+
+        let result = AuthResult {
+            user_id: UserId::new(user_id.clone()),
+            role: role.clone(),
+            attributes,
+            provider: self.config.name.clone(),
+            last_sync: chrono::Utc::now(),
+        };
+
+        // Cache authenticated user
+        {
+            let mut cache = self.user_cache.write().await;
+            cache.insert(UserId::new(user_id));
+        }
+
+        Ok(result)
+    }
+
+    /// Sync all users from directory (for batch provisioning)
+    async fn sync_users(&self) -> Result<Vec<AuthResult>, AuthError> {
+        self.sync_all_users().await
+    }
+
+    /// Get user by external ID (from directory)
+    async fn get_user_by_external_id(&self, external_id: &str) -> Result<Option<AuthResult>, AuthError> {
+        let mut ldap = self.create_ldap_connection().await?;
+        
+        // Bind as service account
+        let bind_password = self.get_bind_password()?;
+        ldap.bind(&self.config.bind_dn, &bind_password)
+            .await
+            .map_err(|e| AuthError::ConnectionError(format!("Service bind failed: {}", e)))?
+            .success()
+            .map_err(|e| AuthError::ConnectionError(format!("Service bind rejected: {}", e)))?;
+
+        // Search for user
+        let user_filter = self.config.attribute_mapping.user_filter
+            .as_ref()
+            .unwrap_or("(&(objectClass=user)(objectClass=person))")
+            .replace("{username}", external_id);
+
+        let attrs: Vec<String> = vec![
+            self.config.attribute_mapping.user_id_attr.clone(),
+            self.config.attribute_mapping.name_attr.clone(),
+            self.config.attribute_mapping.email_attr.clone(),
+            self.config.attribute_mapping.group_attr.clone(),
+        ];
+
+        let search_base = &self.config.base_dn;
+        
+        let (results, _) = ldap
+            .search(search_base, ldap3::Scope::Subtree, &user_filter, attrs)
+            .await
+            .map_err(|e| AuthError::InternalError(e.into()))?
+            .success()
+            .map_err(|e| AuthError::InternalError(e.into()))?;
+
+        if let Some(entry) = results.first() {
+            Ok(Some(self.process_user_entry(entry.clone())?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Refresh user's group membership and role
+    async fn refresh_user(&self, user_id: UserId) -> Result<AuthResult, AuthError> {
+        // Get user by external ID (user_id maps to sAMAccountName)
+        let external_id = user_id.to_string();
+        match self.get_user_by_external_id(&external_id).await? {
+            Some(result) => Ok(result),
+            None => Err(AuthError::UserNotFound),
+        }
+    }
+
+    /// Validate session (not applicable for pure LDAP, but required by trait)
+    async fn validate_session(&self, _session_token: &str) -> Result<Option<UserId>, AuthError> {
+        Err(AuthError::NotImplemented("LDAP does not support session validation".into()))
+    }
+
+    fn provider_type(&self) -> &str {
+        "ldap"
+    }
+
+    fn provider_name(&self) -> &str {
+        &self.config.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_role_mapping() {
+        let config = ExternalAuthConfig {
+            name: "test-ad".to_string(),
+            uri: "ldaps://dc01.example.com:636".to_string(),
+            bind_dn: "CN=Service Account,OU=Service Accounts,DC=example,DC=com".to_string(),
+            bind_password_env: Some("LDAP_BIND_PASSWORD".to_string()),
+            base_dn: "DC=example,DC=com".to_string(),
+            attribute_mapping: AttributeMapping {
+                user_id_attr: "sAMAccountName".to_string(),
+                name_attr: "displayName".to_string(),
+                email_attr: "mail".to_string(),
+                group_attr: "memberOf".to_string(),
+                user_filter: Some("(&(objectClass=user)(sAMAccountName={username}))".to_string()),
+                user_dn_template: None,
+            },
+            role_mappings: vec![
+                RoleMappingRule {
+                    group_pattern: "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com".to_string(),
+                    role: "admin".to_string(),
+                },
+                RoleMappingRule {
+                    group_pattern: "CN=OpenFang-Users,OU=Groups,DC=example,DC=com".to_string(),
+                    role: "user".to_string(),
+                },
+            ],
+            connection: ConnectionConfig {
+                timeout_secs: 30,
+                tls_enabled: true,
+                ca_cert_path: None,
+                start_tls: Some(false),
+                disable_tls_verify: Some(false),
+            },
+        };
+
+        let provider = LdapAuthProvider::new(config).unwrap();
+        
+        let groups = vec![
+            "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com".to_string(),
+            "CN=OpenFang-Users,OU=Groups,DC=example,DC=com".to_string(),
+        ];
+
+        let role = provider.map_groups_to_roles(&groups);
+        assert_eq!(role, "admin");
+    }
+
+    #[tokio::test]
+    async fn test_higher_role_preferred() {
+        let config = ExternalAuthConfig {
+            name: "test-ad".to_string(),
+            uri: "ldaps://dc01.example.com:636".to_string(),
+            bind_dn: "CN=Service Account,OU=Service Accounts,DC=example,DC=com".to_string(),
+            bind_password_env: Some("LDAP_BIND_PASSWORD".to_string()),
+            base_dn: "DC=example,DC=com".to_string(),
+            attribute_mapping: AttributeMapping {
+                user_id_attr: "sAMAccountName".to_string(),
+                name_attr: "displayName".to_string(),
+                email_attr: "mail".to_string(),
+                group_attr: "memberOf".to_string(),
+                user_filter: None,
+                user_dn_template: None,
+            },
+            role_mappings: vec![
+                RoleMappingRule {
+                    group_pattern: "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com".to_string(),
+                    role: "admin".to_string(),
+                },
+                RoleMappingRule {
+                    group_pattern: "CN=OpenFang-Owners,OU=Groups,DC=example,DC=com".to_string(),
+                    role: "owner".to_string(),
+                },
+            ],
+            connection: ConnectionConfig {
+                timeout_secs: 30,
+                tls_enabled: true,
+                ca_cert_path: None,
+                start_tls: Some(false),
+                disable_tls_verify: Some(false),
+            },
+        };
+
+        let provider = LdapAuthProvider::new(config).unwrap();
+        
+        // Owner role should be preferred over admin
+        let groups = vec![
+            "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com".to_string(),
+            "CN=OpenFang-Owners,OU=Groups,DC=example,DC=com".to_string(),
+        ];
+
+        let role = provider.map_groups_to_roles(&groups);
+        assert_eq!(role, "owner");
+    }
+}

--- a/crates/openfang-auth/src/providers/mod.rs
+++ b/crates/openfang-auth/src/providers/mod.rs
@@ -1,0 +1,5 @@
+//! LDAP authentication provider module.
+
+pub mod ldap;
+
+pub use ldap::LdapAuthProvider;

--- a/crates/openfang-kernel/Cargo.toml
+++ b/crates/openfang-kernel/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Core kernel for the OpenFang Agent OS"
 
 [dependencies]
+openfang-auth = { path = "../openfang-auth" }
 openfang-types = { path = "../openfang-types" }
 openfang-memory = { path = "../openfang-memory" }
 openfang-runtime = { path = "../openfang-runtime" }

--- a/crates/openfang-kernel/src/auth.rs
+++ b/crates/openfang-kernel/src/auth.rs
@@ -2,13 +2,17 @@
 //!
 //! The AuthManager maps platform user identities (Telegram ID, Discord ID, etc.)
 //! to OpenFang users with roles, then enforces permission checks on actions.
+//!
+//! Supports external directory authentication (LDAP, SAML, OIDC) for dynamic
+//! user provisioning and group-based role mapping.
 
 use dashmap::DashMap;
+use openfang_auth::{ExternalAuthProviderTrait, AuthCredentials, create_provider};
 use openfang_types::agent::UserId;
-use openfang_types::config::UserConfig;
+use openfang_types::config::{UserConfig, ExternalAuthConfig};
 use openfang_types::error::{OpenFangError, OpenFangResult};
 use std::fmt;
-use tracing::info;
+use tracing::{info, error};
 
 /// User roles with hierarchical permissions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -100,16 +104,42 @@ pub struct AuthManager {
     users: DashMap<UserId, UserIdentity>,
     /// Channel binding index: "channel_type:platform_id" → UserId.
     channel_index: DashMap<String, UserId>,
+    /// External directory authentication providers (LDAP, SAML, OIDC).
+    external_providers: DashMap<String, std::sync::Arc<dyn ExternalAuthProviderTrait>>,
 }
 
 impl AuthManager {
     /// Create a new AuthManager from kernel user configuration.
-    pub fn new(user_configs: &[UserConfig]) -> Self {
+    pub fn new(user_configs: &[UserConfig], external_configs: &[ExternalAuthConfig]) -> Self {
         let manager = Self {
             users: DashMap::new(),
             channel_index: DashMap::new(),
+            external_providers: DashMap::new(),
         };
 
+        // Initialize external auth providers
+        for config in external_configs {
+            match create_provider(config.clone()) {
+                Ok(provider) => {
+                    let provider_name = config.name.clone();
+                    manager.external_providers.insert(provider_name.clone(), std::sync::Arc::from(provider));
+                    info!(
+                        provider = %provider_name,
+                        type = %config.provider_type,
+                        "Initialized external auth provider"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        provider = %config.name,
+                        error = %e,
+                        "Failed to initialize external auth provider"
+                    );
+                }
+            }
+        }
+
+        // Register static users
         for config in user_configs {
             let user_id = UserId::new();
             let role = UserRole::from_str_role(&config.role);
@@ -149,7 +179,7 @@ impl AuthManager {
 
     /// Get a user's identity by their UserId.
     pub fn get_user(&self, user_id: UserId) -> Option<UserIdentity> {
-        self.users.get(&user_id).map(|r| r.value().clone())
+        self.users.get(&user_id).map(|r| r.clone())
     }
 
     /// Authorize a user for an action.
@@ -184,7 +214,112 @@ impl AuthManager {
 
     /// List all registered users.
     pub fn list_users(&self) -> Vec<UserIdentity> {
-        self.users.iter().map(|r| r.value().clone()).collect()
+        self.users.iter().map(|r| r.clone()).collect()
+    }
+
+    /// Authenticate user via external directory provider.
+    ///
+    /// # Arguments
+    /// * `provider_name` - Name of the external auth provider (e.g., "active-directory")
+    /// * `credentials` - Username and password
+    ///
+    /// # Returns
+    /// * `Ok(UserId)` - User authenticated and provisioned
+    /// * `Err(OpenFangError)` - Authentication failed
+    pub async fn authenticate_external(
+        &self,
+        provider_name: &str,
+        credentials: &AuthCredentials,
+    ) -> Result<UserId, OpenFangError> {
+        // Get the provider
+        let provider = self
+            .external_providers
+            .get(provider_name)
+            .ok_or_else(|| OpenFangError::AuthDenied(format!("Unknown provider: {}", provider_name)))?
+            .clone();
+
+        // Authenticate
+        let auth_result = provider.authenticate(credentials).await.map_err(|e| {
+            OpenFangError::AuthDenied(format!("External auth failed: {}", e))
+        })?;
+
+        // Check if user already exists
+        let user_id = if let Some(existing) = self.users.get(&auth_result.user_id) {
+            existing.value().id
+        } else {
+            // Create new user from directory
+            let role = UserRole::from_str_role(&auth_result.role);
+            let identity = UserIdentity {
+                id: auth_result.user_id,
+                name: auth_result.attributes
+                    .get("name")
+                    .and_then(|v: &serde_json::Value| v.as_str())
+                    .unwrap_or(&auth_result.user_id.to_string())
+                    .to_string(),
+                role,
+            };
+
+            self.users.insert(auth_result.user_id, identity);
+            auth_result.user_id
+        };
+
+        info!(
+            user_id = %user_id,
+            provider = %provider_name,
+            role = %auth_result.role,
+            "External user authenticated"
+        );
+
+        Ok(user_id)
+    }
+
+    /// Sync users from external directory.
+    pub async fn sync_external_users(&self, provider_name: &str) -> Result<usize, OpenFangError> {
+        let provider = self
+            .external_providers
+            .get(provider_name)
+            .ok_or_else(|| OpenFangError::AuthDenied(format!("Unknown provider: {}", provider_name)))?
+            .clone();
+
+        let users = provider.sync_users().await.map_err(|e| {
+            OpenFangError::AuthDenied(format!("Sync failed: {}", e))
+        })?;
+
+        let mut count = 0;
+        for auth_result in users {
+            // Check if user exists
+            if !self.users.contains_key(&auth_result.user_id) {
+                let role = UserRole::from_str_role(&auth_result.role);
+                let identity = UserIdentity {
+                    id: auth_result.user_id,
+                    name: auth_result.attributes
+                        .get("name")
+                        .and_then(|v: &serde_json::Value| v.as_str())
+                        .unwrap_or(&auth_result.user_id.to_string())
+                        .to_string(),
+                    role,
+                };
+
+                self.users.insert(auth_result.user_id, identity);
+                count += 1;
+            }
+        }
+
+        info!(
+            provider = %provider_name,
+            synced = count,
+            "External user sync completed"
+        );
+
+        Ok(count)
+    }
+
+    /// Get list of configured external providers.
+    pub fn list_external_providers(&self) -> Vec<String> {
+        self.external_providers
+            .iter()
+            .map(|r| r.key().clone())
+            .collect()
     }
 }
 
@@ -227,14 +362,14 @@ mod tests {
 
     #[test]
     fn test_user_registration() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
         assert!(manager.is_enabled());
         assert_eq!(manager.user_count(), 3);
     }
 
     #[test]
     fn test_identify_from_channel() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
 
         // Alice on Telegram
         let owner_tg = manager.identify("telegram", "123456");
@@ -253,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_owner_can_do_everything() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
         let owner_id = manager.identify("telegram", "123456").unwrap();
 
         assert!(manager.authorize(owner_id, &Action::ChatWithAgent).is_ok());
@@ -265,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_user_limited_access() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
         let guest_id = manager.identify("telegram", "999999").unwrap();
 
         // User can chat and view config
@@ -280,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_viewer_read_only() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
         let users = manager.list_users();
         let viewer = users.iter().find(|u| u.name == "ReadOnly").unwrap();
 
@@ -292,14 +427,14 @@ mod tests {
 
     #[test]
     fn test_unknown_user_denied() {
-        let manager = AuthManager::new(&test_configs());
+        let manager = AuthManager::new(&test_configs(), &[]);
         let fake_id = UserId::new();
         assert!(manager.authorize(fake_id, &Action::ChatWithAgent).is_err());
     }
 
     #[test]
     fn test_no_users_means_disabled() {
-        let manager = AuthManager::new(&[]);
+        let manager = AuthManager::new(&[], &[]);
         assert!(!manager.is_enabled());
         assert_eq!(manager.user_count(), 0);
     }

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -817,7 +817,7 @@ impl OpenFangKernel {
             .map_err(|e| KernelError::BootFailed(format!("WASM sandbox init failed: {e}")))?;
 
         // Initialize RBAC authentication manager
-        let auth = AuthManager::new(&config.users);
+        let auth = AuthManager::new(&config.users, &config.external_auth_providers);
         if auth.is_enabled() {
             info!("RBAC enabled with {} users", auth.user_count());
         }

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -1275,6 +1275,9 @@ pub struct KernelConfig {
     /// Dashboard authentication (username/password login).
     #[serde(default)]
     pub auth: AuthConfig,
+    /// External directory authentication providers (LDAP, SAML, OIDC).
+    #[serde(default)]
+    pub external_auth_providers: Vec<ExternalAuthConfig>,
     /// Directory for auto-loading workflow JSON files on startup.
     /// Defaults to `~/.openfang/workflows`. Set to empty string to disable.
     #[serde(default)]
@@ -1344,6 +1347,138 @@ impl Default for AuthConfig {
             password_hash: String::new(),
             session_ttl_hours: 168,
         }
+    }
+}
+
+/// External directory authentication provider configuration.
+///
+/// Supports LDAP, SAML, and OIDC providers for enterprise identity integration.
+/// Users are automatically provisioned on first authentication based on
+/// directory group membership mapped to OpenFang RBAC roles.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ExternalAuthConfig {
+    /// Provider type: "ldap", "saml", or "oidc".
+    pub provider_type: String,
+    /// Human-readable name for this provider.
+    pub name: String,
+    /// Connection endpoint (URI for LDAP, discovery URL for OIDC, SSO URL for SAML).
+    pub uri: String,
+    /// Service account bind DN (LDAP) or client ID (OIDC/SAML).
+    pub bind_dn: String,
+    /// Environment variable name for bind password/secret.
+    pub bind_password_env: Option<String>,
+    /// Base DN for user searches (LDAP) or entity ID (SAML).
+    pub base_dn: String,
+    /// User search filter with {username} placeholder.
+    #[serde(default)]
+    pub user_filter: Option<String>,
+    /// Attribute mappings for user profile extraction.
+    #[serde(default)]
+    pub attribute_mapping: AttributeMapping,
+    /// Role mappings from directory groups to OpenFang roles.
+    #[serde(default)]
+    pub role_mappings: Vec<RoleMappingRule>,
+    /// Connection security settings.
+    #[serde(default)]
+    pub connection: ConnectionConfig,
+}
+
+/// User attribute mapping configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AttributeMapping {
+    /// Attribute name for user ID (e.g., "sAMAccountName", "uid").
+    pub user_id_attr: String,
+    /// Attribute name for display name (e.g., "displayName", "cn").
+    pub name_attr: String,
+    /// Attribute name for email (e.g., "mail", "email").
+    pub email_attr: String,
+    /// Attribute name for group membership (e.g., "memberOf", "groups").
+    pub group_attr: String,
+    /// Custom user filter template with {username} placeholder.
+    #[serde(default)]
+    pub user_filter: Option<String>,
+    /// Custom user DN template with {username} or {user_id} placeholders.
+    #[serde(default)]
+    pub user_dn_template: Option<String>,
+}
+
+/// Role mapping rule for directory group → OpenFang role.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleMappingRule {
+    /// LDAP group DN pattern (supports * wildcard).
+    pub group_pattern: String,
+    /// OpenFang role to assign (owner, admin, user, viewer).
+    pub role: String,
+}
+
+/// LDAP connection security configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ConnectionConfig {
+    /// Connection timeout in seconds.
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+    /// Enable TLS/SSL (LDAPS or StartTLS).
+    #[serde(default = "default_true")]
+    pub tls_enabled: bool,
+    /// Path to CA certificate for self-signed server certificates.
+    pub ca_cert_path: Option<String>,
+    /// Use StartTLS instead of LDAPS.
+    #[serde(default)]
+    pub start_tls: Option<bool>,
+    /// Disable TLS certificate verification (NOT for production).
+    #[serde(default)]
+    pub disable_tls_verify: Option<bool>,
+}
+
+fn default_timeout() -> u64 {
+    30
+}
+
+impl ExternalAuthConfig {
+    /// Create a new LDAP provider configuration.
+    pub fn new_ldap(
+        name: &str,
+        uri: &str,
+        bind_dn: &str,
+        base_dn: &str,
+        bind_password_env: &str,
+    ) -> Self {
+        Self {
+            provider_type: "ldap".to_string(),
+            name: name.to_string(),
+            uri: uri.to_string(),
+            bind_dn: bind_dn.to_string(),
+            bind_password_env: Some(bind_password_env.to_string()),
+            base_dn: base_dn.to_string(),
+            user_filter: Some("(&(objectClass=user)(sAMAccountName={username}))".to_string()),
+            attribute_mapping: AttributeMapping {
+                user_id_attr: "sAMAccountName".to_string(),
+                name_attr: "displayName".to_string(),
+                email_attr: "mail".to_string(),
+                group_attr: "memberOf".to_string(),
+                user_filter: None,
+                user_dn_template: None,
+            },
+            role_mappings: Vec::new(),
+            connection: ConnectionConfig {
+                timeout_secs: 30,
+                tls_enabled: true,
+                ca_cert_path: None,
+                start_tls: Some(false),
+                disable_tls_verify: Some(false),
+            },
+        }
+    }
+
+    /// Add a role mapping rule.
+    pub fn add_role_mapping(&mut self, group_pattern: &str, role: &str) {
+        self.role_mappings.push(RoleMappingRule {
+            group_pattern: group_pattern.to_string(),
+            role: role.to_string(),
+        });
     }
 }
 
@@ -1537,6 +1672,7 @@ impl Default for KernelConfig {
             provider_api_keys: HashMap::new(),
             oauth: OAuthConfig::default(),
             auth: AuthConfig::default(),
+            external_auth_providers: Vec::new(),
             workflows_dir: None,
             heartbeat: HeartbeatSettings::default(),
             skills: HashMap::new(),
@@ -1658,6 +1794,10 @@ impl std::fmt::Debug for KernelConfig {
                 &format!("{} mapping(s)", self.provider_api_keys.len()),
             )
             .field("auth", &format!("enabled={}", self.auth.enabled))
+            .field(
+                "external_auth_providers",
+                &format!("{} provider(s)", self.external_auth_providers.len()),
+            )
             .field("skills", &format!("{} skill config(s)", self.skills.len()))
             .finish()
     }


### PR DESCRIPTION
Implement trait-based external authentication provider architecture supporting LDAP/LDAPS with dynamic user provisioning and group-based RBAC mapping.

The implementation enables deployment owners to leverage existing Active Directory or OpenLDAP directories for user authentication and role assignment. Users are automatically provisioned on first authentication based on directory group membership mapped to OpenFang roles (owner/admin/user/viewer).

Key features:
- LDAPS support with TLS/SSL and self-signed certificate handling
- Group-to-role mapping with privilege hierarchy (higher role wins)
- Automatic user provisioning from directory attributes
- Credential separation (bind passwords in env until vaults work)
- Connection timeout enforcement and certificate validation
- Seamless integration with existing static user configuration

The trait-based design allows future extension to SAML and OIDC providers while maintaining a consistent authentication interface.

Security considerations:
- TLS enforcement required for all LDAP connections
- Bind credentials never stored in configuration files
- Certificate validation enabled by default (bypass disabled)
- Role mappings use regex patterns for flexible group matching
- Users created only after successful directory authentication

Configuration:

```toml
 [[external_auth_providers]]                                                                                                                                                                                                                    │
 type = "ldap"                                                                                                                                                                                                                                  │
 name = "active-directory"                                                                                                                                                                                                                      │
 uri = "ldaps://dc01.example.com:636"                                                                                                                                                                                                           │
 bind_dn = "CN=Service Account,OU=Service Accounts,DC=example,DC=com"                                                                                                                                                                           │
 bind_password_env = "LDAP_BIND_PASSWORD"                                                                                                                                                                                                       │
 base_dn = "DC=example,DC=com"                                                                                                                                                                                                                  │
                                                                                                                                                                                                                                                │
 [external_auth_providers.attribute_mapping]                                                                                                                                                                                                    │
 user_id_attr = "sAMAccountName"                                                                                                                                                                                                                │
 name_attr = "displayName"                                                                                                                                                                                                                      │
 email_attr = "mail"                                                                                                                                                                                                                            │
 group_attr = "memberOf"                                                                                                                                                                                                                        │
                                                                                                                                                                                                                                                │
 [[external_auth_providers.role_mappings]]                                                                                                                                                                                                      │
 group_pattern = "CN=OpenFang-Admins,OU=Groups,DC=example,DC=com"                                                                                                                                                                               │
 role = "admin"                                                                                                                                                                                                                                 │
                                                                                                                                                                                                                                                │
 [[external_auth_providers.role_mappings]]                                                                                                                                                                                                      │
 group_pattern = "CN=OpenFang-Users,OU=Groups,DC=example,DC=com"                                                                                                                                                                                │
 role = "user"                                                                                                                                                                                                                                  │
                                                                                                                                                                                                                                                │
 [[external_auth_providers.role_mappings]]                                                                                                                                                                                                      │
 group_pattern = "CN=OpenFang-Viewers,OU=Groups,DC=example,DC=com"                                                                                                                                                                              │
 role = "viewer"                                                                                                                                                                                                                                │
                                                                                                                                                                                                                                                │
 [external_auth_providers.connection]                                                                                                                                                                                                           │
 timeout_secs = 30                                                                                                                                                                                                                              │
 tls_enabled = true                                                                                                                                                                                                                             │
 ca_cert_path = "/etc/ssl/certs/example-ca.pem"                                                                                                                                                                                                 │
 start_tls = false                                                                                                                                                                                                                              │
 disable_tls_verify = false
```

## Summary

Implement directory authentication trait and LDAP/S initial directory provider

## Changes

<!-- Brief list of what changed. -->

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
-- unrelated failure in telegram section:
```rust
    Checking openfang-kernel v0.6.8 (/opt/code/Rust/ML/Agents/openfang/crates/openfang-kernel)
error: unnecessary use of `get("target_agent_name").is_none()`
    --> crates/openfang-channels/src/telegram.rs:1751:30
     |
1751 |         assert!(msg.metadata.get("target_agent_name").is_none());
     |                 -------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |                 |
     |                 help: replace it with: `!msg.metadata.contains_key("target_agent_name")`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#unnecessary_get_then_check
     = note: `-D clippy::unnecessary-get-then-check` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::unnecessary_get_then_check)]`

error: unnecessary use of `get("target_agent_name").is_none()`
    --> crates/openfang-channels/src/telegram.rs:1785:30
     |
1785 |         assert!(msg.metadata.get("target_agent_name").is_none());
     |                 -------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |                 |
     |                 help: replace it with: `!msg.metadata.contains_key("target_agent_name")`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#unnecessary_get_then_check

error: could not compile `openfang-channels` (lib test) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```
- [x] `cargo test --workspace` passes (wasm targets fail in MPROTECT systems by the way)
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [ ] User input validated at boundaries
