### PR TITLE
feat: add NEAR AI Cloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@
 # OpenRouter (multi-provider gateway)
 # OPENROUTER_API_KEY=sk-or-...
 
+# NEAR AI Cloud (TEE inference)
+# NEARAI_API_KEY=...
+
 # Together AI
 # TOGETHER_API_KEY=...
 

--- a/README.md
+++ b/README.md
@@ -357,11 +357,11 @@ For production workloads, use the [WhatsApp Cloud API](https://developers.facebo
 
 ---
 
-## 27 LLM Providers, 123+ Models
+## LLM Providers, 128+ Models
 
-3 native drivers (Anthropic, Gemini, OpenAI-compatible) route to 27 providers:
+3 native drivers (Anthropic, Gemini, OpenAI-compatible) route to providers including:
 
-Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, Together, Mistral, Fireworks, Cohere, Perplexity, xAI, AI21, Cerebras, SambaNova, HuggingFace, Replicate, Ollama, vLLM, LM Studio, Qwen, MiniMax, Zhipu, Moonshot, Qianfan, Bedrock, and more.
+Anthropic, Gemini, OpenAI, Groq, DeepSeek, OpenRouter, NEAR AI Cloud, Together, Mistral, Fireworks, Cohere, Perplexity, xAI, AI21, Cerebras, SambaNova, HuggingFace, Replicate, Ollama, vLLM, LM Studio, Qwen, MiniMax, Zhipu, Moonshot, Qianfan, Bedrock, and more.
 
 Intelligent routing with task complexity scoring, automatic fallback, cost tracking, and per-model pricing.
 

--- a/crates/openfang-runtime/src/drivers/mod.rs
+++ b/crates/openfang-runtime/src/drivers/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Contains drivers for Anthropic Claude, Google Gemini, OpenAI-compatible APIs, and more.
 //! Supports: Anthropic, Gemini, OpenAI, Groq, OpenRouter, DeepSeek, Together,
-//! Mistral, Fireworks, Ollama, vLLM, Chutes.ai, and any OpenAI-compatible endpoint.
+//! Mistral, Fireworks, NEAR AI Cloud, Ollama, vLLM, Chutes.ai, and any OpenAI-compatible endpoint.
 
 pub mod anthropic;
 pub mod bedrock;
@@ -19,11 +19,12 @@ use openfang_types::model_catalog::{
     AI21_BASE_URL, ANTHROPIC_BASE_URL, AZURE_OPENAI_BASE_URL, CEREBRAS_BASE_URL, CHUTES_BASE_URL,
     COHERE_BASE_URL, DEEPSEEK_BASE_URL, FIREWORKS_BASE_URL, GEMINI_BASE_URL, GROQ_BASE_URL,
     HUGGINGFACE_BASE_URL, KIMI_CODING_BASE_URL, LEMONADE_BASE_URL, LMSTUDIO_BASE_URL,
-    MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, NOVITA_BASE_URL, NVIDIA_NIM_BASE_URL,
-    OLLAMA_BASE_URL, OPENAI_BASE_URL, OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL,
-    QWEN_BASE_URL, REPLICATE_BASE_URL, REQUESTY_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL,
-    VENICE_BASE_URL, VLLM_BASE_URL, VOLCENGINE_BASE_URL, VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL,
-    ZAI_BASE_URL, ZAI_CODING_BASE_URL, ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
+    MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, NEARAI_BASE_URL, NOVITA_BASE_URL,
+    NVIDIA_NIM_BASE_URL, OLLAMA_BASE_URL, OPENAI_BASE_URL, OPENROUTER_BASE_URL,
+    PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL, REPLICATE_BASE_URL, REQUESTY_BASE_URL,
+    SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VENICE_BASE_URL, VLLM_BASE_URL, VOLCENGINE_BASE_URL,
+    VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL, ZAI_BASE_URL, ZAI_CODING_BASE_URL, ZHIPU_BASE_URL,
+    ZHIPU_CODING_BASE_URL,
 };
 use std::sync::Arc;
 
@@ -276,6 +277,11 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
             api_key_env: "CHUTES_API_KEY",
             key_required: true,
         }),
+        "nearai" | "near-ai" => Some(ProviderDefaults {
+            base_url: NEARAI_BASE_URL,
+            api_key_env: "NEARAI_API_KEY",
+            key_required: true,
+        }),
         "venice" => Some(ProviderDefaults {
             base_url: VENICE_BASE_URL,
             api_key_env: "VENICE_API_KEY",
@@ -329,6 +335,7 @@ fn provider_defaults(provider: &str) -> Option<ProviderDefaults> {
 /// - `xai` — xAI (Grok)
 /// - `replicate` — Replicate
 /// - `chutes` — Chutes.ai (serverless open-source model inference)
+/// - `nearai` — NEAR AI Cloud TEE inference
 /// - Any custom provider with `base_url` set uses OpenAI-compatible format
 pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmError> {
     let provider = config.provider.as_str();
@@ -589,7 +596,7 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             "Unknown provider '{}'. Supported: anthropic, gemini, openai, azure, bedrock, groq, \
              openrouter, deepseek, together, mistral, fireworks, ollama, vllm, lmstudio, \
              perplexity, cohere, ai21, cerebras, sambanova, huggingface, xai, replicate, \
-             github-copilot, chutes, venice, nvidia, codex, claude-code. \
+             github-copilot, chutes, nearai, venice, nvidia, codex, claude-code. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
             provider
         ),
@@ -631,6 +638,7 @@ pub fn detect_available_provider() -> Option<(&'static str, &'static str, &'stat
             "PERPLEXITY_API_KEY",
         ),
         ("cohere", "command-r-plus", "COHERE_API_KEY"),
+        ("nearai", "zai-org/GLM-5.1-FP8", "NEARAI_API_KEY"),
         ("novita", "moonshotai/kimi-k2.5", "NOVITA_API_KEY"),
     ];
     for &(provider, model, env_var) in PROBE_ORDER {
@@ -687,6 +695,7 @@ pub fn known_providers() -> &'static [&'static str] {
         "qianfan",
         "volcengine",
         "chutes",
+        "nearai",
         "venice",
         "nvidia",
         "novita",
@@ -839,13 +848,14 @@ mod tests {
         assert!(providers.contains(&"qianfan"));
         assert!(providers.contains(&"volcengine"));
         assert!(providers.contains(&"chutes"));
+        assert!(providers.contains(&"nearai"));
         assert!(providers.contains(&"nvidia"));
         assert!(providers.contains(&"novita"));
         assert!(providers.contains(&"codex"));
         assert!(providers.contains(&"claude-code"));
         assert!(providers.contains(&"qwen-code"));
         assert!(providers.contains(&"azure"));
-        assert_eq!(providers.len(), 38);
+        assert_eq!(providers.len(), 39);
     }
 
     #[test]
@@ -900,6 +910,56 @@ mod tests {
         assert_eq!(d.base_url, "https://api.novita.ai/openai/v1");
         assert_eq!(d.api_key_env, "NOVITA_API_KEY");
         assert!(d.key_required);
+    }
+
+    #[test]
+    fn test_provider_defaults_nearai() {
+        let d = provider_defaults("nearai").unwrap();
+        assert_eq!(d.base_url, "https://cloud-api.near.ai/v1");
+        assert_eq!(d.api_key_env, "NEARAI_API_KEY");
+        assert!(d.key_required);
+    }
+
+    #[test]
+    fn test_provider_defaults_near_ai_alias() {
+        let d = provider_defaults("near-ai").unwrap();
+        assert_eq!(d.base_url, "https://cloud-api.near.ai/v1");
+        assert_eq!(d.api_key_env, "NEARAI_API_KEY");
+        assert!(d.key_required);
+    }
+
+    #[test]
+    fn test_nearai_provider_with_env_key() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let unique_key = "test-nearai-key-12345";
+        let _env = EnvVarGuard::set("NEARAI_API_KEY", unique_key);
+        let config = DriverConfig {
+            provider: "nearai".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: None,
+        };
+        let driver = create_driver(&config);
+        assert!(
+            driver.is_ok(),
+            "NEAR AI provider with env var should succeed"
+        );
+    }
+
+    #[test]
+    fn test_nearai_provider_no_key_errors() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvVarGuard::remove("NEARAI_API_KEY");
+        let config = DriverConfig {
+            provider: "nearai".to_string(),
+            api_key: None,
+            base_url: None,
+            skip_permissions: true,
+            subprocess_timeout_secs: None,
+        };
+        let driver = create_driver(&config);
+        assert!(driver.is_err());
     }
 
     #[test]

--- a/crates/openfang-runtime/src/model_catalog.rs
+++ b/crates/openfang-runtime/src/model_catalog.rs
@@ -1,6 +1,6 @@
 //! Model catalog — registry of known models with metadata, pricing, and auth detection.
 //!
-//! Provides a comprehensive catalog of 130+ builtin models across 28 providers,
+//! Provides a comprehensive catalog of 130+ builtin models across 43 providers,
 //! with alias resolution, auth status detection, and pricing lookups.
 
 use openfang_types::model_catalog::{
@@ -8,11 +8,11 @@ use openfang_types::model_catalog::{
     AZURE_OPENAI_BASE_URL, BEDROCK_BASE_URL, CEREBRAS_BASE_URL, CHUTES_BASE_URL, COHERE_BASE_URL,
     DEEPSEEK_BASE_URL, FIREWORKS_BASE_URL, GEMINI_BASE_URL, GITHUB_COPILOT_BASE_URL, GROQ_BASE_URL,
     HUGGINGFACE_BASE_URL, KIMI_CODING_BASE_URL, LEMONADE_BASE_URL, LMSTUDIO_BASE_URL,
-    MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, NVIDIA_NIM_BASE_URL, OLLAMA_BASE_URL,
-    OPENAI_BASE_URL, OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL, QWEN_BASE_URL,
-    REPLICATE_BASE_URL, REQUESTY_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL, VENICE_BASE_URL,
-    VLLM_BASE_URL, VOLCENGINE_BASE_URL, VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL, ZAI_BASE_URL,
-    ZAI_CODING_BASE_URL, ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
+    MINIMAX_BASE_URL, MISTRAL_BASE_URL, MOONSHOT_BASE_URL, NEARAI_BASE_URL, NVIDIA_NIM_BASE_URL,
+    OLLAMA_BASE_URL, OPENAI_BASE_URL, OPENROUTER_BASE_URL, PERPLEXITY_BASE_URL, QIANFAN_BASE_URL,
+    QWEN_BASE_URL, REPLICATE_BASE_URL, REQUESTY_BASE_URL, SAMBANOVA_BASE_URL, TOGETHER_BASE_URL,
+    VENICE_BASE_URL, VLLM_BASE_URL, VOLCENGINE_BASE_URL, VOLCENGINE_CODING_BASE_URL, XAI_BASE_URL,
+    ZAI_BASE_URL, ZAI_CODING_BASE_URL, ZHIPU_BASE_URL, ZHIPU_CODING_BASE_URL,
 };
 use std::collections::HashMap;
 
@@ -790,6 +790,16 @@ fn builtin_providers() -> Vec<ProviderInfo> {
             auth_status: AuthStatus::Missing,
             model_count: 0,
         },
+        // ── NEAR AI Cloud ───────────────────────────────────────────
+        ProviderInfo {
+            id: "nearai".into(),
+            display_name: "NEAR AI Cloud".into(),
+            api_key_env: "NEARAI_API_KEY".into(),
+            base_url: NEARAI_BASE_URL.into(),
+            key_required: true,
+            auth_status: AuthStatus::Missing,
+            model_count: 0,
+        },
         // ── Venice.ai ────────────────────────────────────────────────
         ProviderInfo {
             id: "venice".into(),
@@ -1030,6 +1040,9 @@ fn builtin_aliases() -> HashMap<String, String> {
         ("codex-o4", "codex/o4-mini"),
         // NVIDIA NIM aliases
         ("nemotron", "nvidia/llama-3.1-nemotron-70b-instruct"),
+        // NEAR AI Cloud aliases
+        ("nearai", "zai-org/GLM-5.1-FP8"),
+        ("nearai-glm", "zai-org/GLM-5.1-FP8"),
         // Venice aliases
         ("venice", "venice-uncensored"),
         // Claude Code aliases
@@ -4023,6 +4036,83 @@ fn builtin_models() -> Vec<ModelCatalogEntry> {
             aliases: vec!["chutes-llama-70b".into()],
         },
         // ══════════════════════════════════════════════════════════════
+        // NEAR AI Cloud TEE inference (5)
+        // ══════════════════════════════════════════════════════════════
+        ModelCatalogEntry {
+            id: "zai-org/GLM-5.1-FP8".into(),
+            display_name: "GLM 5.1 (NEAR AI TEE)".into(),
+            provider: "nearai".into(),
+            tier: ModelTier::Smart,
+            context_window: 202_752,
+            max_output_tokens: 8_192,
+            input_cost_per_m: 0.85,
+            output_cost_per_m: 3.3,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec![
+                "nearai".into(),
+                "nearai-glm".into(),
+                "nearai-glm-5.1".into(),
+            ],
+        },
+        ModelCatalogEntry {
+            id: "Qwen/Qwen3.5-122B-A10B".into(),
+            display_name: "Qwen3.5 122B A10B (NEAR AI TEE)".into(),
+            provider: "nearai".into(),
+            tier: ModelTier::Smart,
+            context_window: 131_072,
+            max_output_tokens: 8_192,
+            input_cost_per_m: 0.4,
+            output_cost_per_m: 3.2,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec!["nearai-qwen3.5".into(), "nearai-qwen3.5-122b".into()],
+        },
+        ModelCatalogEntry {
+            id: "Qwen/Qwen3.6-35B-A3B-FP8".into(),
+            display_name: "Qwen 3.6 35B A3B FP8 (NEAR AI TEE)".into(),
+            provider: "nearai".into(),
+            tier: ModelTier::Balanced,
+            context_window: 262_144,
+            max_output_tokens: 8_192,
+            input_cost_per_m: 0.17,
+            output_cost_per_m: 1.1,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec!["nearai-qwen3.6".into(), "nearai-qwen3.6-35b".into()],
+        },
+        ModelCatalogEntry {
+            id: "Qwen/Qwen3-VL-30B-A3B-Instruct".into(),
+            display_name: "Qwen3 VL 30B A3B Instruct (NEAR AI TEE)".into(),
+            provider: "nearai".into(),
+            tier: ModelTier::Balanced,
+            context_window: 256_000,
+            max_output_tokens: 8_192,
+            input_cost_per_m: 0.15,
+            output_cost_per_m: 0.55,
+            supports_tools: true,
+            supports_vision: true,
+            supports_streaming: true,
+            aliases: vec!["nearai-qwen-vl".into(), "nearai-qwen3-vl".into()],
+        },
+        ModelCatalogEntry {
+            id: "google/gemma-4-31B-it".into(),
+            display_name: "Gemma 4 31B Instruct (NEAR AI TEE)".into(),
+            provider: "nearai".into(),
+            tier: ModelTier::Fast,
+            context_window: 262_144,
+            max_output_tokens: 8_192,
+            input_cost_per_m: 0.13,
+            output_cost_per_m: 0.4,
+            supports_tools: true,
+            supports_vision: false,
+            supports_streaming: true,
+            aliases: vec!["nearai-gemma".into(), "nearai-gemma-4".into()],
+        },
+        // ══════════════════════════════════════════════════════════════
         // Venice.ai (3)
         // ══════════════════════════════════════════════════════════════
         ModelCatalogEntry {
@@ -4083,7 +4173,7 @@ mod tests {
     #[test]
     fn test_catalog_has_providers() {
         let catalog = ModelCatalog::new();
-        assert_eq!(catalog.list_providers().len(), 42);
+        assert_eq!(catalog.list_providers().len(), 43);
     }
 
     #[test]
@@ -4231,6 +4321,34 @@ mod tests {
         assert!(catalog.get_provider("huggingface").is_some());
         assert!(catalog.get_provider("xai").is_some());
         assert!(catalog.get_provider("replicate").is_some());
+        assert!(catalog.get_provider("nearai").is_some());
+    }
+
+    #[test]
+    fn test_nearai_provider_and_models() {
+        let catalog = ModelCatalog::new();
+        let provider = catalog.get_provider("nearai").unwrap();
+        assert_eq!(provider.display_name, "NEAR AI Cloud");
+        assert_eq!(provider.api_key_env, "NEARAI_API_KEY");
+        assert_eq!(provider.base_url, "https://cloud-api.near.ai/v1");
+        assert!(provider.key_required);
+        assert_eq!(provider.model_count, 5);
+
+        let models = catalog.models_by_provider("nearai");
+        assert!(models.iter().all(|m| m.supports_streaming));
+        assert!(models.iter().any(|m| m.id == "zai-org/GLM-5.1-FP8"));
+        assert!(models
+            .iter()
+            .any(|m| m.id == "Qwen/Qwen3-VL-30B-A3B-Instruct" && m.supports_vision));
+    }
+
+    #[test]
+    fn test_nearai_aliases() {
+        let catalog = ModelCatalog::new();
+        let entry = catalog.find_model("nearai").unwrap();
+        assert_eq!(entry.id, "zai-org/GLM-5.1-FP8");
+        assert_eq!(entry.provider, "nearai");
+        assert!(catalog.find_model("nearai-qwen3.6").is_some());
     }
 
     #[test]

--- a/crates/openfang-types/src/model_catalog.rs
+++ b/crates/openfang-types/src/model_catalog.rs
@@ -30,6 +30,7 @@ pub const SAMBANOVA_BASE_URL: &str = "https://api.sambanova.ai/v1";
 pub const HUGGINGFACE_BASE_URL: &str = "https://api-inference.huggingface.co/v1";
 pub const XAI_BASE_URL: &str = "https://api.x.ai/v1";
 pub const REPLICATE_BASE_URL: &str = "https://api.replicate.com/v1";
+pub const NEARAI_BASE_URL: &str = "https://cloud-api.near.ai/v1";
 pub const VENICE_BASE_URL: &str = "https://api.venice.ai/api/v1";
 pub const NVIDIA_NIM_BASE_URL: &str = "https://integrate.api.nvidia.com/v1";
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # OpenFang Documentation
 
-Welcome to the OpenFang documentation. OpenFang is the open-source Agent Operating System -- 14 Rust crates, 40 channels, 60 skills, 20 LLM providers, 76 API endpoints, and 16 security systems in a single binary.
+Welcome to the OpenFang documentation. OpenFang is the open-source Agent Operating System -- 14 Rust crates, 40 channels, 60 skills, many LLM providers, 76 API endpoints, and 16 security systems in a single binary.
 
 ---
 
@@ -27,7 +27,7 @@ Welcome to the OpenFang documentation. OpenFang is the open-source Agent Operati
 | Guide | Description |
 |-------|-------------|
 | [Channel Adapters](channel-adapters.md) | 40 messaging channels -- setup, configuration, custom adapters |
-| [LLM Providers](providers.md) | 20 providers, 51 models, 23 aliases -- setup and model routing |
+| [LLM Providers](providers.md) | Provider setup, model catalog, aliases, and routing |
 | [Skills](skill-development.md) | 60 bundled skills, custom skill development, FangHub marketplace |
 | [MCP & A2A](mcp-a2a.md) | Model Context Protocol and Agent-to-Agent protocol integration |
 
@@ -74,9 +74,9 @@ openfang init && openfang start
 | Messaging channels | 40 |
 | Bundled skills | 60 |
 | Built-in tools | 38 |
-| LLM providers | 20 |
-| Models in catalog | 51 |
-| Model aliases | 23 |
+| LLM providers | Many cloud and local providers |
+| Models in catalog | Builtin plus runtime-discovered models |
+| Model aliases | Builtin aliases |
 | API endpoints | 76 |
 | Security systems | 16 |
 | Tests | 967 |
@@ -100,6 +100,7 @@ openfang init && openfang start
 | `GEMINI_API_KEY` | Google Gemini |
 | `GROQ_API_KEY` | Groq (fast Llama/Mixtral) |
 | `DEEPSEEK_API_KEY` | DeepSeek |
+| `NEARAI_API_KEY` | NEAR AI Cloud TEE inference |
 | `XAI_API_KEY` | xAI (Grok) |
 
 Only one provider key is needed to get started. Groq offers a free tier.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -835,7 +835,7 @@ Delete a specific session and its conversation history.
 
 ## Model Catalog Endpoints
 
-OpenFang maintains a built-in catalog of 51+ models across 20 providers. These endpoints allow you to browse available models, check provider authentication status, and resolve model aliases.
+OpenFang maintains a built-in catalog of models across cloud and local providers. These endpoints allow you to browse available models, check provider authentication status, and resolve model aliases.
 
 ### GET /api/models
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ openfang-types          Shared types: Agent, Capability, Event, Memory, Message,
 |-------|-------------|
 | **openfang-types** | Core type definitions used across all crates. Defines `AgentManifest`, `AgentId`, `Capability`, `Event`, `ToolDefinition`, `KernelConfig`, `OpenFangError`, taint tracking (`TaintLabel`, `TaintSet`), Ed25519 manifest signing, model catalog types (`ModelCatalogEntry`, `ProviderInfo`, `ModelTier`), tool compatibility mappings (21 OpenClaw-to-OpenFang), MCP/A2A config types, and web config types. All config structs use `#[serde(default)]` for forward-compatible TOML parsing. |
 | **openfang-memory** | SQLite-backed memory substrate (schema v5). Uses `Arc<Mutex<Connection>>` with `spawn_blocking` for async bridge. Provides structured KV storage, semantic search with vector embeddings, knowledge graph (entities and relations), session management, task board, usage event persistence (`usage_events` table, `UsageStore`), and canonical sessions for cross-channel memory. Five schema versions: V1 core, V2 collab, V3 embeddings, V4 usage, V5 canonical_sessions. |
-| **openfang-runtime** | Agent execution engine. Contains the agent loop (`run_agent_loop`, `run_agent_loop_streaming`), 3 native LLM drivers (Anthropic, Gemini, OpenAI-compatible covering 20 providers), 23 built-in tools, WASM sandbox (Wasmtime with dual fuel+epoch metering), MCP client/server (JSON-RPC 2.0 over stdio/SSE), A2A protocol (AgentCard, task management), web search engine (4 providers: Tavily/Brave/Perplexity/DuckDuckGo), web fetch with SSRF protection, loop guard (SHA256-based tool loop detection), session repair (history validation), LLM session compactor (block-aware), Merkle hash chain audit trail, and embedding driver. Defines the `KernelHandle` trait that enables inter-agent tools without circular crate dependencies. |
+| **openfang-runtime** | Agent execution engine. Contains the agent loop (`run_agent_loop`, `run_agent_loop_streaming`), 3 native LLM drivers (Anthropic, Gemini, OpenAI-compatible providers), 23 built-in tools, WASM sandbox (Wasmtime with dual fuel+epoch metering), MCP client/server (JSON-RPC 2.0 over stdio/SSE), A2A protocol (AgentCard, task management), web search engine (4 providers: Tavily/Brave/Perplexity/DuckDuckGo), web fetch with SSRF protection, loop guard (SHA256-based tool loop detection), session repair (history validation), LLM session compactor (block-aware), Merkle hash chain audit trail, and embedding driver. Defines the `KernelHandle` trait that enables inter-agent tools without circular crate dependencies. |
 | **openfang-kernel** | The central coordinator. `OpenFangKernel` assembles all subsystems: `AgentRegistry`, `AgentScheduler`, `CapabilityManager`, `EventBus`, `Supervisor`, `WorkflowEngine`, `TriggerEngine`, `BackgroundExecutor`, `WasmSandbox`, `ModelCatalog`, `MeteringEngine`, `ModelRouter`, `AuthManager` (RBAC), `HeartbeatMonitor`, `SetupWizard`, `SkillRegistry`, MCP connections, and `WebToolsContext`. Implements `KernelHandle` for inter-agent operations. Handles agent spawn/kill, message dispatch, workflow execution, trigger evaluation, capability inheritance validation, and graceful shutdown with state persistence. |
 | **openfang-api** | HTTP API server built on Axum 0.8 with 76 endpoints. Routes for agents, workflows, triggers, memory, channels, templates, models, providers, skills, ClawHub, MCP, health, status, version, and shutdown. WebSocket handler for real-time agent chat with streaming. SSE endpoint for streaming responses. OpenAI-compatible endpoints (`POST /v1/chat/completions`, `GET /v1/models`). A2A endpoints (`/.well-known/agent.json`, `/a2a/*`). Middleware: Bearer token auth, request ID injection, structured request logging, GCRA rate limiter (cost-aware), security headers (CSP, X-Frame-Options, etc.), health endpoint redaction. |
 | **openfang-channels** | Channel bridge layer with 40 adapters. Each adapter implements the `ChannelAdapter` trait. Includes: Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, SMS, Webhook, Teams, Mattermost, IRC, Google Chat, Twitch, Rocket.Chat, Zulip, XMPP, LINE, Viber, Messenger, Reddit, Mastodon, Bluesky, Feishu, Revolt, Nextcloud, Guilded, Keybase, Threema, Nostr, Webex, Pumble, Flock, Twist, Mumble, DingTalk, Discourse, Gitter, Ntfy, Gotify, LinkedIn. Features: `AgentRouter` for message routing, `BridgeManager` for lifecycle coordination, `ChannelRateLimiter` (per-user DashMap tracking), `formatter.rs` (Markdown to TelegramHTML/SlackMrkdwn/PlainText), `ChannelOverrides` (model/system_prompt/dm_policy/group_policy/rate_limit/threading/output_format), DM/group policy enforcement. |
@@ -90,7 +90,7 @@ When `OpenFangKernel::boot_with_config()` is called (either by the daemon or in-
    - Validate driver config
 
 5. Initialize model catalog
-   - Build ModelCatalog with 51 builtin models, 20+ aliases, 20 providers
+   - Build ModelCatalog with builtin models, aliases, and provider metadata
    - Run detect_auth() to check env var presence (never reads secrets)
    - Store as kernel.model_catalog
 
@@ -356,13 +356,13 @@ pub trait LlmDriver: Send + Sync {
 
 ### Provider Architecture
 
-Three native driver implementations cover all 20 providers with 51 models:
+Three native driver implementations cover the provider catalog:
 
 1. **AnthropicDriver**: Native Anthropic Messages API. Handles Claude-specific features (content blocks including images, tool use blocks, streaming deltas). Supports `ContentBlock::Image` with media type validation and 5MB cap.
 
 2. **GeminiDriver**: Native Google Gemini API (v1beta). Uses `x-goog-api-key` auth, `systemInstruction`, `functionDeclarations`, `streamGenerateContent?alt=sse`. Maps Gemini function call responses to the unified `ToolUse` stop reason.
 
-3. **OpenAiCompatDriver**: OpenAI-compatible Chat Completions API. Works with any provider that implements the OpenAI API format. Configured with different base URLs per provider. Covers 18+ providers including OpenAI, DeepSeek, Groq, Mistral, Together, and local runners.
+3. **OpenAiCompatDriver**: OpenAI-compatible Chat Completions API. Works with any provider that implements the OpenAI API format. Configured with different base URLs per provider. Covers providers including OpenAI, NEAR AI Cloud, DeepSeek, Groq, Mistral, Together, and local runners.
 
 ### Provider Configuration
 
@@ -374,6 +374,7 @@ Three native driver implementations cover all 20 providers with 51 models:
 | `deepseek` | OpenAI-compat | `https://api.deepseek.com` | Yes |
 | `groq` | OpenAI-compat | `https://api.groq.com/openai` | Yes |
 | `openrouter` | OpenAI-compat | `https://openrouter.ai/api` | Yes |
+| `nearai` | OpenAI-compat | `https://cloud-api.near.ai/v1` | Yes |
 | `mistral` | OpenAI-compat | `https://api.mistral.ai` | Yes |
 | `together` | OpenAI-compat | `https://api.together.xyz` | Yes |
 | `fireworks` | OpenAI-compat | `https://api.fireworks.ai/inference` | Yes |
@@ -417,9 +418,9 @@ The `ModelCatalog` (`openfang-runtime/src/model_catalog.rs`) provides a registry
 
 ### Registry Contents
 
-- **51 builtin models** across 20+ model families (Claude, GPT, Gemini, DeepSeek, Llama, Mixtral, Command, Jamba, Grok, etc.)
-- **20+ aliases** for convenience (e.g., `claude` -> `claude-sonnet-4-20250514`, `grok` -> `grok-2`)
-- **20 providers** with authentication status detection
+- Builtin models across model families (Claude, GPT, Gemini, NEAR AI Cloud TEE models, DeepSeek, Llama, Mixtral, Command, Jamba, Grok, etc.)
+- Aliases for convenience (e.g., `claude` -> `claude-sonnet-4-20250514`, `nearai` -> `zai-org/GLM-5.1-FP8`)
+- Providers with authentication status detection
 
 ### Types
 
@@ -826,7 +827,7 @@ The desktop app (`openfang-desktop`) wraps the full OpenFang stack in a native T
 |  +----------------+  +------------------+  +-------------------+   |
 |  +----------------+  +------------------+  +-------------------+   |
 |  | ModelCatalog   |  | MeteringEngine   |  | ModelRouter       |   |
-|  | (51 models)    |  | (cost tracking)  |  | (auto-select)     |   |
+|  | (model catalog)|  | (cost tracking)  |  | (auto-select)     |   |
 |  +----------------+  +------------------+  +-------------------+   |
 |  +----------------+  +------------------+  +-------------------+   |
 |  | HeartbeatMon   |  | SetupWizard      |  | SkillRegistry     |   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,7 +329,7 @@ api_key_env = "ANTHROPIC_API_KEY"
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider` | string | `"anthropic"` | Provider name. Supported: `anthropic`, `gemini`, `openai`, `groq`, `openrouter`, `deepseek`, `together`, `mistral`, `fireworks`, `ollama`, `vllm`, `lmstudio`, `perplexity`, `cohere`, `ai21`, `cerebras`, `sambanova`, `huggingface`, `xai`, `replicate`. |
+| `provider` | string | `"anthropic"` | Provider name. Supported: `anthropic`, `gemini`, `openai`, `groq`, `openrouter`, `nearai`, `deepseek`, `together`, `mistral`, `fireworks`, `ollama`, `vllm`, `lmstudio`, `perplexity`, `cohere`, `ai21`, `cerebras`, `sambanova`, `huggingface`, `xai`, `replicate`. |
 | `model` | string | `"claude-sonnet-4-20250514"` | Model identifier. Aliases like `sonnet`, `haiku`, `gpt-4o`, `gemini-flash` are resolved by the model catalog. |
 | `api_key_env` | string | `"ANTHROPIC_API_KEY"` | Name of the environment variable holding the API key. The actual key is read from this env var at runtime, never stored in config. |
 | `base_url` | string or null | `null` | Override the API base URL. Useful for proxies or self-hosted endpoints. When `null`, the provider's default URL from the model catalog is used. |
@@ -1399,6 +1399,7 @@ Complete table of all environment variables referenced by the configuration. Non
 | `DEEPSEEK_API_KEY` | DeepSeek provider | DeepSeek API key. |
 | `PERPLEXITY_API_KEY` | Perplexity provider / web search | Perplexity API key. |
 | `OPENROUTER_API_KEY` | OpenRouter provider | OpenRouter API key. |
+| `NEARAI_API_KEY` | NEAR AI Cloud provider | NEAR AI Cloud TEE inference API key. |
 | `TOGETHER_API_KEY` | Together AI provider | Together AI API key. |
 | `MISTRAL_API_KEY` | Mistral provider | Mistral AI API key. |
 | `FIREWORKS_API_KEY` | Fireworks provider | Fireworks AI API key. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -348,7 +348,7 @@ Now that you have OpenFang running:
 - **Use bundled skills**: 60 expert knowledge skills are pre-installed (GitHub, Docker, Kubernetes, security audit, prompt engineering, etc.). See [Skill Development](skill-development.md).
 - **Build custom skills**: Extend agents with Python, WASM, or prompt-only skills. See [Skill Development](skill-development.md).
 - **Use the API**: 76 REST/WS/SSE endpoints, including an OpenAI-compatible `/v1/chat/completions`. See [API Reference](api-reference.md).
-- **Switch LLM providers**: 20 providers supported (Anthropic, OpenAI, Gemini, Groq, DeepSeek, xAI, Ollama, and more). Per-agent model overrides.
+- **Switch LLM providers**: many providers supported (Anthropic, OpenAI, Gemini, Groq, NEAR AI Cloud, DeepSeek, xAI, Ollama, and more). Per-agent model overrides.
 - **Set up workflows**: Chain multiple agents together. Use `openfang workflow create` with a TOML workflow definition.
 - **Use MCP**: Connect to external tools via Model Context Protocol. Configure in `config.toml` under `[[mcp_servers]]`.
 - **Migrate from OpenClaw**: Run `openfang migrate --from openclaw`. See [MIGRATION.md](../MIGRATION.md).

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -188,7 +188,7 @@ docker build -f scripts/docker/install-smoke.Dockerfile .
 The release workflow includes a link to `CHANGELOG.md` in every GitHub release body. Ensure it exists at the repo root and covers:
 
 - All 14 crates and what they do
-- Key features: 40 channels, 60 skills, 20 providers, 51 models
+- Key features: 40 channels, 60 skills, cloud/local LLM providers, builtin and runtime-discovered models
 - Security systems (9 SOTA + 7 critical fixes)
 - Desktop app with auto-updater
 - Migration path from OpenClaw

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # LLM Providers Guide
 
-OpenFang ships with a comprehensive model catalog covering **3 native LLM drivers**, **20 providers**, **51 builtin models**, and **23 aliases**. Every provider uses one of three battle-tested drivers: the native **Anthropic** driver, the native **Gemini** driver, or the universal **OpenAI-compatible** driver. This guide is the single source of truth for configuring, selecting, and managing LLM providers in OpenFang.
+OpenFang ships with a comprehensive model catalog covering **3 native LLM drivers**, cloud and local providers, builtin models, and aliases. Every provider uses one of three battle-tested drivers: the native **Anthropic** driver, the native **Gemini** driver, or the universal **OpenAI-compatible** driver. This guide is the single source of truth for configuring, selecting, and managing LLM providers in OpenFang.
 
 ---
 
@@ -28,6 +28,8 @@ The fastest path from zero to running:
 export GEMINI_API_KEY="your-key"        # Free tier available
 # OR
 export GROQ_API_KEY="your-key"          # Free tier available
+# OR
+export NEARAI_API_KEY="your-key"        # NEAR AI Cloud TEE inference
 # OR
 export ANTHROPIC_API_KEY="your-key"
 # OR
@@ -549,9 +551,38 @@ For Gemini specifically, either `GEMINI_API_KEY` or `GOOGLE_API_KEY` will work.
 
 ---
 
+### 21. NEAR AI Cloud
+
+| | |
+|---|---|
+| **Display Name** | NEAR AI Cloud |
+| **Driver** | OpenAI-compatible |
+| **Env Var** | `NEARAI_API_KEY` |
+| **Base URL** | `https://cloud-api.near.ai/v1` |
+| **Key Required** | Yes |
+| **Free Tier** | No |
+| **Auth** | `Authorization: Bearer` header |
+| **Models** | 5 builtin TEE-backed chat models |
+
+**Available Models:**
+- `zai-org/GLM-5.1-FP8` (Smart, default)
+- `Qwen/Qwen3.5-122B-A10B` (Smart)
+- `Qwen/Qwen3.6-35B-A3B-FP8` (Balanced)
+- `Qwen/Qwen3-VL-30B-A3B-Instruct` (Balanced, vision)
+- `google/gemma-4-31B-it` (Fast)
+
+**Setup:**
+1. Create an API key in NEAR AI Cloud
+2. `export NEARAI_API_KEY="..."`
+3. Use `provider = "nearai"` with any NEAR AI Cloud model ID
+
+**Notes:** NEAR AI Cloud uses the OpenAI-compatible chat completions API and provides TEE-backed private inference for the builtin `nearai` catalog entries.
+
+---
+
 ## Model Catalog
 
-The complete catalog of all 51 builtin models, sorted by provider. Pricing is per million tokens.
+The builtin catalog is sorted by provider. Pricing is per million tokens.
 
 | # | Model ID | Display Name | Provider | Tier | Context Window | Max Output | Input $/M | Output $/M | Tools | Vision |
 |---|----------|-------------|----------|------|---------------|------------|-----------|------------|-------|--------|
@@ -608,6 +639,11 @@ The complete catalog of all 51 builtin models, sorted by provider. Pricing is pe
 | 51 | `grok-2-mini` | Grok 2 Mini | xai | Fast | 131,072 | 32,768 | $0.30 | $0.50 | Yes | No |
 | 52 | `hf/meta-llama/Llama-3.3-70B-Instruct` | Llama 3.3 70B (HF) | huggingface | Balanced | 128,000 | 4,096 | $0.30 | $0.30 | No | No |
 | 53 | `replicate/meta-llama-3.3-70b-instruct` | Llama 3.3 70B (Replicate) | replicate | Balanced | 128,000 | 4,096 | $0.40 | $0.40 | No | No |
+| 54 | `zai-org/GLM-5.1-FP8` | GLM 5.1 (NEAR AI TEE) | nearai | Smart | 202,752 | 8,192 | $0.85 | $3.30 | Yes | No |
+| 55 | `Qwen/Qwen3.5-122B-A10B` | Qwen3.5 122B A10B (NEAR AI TEE) | nearai | Smart | 131,072 | 8,192 | $0.40 | $3.20 | Yes | No |
+| 56 | `Qwen/Qwen3.6-35B-A3B-FP8` | Qwen 3.6 35B A3B FP8 (NEAR AI TEE) | nearai | Balanced | 262,144 | 8,192 | $0.17 | $1.10 | Yes | No |
+| 57 | `Qwen/Qwen3-VL-30B-A3B-Instruct` | Qwen3 VL 30B A3B Instruct (NEAR AI TEE) | nearai | Balanced | 256,000 | 8,192 | $0.15 | $0.55 | Yes | Yes |
+| 58 | `google/gemma-4-31B-it` | Gemma 4 31B Instruct (NEAR AI TEE) | nearai | Fast | 262,144 | 8,192 | $0.13 | $0.40 | Yes | No |
 
 **Model Tiers:**
 
@@ -621,13 +657,13 @@ The complete catalog of all 51 builtin models, sorted by provider. Pricing is pe
 
 **Notes:**
 - Local providers (Ollama, vLLM, LM Studio) auto-discover models at runtime. Any model you download and serve will be merged into the catalog with `Local` tier and zero cost.
-- The 46 entries above are the builtin models. The total of 51 referenced in the catalog includes runtime auto-discovered models that vary per installation.
+- The entries above are builtin models. Local providers can also auto-discover models at runtime, and those vary per installation.
 
 ---
 
 ## Model Aliases
 
-All 23 aliases resolve to canonical model IDs. Aliases are case-insensitive.
+Aliases resolve to canonical model IDs and are case-insensitive.
 
 | Alias | Resolves To |
 |-------|------------|
@@ -654,6 +690,8 @@ All 23 aliases resolve to canonical model IDs. Aliases are case-insensitive.
 | `sonar` | `sonar-pro` |
 | `jamba` | `jamba-1.5-large` |
 | `command-r` | `command-r-plus` |
+| `nearai` | `zai-org/GLM-5.1-FP8` |
+| `nearai-glm` | `zai-org/GLM-5.1-FP8` |
 
 You can use aliases anywhere a model ID is accepted: in config files, REST API calls, chat commands, and the model routing configuration.
 
@@ -903,7 +941,7 @@ Returns a map of all alias-to-canonical-ID mappings.
 GET /api/providers
 ```
 
-Returns all 20 providers with auth status and model counts.
+Returns all providers with auth status and model counts.
 
 **Response:**
 ```json
@@ -998,7 +1036,7 @@ Local:
 
 ### `/providers`
 
-Lists all 20 providers with their authentication status.
+Lists all providers with their authentication status.
 
 ```
 /providers
@@ -1006,13 +1044,14 @@ Lists all 20 providers with their authentication status.
 
 Example output:
 ```
-LLM Providers (20):
+LLM Providers:
 
   Anthropic          ANTHROPIC_API_KEY       Configured    3 models
   OpenAI             OPENAI_API_KEY          Missing       6 models
   Google Gemini      GEMINI_API_KEY          Configured    3 models
   DeepSeek           DEEPSEEK_API_KEY        Missing       2 models
   Groq               GROQ_API_KEY            Configured    4 models
+  NEAR AI Cloud      NEARAI_API_KEY          Missing       5 models
   Ollama             (no key needed)         Ready         3 models
   vLLM               (no key needed)         Ready         1 model
   LM Studio          (no key needed)         Ready         1 model
@@ -1033,6 +1072,7 @@ Quick reference for all provider environment variables:
 | DeepSeek | `DEEPSEEK_API_KEY` | Yes |
 | Groq | `GROQ_API_KEY` | Yes |
 | OpenRouter | `OPENROUTER_API_KEY` | Yes |
+| NEAR AI Cloud | `NEARAI_API_KEY` | Yes |
 | Mistral AI | `MISTRAL_API_KEY` | Yes |
 | Together AI | `TOGETHER_API_KEY` | Yes |
 | Fireworks AI | `FIREWORKS_API_KEY` | Yes |

--- a/openfang.toml.example
+++ b/openfang.toml.example
@@ -10,7 +10,7 @@
                                              # See docs/configuration.md "Exposing the Dashboard".
 
 [default_model]
-provider = "anthropic"                    # "anthropic", "gemini", "openai", "groq", "ollama", etc.
+provider = "anthropic"                    # "anthropic", "gemini", "openai", "nearai", "groq", "ollama", etc.
 model = "claude-sonnet-4-20250514"        # Model identifier
 api_key_env = "ANTHROPIC_API_KEY"         # Environment variable holding API key
 # base_url = "https://api.anthropic.com"  # Optional: override API endpoint


### PR DESCRIPTION
## Summary

Adds NEAR AI Cloud as a built-in OpenAI-compatible inference provider with `NEARAI_API_KEY` authentication and the default `https://cloud-api.near.ai/v1` base URL.

## Changes

- Registers `nearai` in provider defaults, provider detection, and the model catalog.
- Adds five NEAR AI Cloud TEE-backed chat models with pricing, context windows, aliases, and provider metadata.
- Documents NEAR AI Cloud setup in provider/configuration docs and environment examples.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p openfang-runtime nearai`
- [x] `cargo test -p openfang-runtime test_known_providers_list`
- [x] `cargo test -p openfang-runtime test_catalog_has_providers`
- [x] `cargo build -p openfang-runtime --lib`
- [x] `cargo clippy -p openfang-runtime --all-targets -- -D warnings`
- [x] `cargo build --workspace --lib --exclude openfang-desktop`

Full `cargo build --workspace --lib` requires the desktop GTK/GLib pkg-config dependencies; the non-desktop workspace library build passed locally.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries