### PR TITLE
Fix: delete workflow file when removing a workflow

### DIFF
--- a/crates/openfang-api/src/routes.rs
+++ b/crates/openfang-api/src/routes.rs
@@ -1237,6 +1237,16 @@ pub async fn delete_workflow(
     });
 
     if state.kernel.workflows.remove_workflow(workflow_id).await {
+        let wf_dir = state
+            .kernel
+            .config
+            .workflows_dir
+            .clone()
+            .unwrap_or_else(|| state.kernel.config.home_dir.join("workflows"));
+        let wf_path = wf_dir.join(format!("{}.json", id));
+        if let Err(e) = std::fs::remove_file(&wf_path) {
+            tracing::warn!("Failed to remove workflow file {}: {e}", wf_path.display());
+        }
         (
             StatusCode::OK,
             Json(serde_json::json!({"status": "removed", "workflow_id": id})),


### PR DESCRIPTION
## Summary
- When a workflow is deleted via the API or dashboard, only the in-memory entry was removed but the corresponding `.json` file in `~/.openfang/workflows/` was left behind
- On daemon restart, `load_workflows_from_dir()` would re-import these "deleted" workflows, causing them to reappear

## Fix
- Modified `delete_workflow()` in `crates/openfang-api/src/routes.rs` to also delete the `.json` file from disk when removing a workflow

## Testing
- Lint (`cargo clippy`) and build (`cargo build --workspace --lib`) pass

## Related Issue
Fixes: https://github.com/RightNow-AI/openfang/issues/1192