### PR TITLE
feat(mcp): support push notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: check-${{ matrix.os }}
+          cache-bin: false
       - name: Install Tauri system deps (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -50,6 +51,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: test-${{ matrix.os }}
+          cache-bin: false
       - name: Install Tauri system deps (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -72,6 +74,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install Tauri system deps
         run: |
           sudo apt-get update
@@ -102,6 +106,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1555,7 +1555,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1805,7 +1805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2743,7 +2743,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3255,9 +3255,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3739,7 +3739,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5144,7 +5144,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5710,7 +5710,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5769,7 +5769,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6315,7 +6315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7051,7 +7051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7623,7 +7623,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8496,7 +8496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,6 +4230,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
+ "governor",
  "hex",
  "http",
  "openfang-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ socket2 = "0.5"
 zip = { version = "4", default-features = false, features = ["deflate"] }
 
 # Email (SMTP + IMAP)
-lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 imap = "2"
 native-tls = { version = "0.2", features = ["vendored"] }
 mailparse = "0.16"

--- a/crates/openfang-extensions/src/registry.rs
+++ b/crates/openfang-extensions/src/registry.rs
@@ -208,6 +208,7 @@ impl IntegrationRegistry {
                     headers: Vec::new(),
                     allow_push_events: false,
                     push_queue_size: 256,
+                    push_rate_limit_per_minute: 600,
                 })
             })
             .collect()

--- a/crates/openfang-extensions/src/registry.rs
+++ b/crates/openfang-extensions/src/registry.rs
@@ -206,6 +206,8 @@ impl IntegrationRegistry {
                     timeout_secs: 30,
                     env,
                     headers: Vec::new(),
+                    allow_push_events: false,
+                    push_queue_size: 256,
                 })
             })
             .collect()

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -6853,6 +6853,9 @@ fn manifest_to_capabilities(manifest: &AgentManifest) -> Vec<Capability> {
             if !manifest.capabilities.memory_write.is_empty() {
                 merged.memory_write = manifest.capabilities.memory_write.clone();
             }
+            if !manifest.capabilities.mcp_subscribe.is_empty() {
+                merged.mcp_subscribe = manifest.capabilities.mcp_subscribe.clone();
+            }
             if manifest.capabilities.ofp_discover {
                 merged.ofp_discover = true;
             }
@@ -6878,6 +6881,9 @@ fn manifest_to_capabilities(manifest: &AgentManifest) -> Vec<Capability> {
     }
     for scope in &effective_caps.memory_write {
         caps.push(Capability::MemoryWrite(scope.clone()));
+    }
+    for resource in &effective_caps.mcp_subscribe {
+        caps.push(Capability::McpSubscribe(resource.clone()));
     }
     if effective_caps.agent_spawn {
         caps.push(Capability::AgentSpawn);
@@ -7411,6 +7417,61 @@ impl KernelHandle for OpenFangKernel {
         );
         OpenFangKernel::publish_event(self, event).await;
         Ok(())
+    }
+
+    async fn mcp_subscribe_resource(
+        &self,
+        agent_id: &str,
+        server: Option<&str>,
+        uri: &str,
+    ) -> Result<String, String> {
+        let agent_id: AgentId = agent_id
+            .parse()
+            .map_err(|_| format!("Invalid agent ID: {agent_id}"))?;
+        let uri = uri.trim();
+        if uri.is_empty() {
+            return Err("MCP resource URI is required".to_string());
+        }
+
+        let server_name = {
+            let conns = self.mcp_connections.lock().await;
+            match server.map(str::trim).filter(|s| !s.is_empty()) {
+                Some(requested) => conns
+                    .iter()
+                    .find(|conn| {
+                        conn.name() == requested
+                            || openfang_runtime::mcp::normalize_name(conn.name())
+                                == openfang_runtime::mcp::normalize_name(requested)
+                    })
+                    .map(|conn| conn.name().to_string())
+                    .ok_or_else(|| format!("MCP server '{requested}' not connected"))?,
+                None if conns.len() == 1 => conns[0].name().to_string(),
+                None if conns.is_empty() => return Err("No MCP servers are connected".to_string()),
+                None => {
+                    return Err(
+                        "Multiple MCP servers are connected; provide the 'server' argument"
+                            .to_string(),
+                    )
+                }
+            }
+        };
+
+        let resource = format!("{server_name}:{uri}");
+        self.capabilities
+            .check(agent_id, &Capability::McpSubscribe(resource.clone()))
+            .require()
+            .map_err(|e| e.to_string())?;
+
+        let mut conns = self.mcp_connections.lock().await;
+        let conn = conns
+            .iter_mut()
+            .find(|conn| conn.name() == server_name)
+            .ok_or_else(|| format!("MCP server '{server_name}' not connected"))?;
+        conn.subscribe_resource(uri).await?;
+
+        Ok(format!(
+            "Subscribed to MCP resource '{uri}' on '{server_name}'"
+        ))
     }
 
     async fn knowledge_add_entity(
@@ -8046,12 +8107,14 @@ mod tests {
             max_history_messages: None,
         };
         manifest.capabilities.tools = vec!["file_read".to_string(), "web_fetch".to_string()];
+        manifest.capabilities.mcp_subscribe = vec!["github:repo://*".to_string()];
         manifest.capabilities.agent_spawn = true;
 
         let caps = manifest_to_capabilities(&manifest);
         assert!(caps.contains(&Capability::ToolInvoke("file_read".to_string())));
+        assert!(caps.contains(&Capability::McpSubscribe("github:repo://*".to_string())));
         assert!(caps.contains(&Capability::AgentSpawn));
-        assert_eq!(caps.len(), 3); // 2 tools + agent_spawn
+        assert_eq!(caps.len(), 4); // 2 tools + mcp_subscribe + agent_spawn
     }
 
     /// Regression for #1087: when the user edits any field in agent.toml

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -105,6 +105,9 @@ pub struct OpenFangKernel {
     pub running_tasks: dashmap::DashMap<AgentId, tokio::task::AbortHandle>,
     /// MCP server connections (lazily initialized at start_background_agents).
     pub mcp_connections: tokio::sync::Mutex<Vec<openfang_runtime::mcp::McpConnection>>,
+    /// Resource URIs subscribed per MCP server, replayed after reconnect.
+    pub mcp_subscriptions:
+        tokio::sync::RwLock<std::collections::HashMap<String, std::collections::HashSet<String>>>,
     /// MCP tool definitions cache (populated after connections are established).
     pub mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
     /// A2A task store for tracking task lifecycle.
@@ -1189,6 +1192,7 @@ impl OpenFangKernel {
             skill_config_overrides: std::sync::RwLock::new(None),
             running_tasks: dashmap::DashMap::new(),
             mcp_connections: tokio::sync::Mutex::new(Vec::new()),
+            mcp_subscriptions: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             mcp_tools: std::sync::Mutex::new(Vec::new()),
             a2a_task_store: openfang_runtime::a2a::A2aTaskStore::default(),
             a2a_external_agents: std::sync::Mutex::new(Vec::new()),
@@ -5834,6 +5838,41 @@ impl OpenFangKernel {
         });
     }
 
+    async fn record_mcp_subscription(&self, server: &str, uri: &str) {
+        self.mcp_subscriptions
+            .write()
+            .await
+            .entry(server.to_string())
+            .or_default()
+            .insert(uri.to_string());
+    }
+
+    async fn replay_mcp_subscriptions(&self, conn: &openfang_runtime::mcp::McpConnection) -> usize {
+        let server = conn.name().to_string();
+        let uris: Vec<String> = self
+            .mcp_subscriptions
+            .read()
+            .await
+            .get(&server)
+            .map(|uris| uris.iter().cloned().collect())
+            .unwrap_or_default();
+
+        let mut replayed = 0;
+        for uri in uris {
+            match conn.subscribe_resource(uri.clone()).await {
+                Ok(()) => replayed += 1,
+                Err(e) => warn!(
+                    server = %server,
+                    uri = %uri,
+                    error = %e,
+                    "Failed to replay MCP resource subscription after reconnect"
+                ),
+            }
+        }
+
+        replayed
+    }
+
     /// Connect to all configured MCP servers and cache their tool definitions.
     async fn connect_mcp_servers(self: &Arc<Self>) {
         use openfang_runtime::mcp::{McpConnection, McpServerConfig, McpTransport};
@@ -6059,6 +6098,7 @@ impl OpenFangKernel {
                 }
             }
             for name in &removed {
+                self.mcp_subscriptions.write().await.remove(name);
                 self.extension_health.unregister(name);
                 info!(server = %name, "Extension MCP server disconnected (removed)");
             }
@@ -6136,6 +6176,7 @@ impl OpenFangKernel {
         match McpConnection::connect_with_notifications(mcp_config, notification_tx).await {
             Ok(conn) => {
                 let tool_count = conn.tools().len();
+                let replayed_subscriptions = self.replay_mcp_subscriptions(&conn).await;
                 if let Ok(mut tools) = self.mcp_tools.lock() {
                     tools.extend(conn.tools().iter().cloned());
                 }
@@ -6143,11 +6184,13 @@ impl OpenFangKernel {
                 info!(
                     server = %id,
                     tools = tool_count,
+                    replayed_subscriptions,
                     "Extension MCP server reconnected"
                 );
                 if let Some(receiver) = notification_rx {
                     self.spawn_mcp_notification_bridge(receiver);
                 }
+                self.mcp_connections.lock().await.push(conn);
                 let event = Event::new(
                     AgentId::from_string("system:mcp"),
                     EventTarget::Broadcast,
@@ -6156,7 +6199,6 @@ impl OpenFangKernel {
                     }),
                 );
                 self.publish_event(event).await;
-                self.mcp_connections.lock().await.push(conn);
                 Ok(tool_count)
             }
             Err(e) => {
@@ -7465,12 +7507,15 @@ impl KernelHandle for OpenFangKernel {
             .require()
             .map_err(|e| e.to_string())?;
 
-        let mut conns = self.mcp_connections.lock().await;
-        let conn = conns
-            .iter_mut()
-            .find(|conn| conn.name() == server_name)
-            .ok_or_else(|| format!("MCP server '{server_name}' not connected"))?;
-        conn.subscribe_resource(uri).await?;
+        {
+            let conns = self.mcp_connections.lock().await;
+            let conn = conns
+                .iter()
+                .find(|conn| conn.name() == server_name)
+                .ok_or_else(|| format!("MCP server '{server_name}' not connected"))?;
+            conn.subscribe_resource(uri).await?;
+        }
+        self.record_mcp_subscription(&server_name, uri).await;
 
         Ok(format!(
             "Subscribed to MCP resource '{uri}' on '{server_name}'"

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5835,6 +5835,8 @@ impl OpenFangKernel {
                 timeout_secs: server_config.timeout_secs,
                 env: server_config.env.clone(),
                 headers: server_config.headers.clone(),
+                allow_push_events: server_config.allow_push_events,
+                push_queue_size: server_config.push_queue_size,
             };
 
             match McpConnection::connect(mcp_config).await {
@@ -5945,6 +5947,8 @@ impl OpenFangKernel {
                 timeout_secs: server_config.timeout_secs,
                 env: server_config.env.clone(),
                 headers: server_config.headers.clone(),
+                allow_push_events: server_config.allow_push_events,
+                push_queue_size: server_config.push_queue_size,
             };
 
             self.extension_health.register(&server_config.name);
@@ -6065,6 +6069,8 @@ impl OpenFangKernel {
             timeout_secs: server_config.timeout_secs,
             env: server_config.env.clone(),
             headers: server_config.headers.clone(),
+            allow_push_events: server_config.allow_push_events,
+            push_queue_size: server_config.push_queue_size,
         };
 
         match McpConnection::connect(mcp_config).await {
@@ -9187,6 +9193,8 @@ mod tests {
                 timeout_secs: 30,
                 env: vec!["OPENAI_API_KEY".to_string()],
                 headers: vec![],
+                allow_push_events: false,
+                push_queue_size: 256,
             }],
             ..KernelConfig::default()
         };

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5797,6 +5797,43 @@ impl OpenFangKernel {
         Ok(primary)
     }
 
+    fn mcp_notification_channel(
+        &self,
+        allow_push_events: bool,
+        push_queue_size: usize,
+    ) -> (
+        Option<openfang_runtime::mcp::McpNotificationSender>,
+        Option<openfang_runtime::mcp::McpNotificationReceiver>,
+    ) {
+        if !allow_push_events {
+            return (None, None);
+        }
+
+        let (tx, rx) = openfang_runtime::mcp::mcp_notification_channel(push_queue_size);
+        (Some(tx), Some(rx))
+    }
+
+    fn spawn_mcp_notification_bridge(
+        self: &Arc<Self>,
+        receiver: openfang_runtime::mcp::McpNotificationReceiver,
+    ) {
+        let kernel = Arc::downgrade(self);
+        tokio::spawn(async move {
+            loop {
+                let mcp_event = receiver.recv().await;
+                let Some(kernel) = kernel.upgrade() else {
+                    break;
+                };
+                let event = Event::new(
+                    AgentId::from_string("system:mcp"),
+                    EventTarget::Broadcast,
+                    EventPayload::Mcp(mcp_event),
+                );
+                kernel.publish_event(event).await;
+            }
+        });
+    }
+
     /// Connect to all configured MCP servers and cache their tool definitions.
     async fn connect_mcp_servers(self: &Arc<Self>) {
         use openfang_runtime::mcp::{McpConnection, McpServerConfig, McpTransport};
@@ -5829,6 +5866,10 @@ impl OpenFangKernel {
                 }
             }
 
+            let (notification_tx, notification_rx) = self.mcp_notification_channel(
+                server_config.allow_push_events,
+                server_config.push_queue_size,
+            );
             let mcp_config = McpServerConfig {
                 name: server_config.name.clone(),
                 transport,
@@ -5839,7 +5880,7 @@ impl OpenFangKernel {
                 push_queue_size: server_config.push_queue_size,
             };
 
-            match McpConnection::connect(mcp_config).await {
+            match McpConnection::connect_with_notifications(mcp_config, notification_tx).await {
                 Ok(conn) => {
                     let tool_count = conn.tools().len();
                     // Cache tool definitions
@@ -5854,6 +5895,9 @@ impl OpenFangKernel {
                     // Update extension health if this is an extension-provided server
                     self.extension_health
                         .report_ok(&server_config.name, tool_count);
+                    if let Some(receiver) = notification_rx {
+                        self.spawn_mcp_notification_bridge(receiver);
+                    }
                     self.mcp_connections.lock().await.push(conn);
                 }
                 Err(e) => {
@@ -5953,7 +5997,12 @@ impl OpenFangKernel {
 
             self.extension_health.register(&server_config.name);
 
-            match McpConnection::connect(mcp_config).await {
+            let (notification_tx, notification_rx) = self.mcp_notification_channel(
+                server_config.allow_push_events,
+                server_config.push_queue_size,
+            );
+
+            match McpConnection::connect_with_notifications(mcp_config, notification_tx).await {
                 Ok(conn) => {
                     let tool_count = conn.tools().len();
                     if let Ok(mut tools) = self.mcp_tools.lock() {
@@ -5966,6 +6015,9 @@ impl OpenFangKernel {
                         tools = tool_count,
                         "Extension MCP server connected (hot-reload)"
                     );
+                    if let Some(receiver) = notification_rx {
+                        self.spawn_mcp_notification_bridge(receiver);
+                    }
                     self.mcp_connections.lock().await.push(conn);
                     connected_count += 1;
                 }
@@ -6073,7 +6125,12 @@ impl OpenFangKernel {
             push_queue_size: server_config.push_queue_size,
         };
 
-        match McpConnection::connect(mcp_config).await {
+        let (notification_tx, notification_rx) = self.mcp_notification_channel(
+            server_config.allow_push_events,
+            server_config.push_queue_size,
+        );
+
+        match McpConnection::connect_with_notifications(mcp_config, notification_tx).await {
             Ok(conn) => {
                 let tool_count = conn.tools().len();
                 if let Ok(mut tools) = self.mcp_tools.lock() {
@@ -6085,6 +6142,17 @@ impl OpenFangKernel {
                     tools = tool_count,
                     "Extension MCP server reconnected"
                 );
+                if let Some(receiver) = notification_rx {
+                    self.spawn_mcp_notification_bridge(receiver);
+                }
+                let event = Event::new(
+                    AgentId::from_string("system:mcp"),
+                    EventTarget::Broadcast,
+                    EventPayload::Mcp(McpEvent::ConnectionReconnected {
+                        server: id.to_string(),
+                    }),
+                );
+                self.publish_event(event).await;
                 self.mcp_connections.lock().await.push(conn);
                 Ok(tool_count)
             }

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -108,6 +108,8 @@ pub struct OpenFangKernel {
     /// Resource URIs subscribed per MCP server, replayed after reconnect.
     pub mcp_subscriptions:
         tokio::sync::RwLock<std::collections::HashMap<String, std::collections::HashSet<String>>>,
+    /// Cached agent fan-out targets for MCP list-change notifications.
+    mcp_fanout_targets: std::sync::RwLock<std::collections::HashMap<String, Vec<AgentId>>>,
     /// MCP tool definitions cache (populated after connections are established).
     pub mcp_tools: std::sync::Mutex<Vec<ToolDefinition>>,
     /// A2A task store for tracking task lifecycle.
@@ -1193,6 +1195,7 @@ impl OpenFangKernel {
             running_tasks: dashmap::DashMap::new(),
             mcp_connections: tokio::sync::Mutex::new(Vec::new()),
             mcp_subscriptions: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            mcp_fanout_targets: std::sync::RwLock::new(std::collections::HashMap::new()),
             mcp_tools: std::sync::Mutex::new(Vec::new()),
             a2a_task_store: openfang_runtime::a2a::A2aTaskStore::default(),
             a2a_external_agents: std::sync::Mutex::new(Vec::new()),
@@ -1747,6 +1750,7 @@ impl OpenFangKernel {
         self.registry
             .register(entry.clone())
             .map_err(KernelError::OpenFang)?;
+        self.rebuild_mcp_fanout_targets();
 
         // Update parent's children list
         if let Some(parent_id) = parent {
@@ -3472,6 +3476,7 @@ impl OpenFangKernel {
         self.registry
             .update_mcp_servers(agent_id, servers.clone())
             .map_err(KernelError::OpenFang)?;
+        self.rebuild_mcp_fanout_targets();
 
         if let Some(entry) = self.registry.get(agent_id) {
             let _ = self.memory.save_agent(&entry);
@@ -3728,6 +3733,7 @@ impl OpenFangKernel {
         self.capabilities.revoke_all(agent_id);
         self.event_bus.unsubscribe_agent(agent_id);
         self.triggers.remove_agent_triggers(agent_id);
+        self.rebuild_mcp_fanout_targets();
 
         // Remove cron jobs so they don't linger as orphans (#504)
         let cron_removed = self.cron_scheduler.remove_agent_jobs(agent_id);
@@ -5828,14 +5834,86 @@ impl OpenFangKernel {
                 let Some(kernel) = kernel.upgrade() else {
                     break;
                 };
-                let event = Event::new(
-                    AgentId::from_string("system:mcp"),
-                    EventTarget::Broadcast,
-                    EventPayload::Mcp(mcp_event),
-                );
-                kernel.publish_event(event).await;
+                kernel.publish_mcp_event(mcp_event).await;
             }
         });
+    }
+
+    async fn publish_mcp_event(&self, mcp_event: McpEvent) {
+        if let McpEvent::ToolListChanged { server } = &mcp_event {
+            let agent_targets = self.agents_for_mcp_server(server);
+            if agent_targets.is_empty() {
+                let event = Event::new(
+                    AgentId::from_string("system:mcp"),
+                    EventTarget::System,
+                    EventPayload::Mcp(mcp_event),
+                );
+                self.event_bus.publish(event).await;
+                return;
+            }
+
+            for agent_id in agent_targets {
+                let event = Event::new(
+                    AgentId::from_string("system:mcp"),
+                    EventTarget::Agent(agent_id),
+                    EventPayload::Mcp(mcp_event.clone()),
+                );
+                self.publish_event(event).await;
+            }
+            return;
+        }
+
+        let event = Event::new(
+            AgentId::from_string("system:mcp"),
+            EventTarget::Broadcast,
+            EventPayload::Mcp(mcp_event),
+        );
+        self.publish_event(event).await;
+    }
+
+    fn agents_for_mcp_server(&self, server: &str) -> Vec<AgentId> {
+        let normalized_server = openfang_runtime::mcp::normalize_name(server);
+        self.mcp_fanout_targets
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&normalized_server)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn rebuild_mcp_fanout_targets(&self) {
+        let known_servers: Vec<String> = self
+            .effective_mcp_servers
+            .read()
+            .map(|servers| {
+                servers
+                    .iter()
+                    .map(|server| openfang_runtime::mcp::normalize_name(&server.name))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut targets: std::collections::HashMap<String, Vec<AgentId>> =
+            std::collections::HashMap::new();
+        for entry in self.registry.list() {
+            if entry.manifest.mcp_servers.is_empty() {
+                for server in &known_servers {
+                    targets.entry(server.clone()).or_default().push(entry.id);
+                }
+            } else {
+                for server in &entry.manifest.mcp_servers {
+                    targets
+                        .entry(openfang_runtime::mcp::normalize_name(server))
+                        .or_default()
+                        .push(entry.id);
+                }
+            }
+        }
+
+        *self
+            .mcp_fanout_targets
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = targets;
     }
 
     async fn record_mcp_subscription(&self, server: &str, uri: &str) {
@@ -5883,6 +5961,7 @@ impl OpenFangKernel {
             .read()
             .map(|s| s.clone())
             .unwrap_or_default();
+        self.rebuild_mcp_fanout_targets();
 
         for server_config in &servers {
             let transport = match &server_config.transport {
@@ -6012,6 +6091,7 @@ impl OpenFangKernel {
         if let Ok(mut effective) = self.effective_mcp_servers.write() {
             *effective = new_configs;
         }
+        self.rebuild_mcp_fanout_targets();
 
         // 5. Connect new servers
         let mut connected_count = 0;
@@ -6191,14 +6271,10 @@ impl OpenFangKernel {
                     self.spawn_mcp_notification_bridge(receiver);
                 }
                 self.mcp_connections.lock().await.push(conn);
-                let event = Event::new(
-                    AgentId::from_string("system:mcp"),
-                    EventTarget::Broadcast,
-                    EventPayload::Mcp(McpEvent::ConnectionReconnected {
-                        server: id.to_string(),
-                    }),
-                );
-                self.publish_event(event).await;
+                self.publish_mcp_event(McpEvent::ConnectionReconnected {
+                    server: id.to_string(),
+                })
+                .await;
                 Ok(tool_count)
             }
             Err(e) => {

--- a/crates/openfang-kernel/src/kernel.rs
+++ b/crates/openfang-kernel/src/kernel.rs
@@ -5878,6 +5878,7 @@ impl OpenFangKernel {
                 headers: server_config.headers.clone(),
                 allow_push_events: server_config.allow_push_events,
                 push_queue_size: server_config.push_queue_size,
+                push_rate_limit_per_minute: server_config.push_rate_limit_per_minute,
             };
 
             match McpConnection::connect_with_notifications(mcp_config, notification_tx).await {
@@ -5993,6 +5994,7 @@ impl OpenFangKernel {
                 headers: server_config.headers.clone(),
                 allow_push_events: server_config.allow_push_events,
                 push_queue_size: server_config.push_queue_size,
+                push_rate_limit_per_minute: server_config.push_rate_limit_per_minute,
             };
 
             self.extension_health.register(&server_config.name);
@@ -6123,6 +6125,7 @@ impl OpenFangKernel {
             headers: server_config.headers.clone(),
             allow_push_events: server_config.allow_push_events,
             push_queue_size: server_config.push_queue_size,
+            push_rate_limit_per_minute: server_config.push_rate_limit_per_minute,
         };
 
         let (notification_tx, notification_rx) = self.mcp_notification_channel(
@@ -9326,6 +9329,7 @@ mod tests {
                 headers: vec![],
                 allow_push_events: false,
                 push_queue_size: 256,
+                push_rate_limit_per_minute: 600,
             }],
             ..KernelConfig::default()
         };

--- a/crates/openfang-kernel/src/triggers.rs
+++ b/crates/openfang-kernel/src/triggers.rs
@@ -282,6 +282,12 @@ impl TriggerEngine {
                 continue;
             }
 
+            if let openfang_types::event::EventTarget::Agent(target_agent) = &event.target {
+                if trigger.agent_id != *target_agent {
+                    continue;
+                }
+            }
+
             // Check max fires
             if trigger.max_fires > 0 && trigger.fire_count >= trigger.max_fires {
                 trigger.enabled = false;
@@ -571,6 +577,37 @@ mod tests {
         assert_eq!(engine.evaluate(&event).len(), 1);
         // Third should not
         assert_eq!(engine.evaluate(&event).len(), 0);
+    }
+
+    #[test]
+    fn test_agent_target_only_evaluates_matching_agent_triggers() {
+        let engine = TriggerEngine::new();
+        let target_agent = AgentId::new();
+        let other_agent = AgentId::new();
+        engine.register(
+            target_agent,
+            TriggerPattern::All,
+            "Target: {{event}}".to_string(),
+            0,
+        );
+        engine.register(
+            other_agent,
+            TriggerPattern::All,
+            "Other: {{event}}".to_string(),
+            0,
+        );
+
+        let event = Event::new(
+            AgentId::new(),
+            EventTarget::Agent(target_agent),
+            EventPayload::System(SystemEvent::HealthCheck {
+                status: "ok".to_string(),
+            }),
+        );
+
+        let matches = engine.evaluate(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, target_agent);
     }
 
     #[test]

--- a/crates/openfang-kernel/src/triggers.rs
+++ b/crates/openfang-kernel/src/triggers.rs
@@ -409,6 +409,9 @@ fn describe_event(event: &Event) -> String {
         EventPayload::Network(ne) => {
             format!("Network event: {:?}", ne)
         }
+        EventPayload::Mcp(mcp) => {
+            format!("MCP event: {:?}", mcp)
+        }
         EventPayload::System(se) => match se {
             SystemEvent::KernelStarted => "Kernel started".to_string(),
             SystemEvent::KernelStopping => "Kernel stopping".to_string(),

--- a/crates/openfang-runtime/Cargo.toml
+++ b/crates/openfang-runtime/Cargo.toml
@@ -31,6 +31,7 @@ dashmap = { workspace = true }
 regex-lite = { workspace = true }
 rusqlite = { workspace = true }
 rmcp = { workspace = true }
+governor = { workspace = true }
 http = "1"
 tokio-tungstenite = "0.24"
 shlex = "1"

--- a/crates/openfang-runtime/src/kernel_handle.rs
+++ b/crates/openfang-runtime/src/kernel_handle.rs
@@ -86,6 +86,17 @@ pub trait KernelHandle: Send + Sync {
         payload: serde_json::Value,
     ) -> Result<(), String>;
 
+    /// Subscribe the calling agent to server-initiated MCP resource updates.
+    async fn mcp_subscribe_resource(
+        &self,
+        agent_id: &str,
+        server: Option<&str>,
+        uri: &str,
+    ) -> Result<String, String> {
+        let _ = (agent_id, server, uri);
+        Err("MCP resource subscription not available".to_string())
+    }
+
     /// Add an entity to the knowledge graph.
     async fn knowledge_add_entity(
         &self,

--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -7,6 +7,7 @@
 //!
 //! All MCP tools are namespaced with `mcp_{server}_{tool}` to prevent collisions.
 
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use http::{HeaderName, HeaderValue};
 use openfang_types::event::McpEvent;
 use openfang_types::tool::ToolDefinition;
@@ -19,6 +20,7 @@ use rmcp::{ClientHandler, RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
+use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 use tracing::{debug, info, warn};
@@ -52,6 +54,9 @@ pub struct McpServerConfig {
     /// Maximum queued push notifications before older events are dropped.
     #[serde(default = "default_push_queue_size")]
     pub push_queue_size: usize,
+    /// Maximum server-initiated notifications accepted per minute.
+    #[serde(default = "default_push_rate_limit_per_minute")]
+    pub push_rate_limit_per_minute: u32,
 }
 
 fn default_timeout() -> u64 {
@@ -60,6 +65,10 @@ fn default_timeout() -> u64 {
 
 fn default_push_queue_size() -> usize {
     256
+}
+
+fn default_push_rate_limit_per_minute() -> u32 {
+    600
 }
 
 /// Transport type for MCP server connections.
@@ -222,14 +231,18 @@ struct OpenFangMcpClient {
     server_name: String,
     allow_push_events: bool,
     notification_tx: Option<McpNotificationSender>,
+    rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
 }
 
 impl OpenFangMcpClient {
     fn new(
         server_name: String,
         allow_push_events: bool,
+        push_rate_limit_per_minute: u32,
         notification_tx: Option<McpNotificationSender>,
     ) -> Self {
+        let rate_limiter = NonZeroU32::new(push_rate_limit_per_minute)
+            .map(|limit| Arc::new(RateLimiter::direct(Quota::per_minute(limit))));
         Self {
             info: ClientInfo::new(
                 ClientCapabilities::default(),
@@ -238,6 +251,7 @@ impl OpenFangMcpClient {
             server_name,
             allow_push_events,
             notification_tx,
+            rate_limiter,
         }
     }
 
@@ -254,6 +268,22 @@ impl OpenFangMcpClient {
         let Some(tx) = &self.notification_tx else {
             return;
         };
+
+        if let Some(limiter) = &self.rate_limiter {
+            if limiter.check().is_err() {
+                tx.push(McpEvent::NotificationDropped {
+                    server: mcp_event_server(&event).to_string(),
+                    kind: mcp_event_kind(&event).to_string(),
+                    dropped_count: 1,
+                });
+                warn!(
+                    server = %self.server_name,
+                    kind = mcp_event_kind(&event),
+                    "MCP push notification dropped by rate limit"
+                );
+                return;
+            }
+        }
 
         tx.push(event);
     }
@@ -329,6 +359,7 @@ impl McpConnection {
         let client_handler = OpenFangMcpClient::new(
             config.name.clone(),
             config.allow_push_events,
+            config.push_rate_limit_per_minute,
             notification_tx,
         );
         let client = match &config.transport {
@@ -775,6 +806,7 @@ mod tests {
             headers: vec![],
             allow_push_events: false,
             push_queue_size: default_push_queue_size(),
+            push_rate_limit_per_minute: default_push_rate_limit_per_minute(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -802,6 +834,7 @@ mod tests {
             headers: vec![],
             allow_push_events: false,
             push_queue_size: default_push_queue_size(),
+            push_rate_limit_per_minute: default_push_rate_limit_per_minute(),
         };
         let json = serde_json::to_string(&sse_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -821,11 +854,13 @@ mod tests {
             headers: vec!["Authorization: Bearer test-token-456".to_string()],
             allow_push_events: true,
             push_queue_size: 512,
+            push_rate_limit_per_minute: 120,
         };
         let json = serde_json::to_string(&http_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
         assert!(back.allow_push_events);
         assert_eq!(back.push_queue_size, 512);
+        assert_eq!(back.push_rate_limit_per_minute, 120);
         match back.transport {
             McpTransport::Http { url } => {
                 assert_eq!(url, "https://mcp.atlassian.com/v1/mcp")
@@ -882,20 +917,50 @@ mod tests {
     #[test]
     fn test_openfang_mcp_client_gates_push_events() {
         let (tx, rx) = mcp_notification_channel(4);
-        let client = OpenFangMcpClient::new("test".to_string(), false, Some(tx.clone()));
+        let client = OpenFangMcpClient::new("test".to_string(), false, 600, Some(tx.clone()));
 
         client.dispatch(McpEvent::ToolListChanged {
             server: "test".to_string(),
         });
         assert!(rx.try_recv().is_none());
 
-        let client = OpenFangMcpClient::new("test".to_string(), true, Some(tx));
+        let client = OpenFangMcpClient::new("test".to_string(), true, 600, Some(tx));
         client.dispatch(McpEvent::ToolListChanged {
             server: "test".to_string(),
         });
         match rx.try_recv() {
             Some(McpEvent::ToolListChanged { server }) => assert_eq!(server, "test"),
             other => panic!("expected ToolListChanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_openfang_mcp_client_rate_limits_push_events() {
+        let (tx, rx) = mcp_notification_channel(4);
+        let client = OpenFangMcpClient::new("test".to_string(), true, 1, Some(tx));
+
+        client.dispatch(McpEvent::ResourceListChanged {
+            server: "test".to_string(),
+        });
+        client.dispatch(McpEvent::ToolListChanged {
+            server: "test".to_string(),
+        });
+
+        match rx.try_recv() {
+            Some(McpEvent::ResourceListChanged { server }) => assert_eq!(server, "test"),
+            other => panic!("expected ResourceListChanged, got {other:?}"),
+        }
+        match rx.try_recv() {
+            Some(McpEvent::NotificationDropped {
+                server,
+                kind,
+                dropped_count,
+            }) => {
+                assert_eq!(server, "test");
+                assert_eq!(kind, "tool_list_changed");
+                assert_eq!(dropped_count, 1);
+            }
+            other => panic!("expected NotificationDropped, got {other:?}"),
         }
     }
 }

--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -8,13 +8,20 @@
 //! All MCP tools are namespaced with `mcp_{server}_{tool}` to prevent collisions.
 
 use http::{HeaderName, HeaderValue};
+use openfang_types::event::McpEvent;
 use openfang_types::tool::ToolDefinition;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
-use rmcp::service::RunningService;
-use rmcp::{RoleClient, ServiceExt};
+use rmcp::model::{
+    CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation,
+    ResourceUpdatedNotificationParam, ServerCapabilities,
+};
+use rmcp::service::{MaybeSendFuture, NotificationContext, RunningService};
+use rmcp::{ClientHandler, RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use tracing::{debug, info};
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+use tracing::{debug, info, warn};
 
 // ---------------------------------------------------------------------------
 // Configuration types
@@ -91,7 +98,217 @@ pub struct McpConnection {
     original_names: HashMap<String, String>,
     /// The rmcp client handle — type-erased because the concrete type
     /// depends on which transport was used (stdio vs HTTP).
-    client: RunningService<RoleClient, ClientInfo>,
+    client: RunningService<RoleClient, OpenFangMcpClient>,
+}
+
+/// Create a bounded queue for MCP push notifications.
+///
+/// When the queue is full, the oldest queued notifications are dropped and a
+/// `NotificationDropped` event is enqueued ahead of the newest event.
+pub fn mcp_notification_channel(
+    capacity: usize,
+) -> (McpNotificationSender, McpNotificationReceiver) {
+    let inner = Arc::new(McpNotificationChannelInner {
+        queue: Mutex::new(VecDeque::new()),
+        notify: Notify::new(),
+        capacity: capacity.max(2),
+    });
+
+    (
+        McpNotificationSender {
+            inner: Arc::clone(&inner),
+        },
+        McpNotificationReceiver { inner },
+    )
+}
+
+#[derive(Clone)]
+pub struct McpNotificationSender {
+    inner: Arc<McpNotificationChannelInner>,
+}
+
+pub struct McpNotificationReceiver {
+    inner: Arc<McpNotificationChannelInner>,
+}
+
+struct McpNotificationChannelInner {
+    queue: Mutex<VecDeque<McpEvent>>,
+    notify: Notify,
+    capacity: usize,
+}
+
+impl McpNotificationSender {
+    pub fn push(&self, event: McpEvent) {
+        let dropped_event = {
+            let mut queue = self
+                .inner
+                .queue
+                .lock()
+                .expect("MCP notification queue poisoned");
+            let required_slots = if queue.len() >= self.inner.capacity {
+                2
+            } else {
+                1
+            };
+            let overflow = queue
+                .len()
+                .saturating_add(required_slots)
+                .saturating_sub(self.inner.capacity);
+            let mut dropped_count = 0;
+
+            for _ in 0..overflow {
+                if queue.pop_front().is_some() {
+                    dropped_count += 1;
+                }
+            }
+
+            let dropped_event = if dropped_count > 0 {
+                Some(McpEvent::NotificationDropped {
+                    server: mcp_event_server(&event).to_string(),
+                    kind: mcp_event_kind(&event).to_string(),
+                    dropped_count,
+                })
+            } else {
+                None
+            };
+
+            if let Some(dropped) = dropped_event.clone() {
+                queue.push_back(dropped);
+            }
+            queue.push_back(event);
+            dropped_event
+        };
+
+        if let Some(McpEvent::NotificationDropped {
+            server,
+            kind,
+            dropped_count,
+        }) = dropped_event
+        {
+            warn!(
+                server = %server,
+                kind = %kind,
+                dropped_count,
+                "MCP notification queue dropped older events"
+            );
+        }
+
+        self.inner.notify.notify_waiters();
+    }
+}
+
+impl McpNotificationReceiver {
+    pub async fn recv(&self) -> McpEvent {
+        loop {
+            if let Some(event) = self.try_recv() {
+                return event;
+            }
+            self.inner.notify.notified().await;
+        }
+    }
+
+    pub fn try_recv(&self) -> Option<McpEvent> {
+        self.inner
+            .queue
+            .lock()
+            .expect("MCP notification queue poisoned")
+            .pop_front()
+    }
+}
+
+#[derive(Clone)]
+struct OpenFangMcpClient {
+    info: ClientInfo,
+    server_name: String,
+    allow_push_events: bool,
+    notification_tx: Option<McpNotificationSender>,
+}
+
+impl OpenFangMcpClient {
+    fn new(
+        server_name: String,
+        allow_push_events: bool,
+        notification_tx: Option<McpNotificationSender>,
+    ) -> Self {
+        Self {
+            info: ClientInfo::new(
+                ClientCapabilities::default(),
+                Implementation::new("openfang", env!("CARGO_PKG_VERSION")),
+            ),
+            server_name,
+            allow_push_events,
+            notification_tx,
+        }
+    }
+
+    fn dispatch(&self, event: McpEvent) {
+        if !self.allow_push_events {
+            debug!(
+                server = %self.server_name,
+                kind = mcp_event_kind(&event),
+                "MCP push notification ignored because allow_push_events is false"
+            );
+            return;
+        }
+
+        let Some(tx) = &self.notification_tx else {
+            return;
+        };
+
+        tx.push(event);
+    }
+}
+
+impl ClientHandler for OpenFangMcpClient {
+    fn on_resource_updated(
+        &self,
+        params: ResourceUpdatedNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+        async move {
+            self.dispatch(McpEvent::ResourceUpdated {
+                server: self.server_name.clone(),
+                uri: params.uri,
+            });
+        }
+    }
+
+    fn on_resource_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+        async move {
+            self.dispatch(McpEvent::ResourceListChanged {
+                server: self.server_name.clone(),
+            });
+        }
+    }
+
+    fn on_tool_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+        async move {
+            self.dispatch(McpEvent::ToolListChanged {
+                server: self.server_name.clone(),
+            });
+        }
+    }
+
+    fn on_prompt_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+        async move {
+            self.dispatch(McpEvent::PromptListChanged {
+                server: self.server_name.clone(),
+            });
+        }
+    }
+
+    fn get_info(&self) -> ClientInfo {
+        self.info.clone()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -101,17 +318,25 @@ pub struct McpConnection {
 impl McpConnection {
     /// Connect to an MCP server, perform handshake, and discover tools.
     pub async fn connect(config: McpServerConfig) -> Result<Self, String> {
-        let client_info = ClientInfo::new(
-            ClientCapabilities::default(),
-            Implementation::new("openfang", env!("CARGO_PKG_VERSION")),
-        );
+        Self::connect_with_notifications(config, None).await
+    }
 
+    /// Connect to an MCP server with a push-notification queue.
+    pub async fn connect_with_notifications(
+        config: McpServerConfig,
+        notification_tx: Option<McpNotificationSender>,
+    ) -> Result<Self, String> {
+        let client_handler = OpenFangMcpClient::new(
+            config.name.clone(),
+            config.allow_push_events,
+            notification_tx,
+        );
         let client = match &config.transport {
             McpTransport::Stdio { command, args } => {
-                Self::connect_stdio(command, args, &config.env, client_info).await?
+                Self::connect_stdio(command, args, &config.env, client_handler).await?
             }
             McpTransport::Sse { url } | McpTransport::Http { url } => {
-                Self::connect_http(url, &config.headers, client_info).await?
+                Self::connect_http(url, &config.headers, client_handler).await?
             }
         };
 
@@ -221,6 +446,28 @@ impl McpConnection {
         &self.config.name
     }
 
+    /// Subscribe to server notifications for a resource URI.
+    pub async fn subscribe_resource(&self, uri: impl Into<String>) -> Result<(), String> {
+        let uri = uri.into();
+        let server_capabilities = self
+            .client
+            .peer_info()
+            .map(|info| info.capabilities.clone())
+            .unwrap_or_else(ServerCapabilities::default);
+
+        if !server_supports_resource_subscribe(&server_capabilities) {
+            return Err(format!(
+                "MCP server '{}' does not advertise resource subscription support",
+                self.config.name
+            ));
+        }
+
+        self.client
+            .subscribe(rmcp::model::SubscribeRequestParams::new(uri))
+            .await
+            .map_err(|e| format!("MCP resource subscribe failed: {e}"))
+    }
+
     // -- Transport constructors -----------------------------------------------
 
     /// Connect using stdio transport (subprocess).
@@ -228,8 +475,8 @@ impl McpConnection {
         command: &str,
         args: &[String],
         env_whitelist: &[String],
-        client_info: ClientInfo,
-    ) -> Result<RunningService<RoleClient, ClientInfo>, String> {
+        client_handler: OpenFangMcpClient,
+    ) -> Result<RunningService<RoleClient, OpenFangMcpClient>, String> {
         use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
         use tokio::process::Command;
 
@@ -282,7 +529,7 @@ impl McpConnection {
         }))
         .map_err(|e| format!("Failed to spawn MCP server '{cmd_str}': {e}"))?;
 
-        let client = client_info
+        let client = client_handler
             .serve(transport)
             .await
             .map_err(|e| format!("MCP stdio handshake failed: {e}"))?;
@@ -298,8 +545,8 @@ impl McpConnection {
     async fn connect_http(
         url: &str,
         headers: &[String],
-        client_info: ClientInfo,
-    ) -> Result<RunningService<RoleClient, ClientInfo>, String> {
+        client_handler: OpenFangMcpClient,
+    ) -> Result<RunningService<RoleClient, OpenFangMcpClient>, String> {
         use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
         use rmcp::transport::StreamableHttpClientTransport;
 
@@ -327,7 +574,7 @@ impl McpConnection {
 
         let transport = StreamableHttpClientTransport::from_config(config);
 
-        let client = client_info
+        let client = client_handler
             .serve(transport)
             .await
             .map_err(|e| format!("MCP HTTP connection failed: {e}"))?;
@@ -400,6 +647,36 @@ pub fn extract_mcp_server_from_known<'a>(
 fn strip_mcp_prefix<'a>(server: &str, tool_name: &'a str) -> Option<&'a str> {
     let prefix = format!("mcp_{}_", normalize_name(server));
     tool_name.strip_prefix(&prefix)
+}
+
+fn server_supports_resource_subscribe(capabilities: &ServerCapabilities) -> bool {
+    capabilities
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.subscribe)
+        .unwrap_or(false)
+}
+
+fn mcp_event_server(event: &McpEvent) -> &str {
+    match event {
+        McpEvent::ResourceUpdated { server, .. }
+        | McpEvent::ResourceListChanged { server }
+        | McpEvent::ToolListChanged { server }
+        | McpEvent::PromptListChanged { server }
+        | McpEvent::ConnectionReconnected { server }
+        | McpEvent::NotificationDropped { server, .. } => server,
+    }
+}
+
+fn mcp_event_kind(event: &McpEvent) -> &'static str {
+    match event {
+        McpEvent::ResourceUpdated { .. } => "resource_updated",
+        McpEvent::ResourceListChanged { .. } => "resource_list_changed",
+        McpEvent::ToolListChanged { .. } => "tool_list_changed",
+        McpEvent::PromptListChanged { .. } => "prompt_list_changed",
+        McpEvent::ConnectionReconnected { .. } => "connection_reconnected",
+        McpEvent::NotificationDropped { .. } => "notification_dropped",
+    }
 }
 
 /// Normalize a name for use in tool namespacing (lowercase, replace hyphens).
@@ -554,6 +831,71 @@ mod tests {
                 assert_eq!(url, "https://mcp.atlassian.com/v1/mcp")
             }
             _ => panic!("Expected Http transport"),
+        }
+    }
+
+    #[test]
+    fn test_server_supports_resource_subscribe() {
+        let mut capabilities = ServerCapabilities::default();
+        assert!(!server_supports_resource_subscribe(&capabilities));
+
+        capabilities.resources = Some(rmcp::model::ResourcesCapability {
+            subscribe: Some(true),
+            list_changed: None,
+        });
+        assert!(server_supports_resource_subscribe(&capabilities));
+    }
+
+    #[test]
+    fn test_mcp_notification_queue_drops_oldest() {
+        let (tx, rx) = mcp_notification_channel(2);
+
+        tx.push(McpEvent::ResourceListChanged {
+            server: "test".to_string(),
+        });
+        tx.push(McpEvent::ToolListChanged {
+            server: "test".to_string(),
+        });
+        tx.push(McpEvent::PromptListChanged {
+            server: "test".to_string(),
+        });
+
+        match rx.try_recv() {
+            Some(McpEvent::NotificationDropped {
+                server,
+                kind,
+                dropped_count,
+            }) => {
+                assert_eq!(server, "test");
+                assert_eq!(kind, "prompt_list_changed");
+                assert_eq!(dropped_count, 2);
+            }
+            other => panic!("expected NotificationDropped, got {other:?}"),
+        }
+        match rx.try_recv() {
+            Some(McpEvent::PromptListChanged { server }) => assert_eq!(server, "test"),
+            other => panic!("expected PromptListChanged, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_openfang_mcp_client_gates_push_events() {
+        let (tx, rx) = mcp_notification_channel(4);
+        let client = OpenFangMcpClient::new("test".to_string(), false, Some(tx.clone()));
+
+        client.dispatch(McpEvent::ToolListChanged {
+            server: "test".to_string(),
+        });
+        assert!(rx.try_recv().is_none());
+
+        let client = OpenFangMcpClient::new("test".to_string(), true, Some(tx));
+        client.dispatch(McpEvent::ToolListChanged {
+            server: "test".to_string(),
+        });
+        match rx.try_recv() {
+            Some(McpEvent::ToolListChanged { server }) => assert_eq!(server, "test"),
+            other => panic!("expected ToolListChanged, got {other:?}"),
         }
     }
 }

--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -289,6 +289,7 @@ impl OpenFangMcpClient {
     }
 }
 
+#[allow(clippy::manual_async_fn)]
 impl ClientHandler for OpenFangMcpClient {
     fn on_resource_updated(
         &self,
@@ -484,7 +485,7 @@ impl McpConnection {
             .client
             .peer_info()
             .map(|info| info.capabilities.clone())
-            .unwrap_or_else(ServerCapabilities::default);
+            .unwrap_or_default();
 
         if !server_supports_resource_subscribe(&server_capabilities) {
             return Err(format!(

--- a/crates/openfang-runtime/src/mcp.rs
+++ b/crates/openfang-runtime/src/mcp.rs
@@ -39,10 +39,20 @@ pub struct McpServerConfig {
     /// or any custom headers required by a remote MCP server.
     #[serde(default)]
     pub headers: Vec<String>,
+    /// Allow server-initiated MCP notifications to enter the event bus.
+    #[serde(default)]
+    pub allow_push_events: bool,
+    /// Maximum queued push notifications before older events are dropped.
+    #[serde(default = "default_push_queue_size")]
+    pub push_queue_size: usize,
 }
 
 fn default_timeout() -> u64 {
     60
+}
+
+fn default_push_queue_size() -> usize {
+    256
 }
 
 /// Transport type for MCP server connections.
@@ -486,6 +496,8 @@ mod tests {
             timeout_secs: 30,
             env: vec!["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()],
             headers: vec![],
+            allow_push_events: false,
+            push_queue_size: default_push_queue_size(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -511,6 +523,8 @@ mod tests {
             timeout_secs: 60,
             env: vec![],
             headers: vec![],
+            allow_push_events: false,
+            push_queue_size: default_push_queue_size(),
         };
         let json = serde_json::to_string(&sse_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
@@ -528,9 +542,13 @@ mod tests {
             timeout_secs: 120,
             env: vec![],
             headers: vec!["Authorization: Bearer test-token-456".to_string()],
+            allow_push_events: true,
+            push_queue_size: 512,
         };
         let json = serde_json::to_string(&http_config).unwrap();
         let back: McpServerConfig = serde_json::from_str(&json).unwrap();
+        assert!(back.allow_push_events);
+        assert_eq!(back.push_queue_size, 512);
         match back.transport {
             McpTransport::Http { url } => {
                 assert_eq!(url, "https://mcp.atlassian.com/v1/mcp")

--- a/crates/openfang-runtime/src/tool_runner.rs
+++ b/crates/openfang-runtime/src/tool_runner.rs
@@ -486,6 +486,11 @@ pub async fn execute_tool(
         // Canvas / A2UI tool
         "canvas_present" => tool_canvas_present(input, workspace_root).await,
 
+        // MCP subscription control tool.
+        "mcp_subscribe_resource" => {
+            tool_mcp_subscribe_resource(input, kernel, caller_agent_id).await
+        }
+
         other => {
             // Fallback 1: MCP tools (mcp_{server}_{tool} prefix)
             if mcp::is_mcp_tool(other) {
@@ -651,6 +656,19 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
                     "max_results": { "type": "integer", "description": "Maximum number of results to return (default: 5, max: 20)" }
                 },
                 "required": ["query"]
+            }),
+        },
+        // --- MCP control tools ---
+        ToolDefinition {
+            name: "mcp_subscribe_resource".to_string(),
+            description: "Subscribe to server-initiated updates for an MCP resource URI. Requires an mcp_subscribe capability grant for the server and URI.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "uri": { "type": "string", "description": "The MCP resource URI to subscribe to" },
+                    "server": { "type": "string", "description": "Optional MCP server name; required when more than one server is connected" }
+                },
+                "required": ["uri"]
             }),
         },
         // --- Shell tool ---
@@ -2000,6 +2018,26 @@ async fn tool_event_publish(
         .unwrap_or(serde_json::json!({}));
     kh.publish_event(event_type, payload).await?;
     Ok(format!("Event '{event_type}' published successfully."))
+}
+
+async fn tool_mcp_subscribe_resource(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> Result<String, String> {
+    let kh = require_kernel(kernel)?;
+    let agent_id = caller_agent_id.ok_or("Missing caller agent ID")?;
+    let uri = input["uri"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or("Missing 'uri' parameter")?;
+    let server = input["server"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    kh.mcp_subscribe_resource(agent_id, server, uri).await
 }
 
 // ---------------------------------------------------------------------------
@@ -3770,6 +3808,7 @@ mod tests {
         assert!(names.contains(&"task_complete"));
         assert!(names.contains(&"task_list"));
         assert!(names.contains(&"event_publish"));
+        assert!(names.contains(&"mcp_subscribe_resource"));
         // 5 new Phase 3 tools
         assert!(names.contains(&"schedule_create"));
         assert!(names.contains(&"schedule_list"));

--- a/crates/openfang-types/src/agent.rs
+++ b/crates/openfang-types/src/agent.rs
@@ -361,6 +361,7 @@ impl ToolProfile {
                 vec!["self.*".into()]
             },
             memory_write: vec!["self.*".into()],
+            mcp_subscribe: vec![],
             ofp_discover: false,
             ofp_connect: vec![],
         }
@@ -589,6 +590,9 @@ pub struct ManifestCapabilities {
     /// Memory write scopes.
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub memory_write: Vec<String>,
+    /// MCP resource subscription scopes, formatted as "server:uri".
+    #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
+    pub mcp_subscribe: Vec<String>,
     /// Whether this agent can spawn sub-agents.
     pub agent_spawn: bool,
     /// Agent message patterns (e.g., ["*"] or ["agent-name"]).

--- a/crates/openfang-types/src/capability.rs
+++ b/crates/openfang-types/src/capability.rs
@@ -27,6 +27,8 @@ pub enum Capability {
     ToolInvoke(String),
     /// Invoke any tool (dangerous, requires explicit grant).
     ToolAll,
+    /// Subscribe to MCP resource updates matching the given server/URI pattern.
+    McpSubscribe(String),
 
     // -- LLM --
     /// Query models matching the pattern.
@@ -118,6 +120,9 @@ pub fn capability_matches(granted: &Capability, required: &Capability) -> bool {
         }
         (Capability::ToolInvoke(granted_id), Capability::ToolInvoke(required_id)) => {
             granted_id == required_id || granted_id == "*"
+        }
+        (Capability::McpSubscribe(pattern), Capability::McpSubscribe(resource)) => {
+            glob_matches(pattern, resource)
         }
         (Capability::LlmQuery(pattern), Capability::LlmQuery(model)) => {
             glob_matches(pattern, model)
@@ -244,6 +249,18 @@ mod tests {
         assert!(capability_matches(
             &Capability::ToolAll,
             &Capability::ToolInvoke("web_search".to_string()),
+        ));
+    }
+
+    #[test]
+    fn test_mcp_subscribe_matches_resource_pattern() {
+        assert!(capability_matches(
+            &Capability::McpSubscribe("github:*".to_string()),
+            &Capability::McpSubscribe("github:repo://RightNow-AI/openfang".to_string()),
+        ));
+        assert!(!capability_matches(
+            &Capability::McpSubscribe("gmail:*".to_string()),
+            &Capability::McpSubscribe("github:repo://RightNow-AI/openfang".to_string()),
         ));
     }
 

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -1424,10 +1424,20 @@ pub struct McpServerConfigEntry {
     /// Each entry is `"Header-Name: value"` (e.g., `"Authorization: Bearer <token>"`).
     #[serde(default)]
     pub headers: Vec<String>,
+    /// Allow server-initiated MCP notifications to enter the event bus.
+    #[serde(default)]
+    pub allow_push_events: bool,
+    /// Maximum queued push notifications before older events are dropped.
+    #[serde(default = "default_mcp_push_queue_size")]
+    pub push_queue_size: usize,
 }
 
 fn default_mcp_timeout() -> u64 {
     30
+}
+
+fn default_mcp_push_queue_size() -> usize {
+    256
 }
 
 /// Transport configuration for an MCP server.

--- a/crates/openfang-types/src/config.rs
+++ b/crates/openfang-types/src/config.rs
@@ -1430,6 +1430,9 @@ pub struct McpServerConfigEntry {
     /// Maximum queued push notifications before older events are dropped.
     #[serde(default = "default_mcp_push_queue_size")]
     pub push_queue_size: usize,
+    /// Maximum server-initiated notifications accepted per minute.
+    #[serde(default = "default_mcp_push_rate_limit_per_minute")]
+    pub push_rate_limit_per_minute: u32,
 }
 
 fn default_mcp_timeout() -> u64 {
@@ -1438,6 +1441,10 @@ fn default_mcp_timeout() -> u64 {
 
 fn default_mcp_push_queue_size() -> usize {
     256
+}
+
+fn default_mcp_push_rate_limit_per_minute() -> u32 {
+    600
 }
 
 /// Transport configuration for an MCP server.

--- a/crates/openfang-types/src/event.rs
+++ b/crates/openfang-types/src/event.rs
@@ -80,6 +80,8 @@ pub enum EventPayload {
     Lifecycle(LifecycleEvent),
     /// Network event (remote agent activity).
     Network(NetworkEvent),
+    /// MCP server-initiated notification.
+    Mcp(McpEvent),
     /// System event (health, resources).
     System(SystemEvent),
     /// User-defined payload.
@@ -218,6 +220,48 @@ pub enum NetworkEvent {
         service: String,
         /// The peers that provide the service.
         providers: Vec<String>,
+    },
+}
+
+/// MCP server-initiated event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event")]
+pub enum McpEvent {
+    /// A subscribed resource changed.
+    ResourceUpdated {
+        /// MCP server name from config.
+        server: String,
+        /// Resource URI reported by the server.
+        uri: String,
+    },
+    /// A server's resource list changed.
+    ResourceListChanged {
+        /// MCP server name from config.
+        server: String,
+    },
+    /// A server's tool list changed.
+    ToolListChanged {
+        /// MCP server name from config.
+        server: String,
+    },
+    /// A server's prompt list changed.
+    PromptListChanged {
+        /// MCP server name from config.
+        server: String,
+    },
+    /// A connection was re-established and subscriptions were replayed.
+    ConnectionReconnected {
+        /// MCP server name from config.
+        server: String,
+    },
+    /// A notification was dropped due to queue pressure.
+    NotificationDropped {
+        /// MCP server name from config.
+        server: String,
+        /// Notification kind that was dropped.
+        kind: String,
+        /// Number of dropped notifications observed.
+        dropped_count: u64,
     },
 }
 
@@ -402,5 +446,28 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.ttl, Some(Duration::from_millis(60_000)));
+    }
+
+    #[test]
+    fn test_mcp_event_serialization() {
+        let agent_id = AgentId::new();
+        let event = Event::new(
+            agent_id,
+            EventTarget::Agent(AgentId::new()),
+            EventPayload::Mcp(McpEvent::ResourceUpdated {
+                server: "github".to_string(),
+                uri: "repo://RightNow-AI/openfang".to_string(),
+            }),
+        );
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: Event = serde_json::from_str(&json).unwrap();
+        match deserialized.payload {
+            EventPayload::Mcp(McpEvent::ResourceUpdated { server, uri }) => {
+                assert_eq!(server, "github");
+                assert_eq!(uri, "repo://RightNow-AI/openfang");
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds MCP resource push-notification support across the type, runtime, and kernel layers. This lets OpenFang subscribe to MCP resources, receive server-side notifications, bridge them into kernel events, and replay subscriptions after MCP reconnects.

Refs #1096.

## Changes

- Adds typed MCP push notification, subscription, and event contracts.
- Extends the MCP runtime to subscribe to resources, handle push events, rate-limit notifications, and emit tool-list-change events for targeted capability refreshes.
- Bridges MCP push events through the kernel trigger path so agents can react to resource changes.
- Adds an `mcp_resource_subscribe` tool and matching capability/config support.
- Replays MCP subscriptions after reconnect so long-lived agents do not silently lose resource watches.

This is currently one focused draft PR. I can split it into stacked PRs if maintainers would prefer type contracts, runtime handling, kernel bridging, and tool surface changes reviewed separately.

## Testing

- [x] `cargo fmt --all -- --check` passes locally
- [x] `cargo check --workspace` passes locally with `openfang-desktop` included
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes locally with `openfang-desktop` included
- [x] `cargo test --workspace` passes locally with `openfang-desktop` included
- [x] CI check/test/clippy/format matrix passes
- [x] `cargo audit` currently fails on an existing workspace dependency advisory: `lettre 0.11.21` / `RUSTSEC-2026-0141`; fix is to upgrade to `lettre >= 0.11.22`
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries